### PR TITLE
Make starting user level and default settings configurable.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -64,6 +64,7 @@ class User < ActiveRecord::Base
   after_save :update_cache
   after_update :update_remote_cache
   before_create :promote_to_admin_if_first_user
+  before_create :customize_new_user
   #after_create :notify_sock_puppets
   has_many :feedback, :class_name => "UserFeedback", :dependent => :destroy
   has_many :posts, :foreign_key => "uploader_id"
@@ -309,6 +310,10 @@ class User < ActiveRecord::Base
       else
         self.level = Levels::MEMBER
       end
+    end
+
+    def customize_new_user
+      Danbooru.config.customize_new_user(self)
     end
 
     def role

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -49,14 +49,19 @@ module Danbooru
       "choujin-steiner"
     end
 
-    # Set to true to give all new users gold access.
-    def start_as_gold?
-      false
-    end
-
-    # Set to true to give all new users contributor access.
-    def start_as_contributor?
-      false
+    # Set the default level, permissions, and other settings for new users here.
+    def customize_new_user(user)
+      # user.level = User::Levels::MEMBER
+      # user.can_approve_posts = false
+      # user.can_upload_free = false
+      # user.is_super_voter = false
+      #
+      # user.base_upload_limit = 10
+      # user.comment_threshold = -1
+      # user.blacklisted_tags = ["spoilers", "guro", "scat", "furry -rating:s"].join("\n")
+      # user.default_image_size = "large"
+      # user.per_page = 20
+      # user.disable_tagged_filenames = false
     end
 
     # What method to use to store images.

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -62,6 +62,7 @@ module Danbooru
       # user.default_image_size = "large"
       # user.per_page = 20
       # user.disable_tagged_filenames = false
+      true
     end
 
     # What method to use to store images.


### PR DESCRIPTION
The default config has `start_as_gold?` and `start_as_contributor?` methods but they don't actually do anything. `git log -G start_as` indicates they never have done anything.

This PR removes those methods and replaces them with a more general `customize_new_user` method for setting the starting user level, permissions and defaults for any other settings. 