### PR TITLE
Site map reports list fix

### DIFF
--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -58,8 +58,9 @@
       <ul>
         <li><h1>Reports</h1></li>
         <li><%= link_to("User Promotions", reports_user_promotions_path) %></li>
-        <li><%= link_to("Contributors", reports_contributors_path) %></ul>
-        <li><%= link_to("Janitor Trials", reports_janitor_trials_path) %></ul>
+        <li><%= link_to("Contributors", reports_contributors_path) %></li>
+        <li><%= link_to("Janitor Trials", reports_janitor_trials_path) %></li>
+      </ul>
     </section>
     <section>
       <ul>


### PR DESCRIPTION
Fix a typo causing the unordered list for the reports section to display incorrectly.