### PR TITLE
Refactor Post#parse_pixiv_id to use illust_id_from_url (fix #2695)

### DIFF
--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -55,7 +55,7 @@ module Sources
         if has_moniker?
           moniker = get_moniker_from_url
         else
-          @illust_id = illust_id_from_url(url)
+          @illust_id = self.class.illust_id_from_url!(url)
           @metadata = get_metadata_from_papi(@illust_id)
           moniker = @metadata.moniker
         end
@@ -64,7 +64,7 @@ module Sources
       end
 
       def get
-        @illust_id = illust_id_from_url(url)
+        @illust_id = self.class.illust_id_from_url!(url)
         @metadata = get_metadata_from_papi(@illust_id)
 
         page = agent.get(URI.parse(normalized_url))
@@ -108,6 +108,51 @@ module Sources
 
       def image_urls
         @metadata.pages
+      end
+
+      def self.illust_id_from_url(url)
+        if url_match?(url)
+          illust_id_from_url!(url)
+        else
+          nil
+        end
+      rescue Sources::Error
+        nil
+      end
+
+      def self.illust_id_from_url!(url)
+        # http://img18.pixiv.net/img/evazion/14901720.png
+        #
+        # http://i2.pixiv.net/img18/img/evazion/14901720.png
+        # http://i2.pixiv.net/img18/img/evazion/14901720_m.png
+        # http://i2.pixiv.net/img18/img/evazion/14901720_s.png
+        # http://i1.pixiv.net/img07/img/pasirism/18557054_p1.png
+        # http://i1.pixiv.net/img07/img/pasirism/18557054_big_p1.png
+        #
+        # http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_64x64.jpg
+        # http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_s.png
+        #
+        # http://i1.pixiv.net/c/600x600/img-master/img/2014/10/02/13/51/23/46304396_p0_master1200.jpg
+        # http://i1.pixiv.net/img-original/img/2014/10/02/13/51/23/46304396_p0.png
+        #
+        # http://i1.pixiv.net/img-zip-ugoira/img/2014/10/03/17/29/16/46323924_ugoira1920x1080.zip
+        if url =~ %r!/(\d+)(?:_\w+)?\.(?:jpg|jpeg|png|gif|zip)!i
+          $1
+
+        # http://www.pixiv.net/member_illust.php?mode=medium&illust_id=18557054
+        # http://www.pixiv.net/member_illust.php?mode=big&illust_id=18557054
+        # http://www.pixiv.net/member_illust.php?mode=manga&illust_id=18557054
+        # http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=18557054&page=1
+        elsif url =~ /illust_id=(\d+)/i
+          $1
+
+        # http://www.pixiv.net/i/18557054
+        elsif url =~ %r!pixiv\.net/i/(\d+)!i
+          $1
+
+        else
+          raise Sources::Error.new("Couldn't get illust ID from URL: #{url}")
+        end
       end
       
     protected
@@ -295,41 +340,6 @@ module Sources
 
       def get_metadata_from_papi(illust_id)
         @metadata ||= PixivApiClient.new.works(illust_id)
-      end
-
-      def illust_id_from_url(url)
-        # http://img18.pixiv.net/img/evazion/14901720.png
-        #
-        # http://i2.pixiv.net/img18/img/evazion/14901720.png
-        # http://i2.pixiv.net/img18/img/evazion/14901720_m.png
-        # http://i2.pixiv.net/img18/img/evazion/14901720_s.png
-        # http://i1.pixiv.net/img07/img/pasirism/18557054_p1.png
-        # http://i1.pixiv.net/img07/img/pasirism/18557054_big_p1.png
-        #
-        # http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_64x64.jpg
-        # http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_s.png
-        #
-        # http://i1.pixiv.net/c/600x600/img-master/img/2014/10/02/13/51/23/46304396_p0_master1200.jpg
-        # http://i1.pixiv.net/img-original/img/2014/10/02/13/51/23/46304396_p0.png
-        #
-        # http://i1.pixiv.net/img-zip-ugoira/img/2014/10/03/17/29/16/46323924_ugoira1920x1080.zip
-        if url =~ %r!/(\d+)(?:_\w+)?\.(?:jpg|jpeg|png|gif|zip)!i
-          $1
-
-        # http://www.pixiv.net/member_illust.php?mode=medium&illust_id=18557054
-        # http://www.pixiv.net/member_illust.php?mode=big&illust_id=18557054
-        # http://www.pixiv.net/member_illust.php?mode=manga&illust_id=18557054
-        # http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=18557054&page=1
-        elsif url =~ /illust_id=(\d+)/i
-          $1
-
-        # http://www.pixiv.net/i/18557054
-        elsif url =~ %r!pixiv\.net/i/(\d+)!i
-          $1
-
-        else
-          raise Sources::Error.new("Couldn't get illust ID from URL: #{url}")
-        end
       end
 
       def work_page?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1644,23 +1644,7 @@ class Post < ActiveRecord::Base
   
   module PixivMethods
     def parse_pixiv_id
-      if source =~ %r!http://i\d\.pixiv\.net/img-inf/img/\d+/\d+/\d+/\d+/\d+/\d+/(\d+)_s.jpg!
-        self.pixiv_id = $1
-      elsif source =~ %r!http://img\d+\.pixiv\.net/img/[^\/]+/(\d+)!
-        self.pixiv_id = $1
-      elsif source =~ %r!http://i\d\.pixiv\.net/img\d+/img/[^\/]+/(\d+)!
-        self.pixiv_id = $1
-      elsif source =~ %r!http://i\d\.pixiv\.net/img-original/img/(?:\d+\/)+(\d+)_p!
-        self.pixiv_id = $1
-      elsif source =~ %r!http://i\d\.pixiv\.net/c/\d+x\d+/img-master/img/(?:\d+\/)+(\d+)_p!
-        self.pixiv_id = $1
-      elsif source =~ /pixiv\.net/ && source =~ /illust_id=(\d+)/
-        self.pixiv_id = $1
-      elsif source =~ %r!http://i\d\.pixiv\.net/img-zip-ugoira/img/(?:\d+\/)+(\d+)_ugoira!
-        self.pixiv_id = $1
-      else
-        self.pixiv_id = nil
-      end
+      self.pixiv_id = Sources::Strategies::Pixiv.illust_id_from_url(source)
     end
   end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -912,7 +912,97 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
-      context "normalizing its source" do
+      context "with a source" do
+        context "that is not from pixiv" do
+          should "clear the pixiv id" do
+            @post.pixiv_id = 1234
+            @post.update(source: "http://fc06.deviantart.net/fs71/f/2013/295/d/7/you_are_already_dead__by_mar11co-d6rgm0e.jpg")
+            assert_equal(nil, @post.pixiv_id)
+
+            @post.pixiv_id = 1234
+            @post.update(source: "http://pictures.hentai-foundry.com//a/AnimeFlux/219123.jpg")
+            assert_equal(nil, @post.pixiv_id)
+          end
+        end
+
+        context "that is from pixiv" do
+          should "save the pixiv id" do
+            @post.update(source: "https://img18.pixiv.net/img/evazion/14901720.png")
+            assert_equal(14901720, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://img18.pixiv.net/img/evazion/14901720.png")
+            assert_equal(14901720, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i2.pixiv.net/img18/img/evazion/14901720.png")
+            assert_equal(14901720, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i2.pixiv.net/img18/img/evazion/14901720_m.png")
+            assert_equal(14901720, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i2.pixiv.net/img18/img/evazion/14901720_s.png")
+            assert_equal(14901720, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img07/img/pasirism/18557054_p1.png")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img07/img/pasirism/18557054_big_p1.png")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_64x64.jpg")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img-inf/img/2011/05/01/23/28/04/18557054_s.png")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/c/600x600/img-master/img/2014/10/02/13/51/23/46304396_p0_master1200.jpg")
+            assert_equal(46304396, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img-original/img/2014/10/02/13/51/23/46304396_p0.png")
+            assert_equal(46304396, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://i1.pixiv.net/img-zip-ugoira/img/2014/10/03/17/29/16/46323924_ugoira1920x1080.zip")
+            assert_equal(46323924, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+
+
+            @post.update(source: "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://www.pixiv.net/member_illust.php?mode=big&illust_id=18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://www.pixiv.net/member_illust.php?mode=manga&illust_id=18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+
+            @post.update(source: "http://www.pixiv.net/i/18557054")
+            assert_equal(18557054, @post.pixiv_id)
+            @post.pixiv_id = nil
+          end
+        end
+
         should "normalize pixiv links" do
           @post.source = "http://i2.pixiv.net/img12/img/zenze/39749565.png"
           assert_equal("http://www.pixiv.net/member_illust.php?mode=medium&illust_id=39749565", @post.normalized_source)


### PR DESCRIPTION
* Makes `illust_id_from_url` a public class method instead of a protected instance method so that `Post#parse_pixiv_id` can use it.
* Also make `illust_id_from_url` swallow the exception that `illust_id_from_url!` throws so that `parse_pixiv_id` can use it.