### PR TITLE
Index and form for bit preferences

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -762,7 +762,7 @@ class User < ActiveRecord::Base
       bitprefs_include = nil
       bitprefs_exclude = nil
 
-      [:can_approve_posts, :can_upload_free, :is_super_voter].each do |x|
+      [:can_approve_posts, :can_upload_free, :is_super_voter, :is_banned].each do |x|
         if params[x].present?
           attr_idx = BOOLEAN_ATTRIBUTES.index(x.to_s)
           if params[x] == "true"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -759,7 +759,6 @@ class User < ActiveRecord::Base
         q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
       end
 
-      bitprefs_length = BOOLEAN_ATTRIBUTES.length
       bitprefs_include = nil
       bitprefs_exclude = nil
 
@@ -767,25 +766,21 @@ class User < ActiveRecord::Base
         if params[x].present?
           attr_idx = BOOLEAN_ATTRIBUTES.index(x.to_s)
           if params[x] == "true"
-            bitprefs_include ||= "0"*bitprefs_length
-            bitprefs_include[attr_idx] = '1'
+            bitprefs_include ||= []
+            bitprefs_include << attr_idx
           elsif params[x] == "false"
-            bitprefs_exclude ||= "0"*bitprefs_length
-            bitprefs_exclude[attr_idx] = '1'
+            bitprefs_exclude ||= 0
+            bitprefs_exclude |= (1 << attr_idx)
           end
         end
       end
-
+      
       if bitprefs_include
-        bitprefs_include.reverse!
-        q = q.where("bit_prefs::bit(:len) & :bits::bit(:len) = :bits::bit(:len)",
-                    {:len => bitprefs_length, :bits => bitprefs_include})
+        q = q.where("bit_position_array(bit_prefs) @> ARRAY[?]::integer[]", bitprefs_include)
       end
-
+      
       if bitprefs_exclude
-        bitprefs_exclude.reverse!
-        q = q.where("bit_prefs::bit(:len) & :bits::bit(:len) = 0::bit(:len)",
-                    {:len => bitprefs_length, :bits => bitprefs_exclude})
+        q = q.where("bit_prefs & ? = 0", bitprefs_exclude)
       end
 
       if params[:current_user_first] == "true" && !CurrentUser.is_anonymous?

--- a/app/views/users/search.html.erb
+++ b/app/views/users/search.html.erb
@@ -19,6 +19,26 @@
       </div>
 
       <div class="input">
+        <label for="search_can_approve_posts">Can approve posts</label>
+        <%= select("search", "can_approve_posts", [[""], ["Yes", "true"], ["No", "false"]]) %>
+      </div>
+
+      <div class="input">
+        <label for="search_can_upload_free">Unrestricted uploads</label>
+        <%= select("search", "can_upload_free", [[""], ["Yes", "true"], ["No", "false"]]) %>
+      </div>
+
+      <div class="input">
+        <label for="search_is_super_voter">Supervoter</label>
+        <%= select("search", "is_super_voter", [[""], ["Yes", "true"], ["No", "false"]]) %>
+      </div>
+
+      <div class="input">
+        <label for="search_is_banned">Banned</label>
+        <%= select("search", "is_banned", [[""], ["Yes", "true"], ["No", "false"]]) %>
+      </div>
+
+      <div class="input">
         <label for="search_order">Order</label>
         <%= select("search", "order", [["Join date", "date"], ["Name", "name"], ["Upload count", "post_upload_count"], ["Note count", "note_count"], ["Post update count", "post_update_count"]]) %>
       </div>

--- a/db/migrate/20160917180923_add_index_to_users_bit_prefs.rb
+++ b/db/migrate/20160917180923_add_index_to_users_bit_prefs.rb
@@ -1,0 +1,24 @@
+class AddIndexToUsersBitPrefs < ActiveRecord::Migration
+  def up
+    execute "set statement_timeout = 0"
+    execute <<-'SQL'
+      CREATE OR REPLACE FUNCTION bit_position_array(x bigint)
+      RETURNS integer[] AS $BODY$
+      select array_agg(i) 
+        from generate_series(0, floor(log(2, x))::integer) i
+       where (x & (1::bigint << i)) > 0;
+      $BODY$ LANGUAGE sql IMMUTABLE
+    SQL
+    
+    execute <<-'SQL'
+      CREATE INDEX index_users_on_bit_prefs_array
+       ON users USING gin (bit_position_array(bit_prefs) _int4_ops)
+    SQL
+  end
+
+  def down
+    execute "set statement_timeout = 0"
+    execute "DROP INDEX index_users_on_bit_prefs_array"
+    execute "DROP FUNCTION bit_position_array(x bigint)"
+  end
+end


### PR DESCRIPTION
See #2644 for details.

Array index failed to work with `not (column && ARRAY[])` syntax, so excluded bits are searched almost the same way as before, except omitting the unnecessary bitstring conversion - turns out, postgres can `&` bigints just fine. 

It's possible to change sql function to create array with negative integers for unset bits and positive for set bits. It would allow complete index support, but storage requirements skyrocket and it needs to know max bit count, so I deemed it wasn't worth it.