### PR TITLE
Give full permissions to the starting admin.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -306,6 +306,9 @@ class User < ActiveRecord::Base
 
       if User.count == 0
         self.level = Levels::ADMIN
+        self.can_approve_posts = true
+        self.can_upload_free = true
+        self.is_super_voter = true
       else
         self.level = Levels::MEMBER
       end


### PR DESCRIPTION
The first user created is automatically made an admin, but that user doesn't start with approval permission. Just giving yourself approval permission doesn't seem to work either (not sure why). I ended up having to make another admin and using that account to give approval permission to my first admin.