### PR TITLE
make og:image canonical according to spec

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -149,7 +149,7 @@
   <meta name="always-resize-images" content="<%= CurrentUser.user.always_resize_images? %>">
   <meta property="og:title" content="<%= @post.presenter.humanized_essential_tag_string %> - <%= Danbooru.config.app_name %>">
   <meta property="og:description" content="<%= @post.presenter.humanized_tag_string %>">
-  <meta property="og:image" content="<%= @post.preview_file_url %>">
+  <meta property="og:image" content="http://<%= Danbooru.config.hostname %><%= @post.large_file_url %>">
 
   <!-- Twitter properties -->
   <% if @post.twitter_card_supported? %>


### PR DESCRIPTION
Currently `og:image` is a relative url, it should be canonical according to spec http://ogp.me/ and I have set it to be the same as `twitter:image:src`.

Discovered this problem while working on my own project which use opengraph data for link preview.