### PR TITLE
Allow quoted source: metatag, allow source: metatag when editing posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -674,7 +674,7 @@ class Post < ActiveRecord::Base
     end
 
     def filter_metatags(tags)
-      @pre_metatags, tags = tags.partition {|x| x =~ /\A(?:rating|parent|-parent):/i}
+      @pre_metatags, tags = tags.partition {|x| x =~ /\A(?:rating|parent|-parent|source):/i}
       @post_metatags, tags = tags.partition {|x| x =~ /\A(?:-pool|pool|newpool|fav|-fav|child|-favgroup|favgroup):/i}
       apply_pre_metatags
       return tags
@@ -756,6 +756,15 @@ class Post < ActiveRecord::Base
             self.parent_id = $1.to_i
             remove_parent_loops
           end
+
+        when /^source:none$/i
+          self.source = nil
+
+        when /^source:"(.*)"$/i
+          self.source = $1
+
+        when /^source:(.*)$/i
+          self.source = $1
 
         when /^rating:([qse])/i
           unless is_rating_locked?


### PR DESCRIPTION
This should take care of #2664. 

@r888888888 requesting code review. I don't think it would break anything, it simply extracts `source:"..."` verbatim from tag string before splitting the rest on spaces. I have two concerns about other code, though:

* What's the purpose of `.gsub(/[%,]/, "")` in `Tag.scan_tags`? I put source extraction before it, since I figured that source _can_ contain commas and percents.
* `source:none` will set post source to nil. `source:""` and `source:` will set it to empty string. Should something be done about that?
