### PR TITLE
Artist finder: Don't return bogus results for non-matching twitter artists

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -37,6 +37,7 @@ class Artist < ActiveRecord::Base
           break if url =~ /lohas\.nicoseiga\.jp\/priv\/$/i
           break if url =~ /(?:data|media)\.tumblr\.com\/[a-z0-9]+\/$/i
           break if url =~ /deviantart\.net\//i
+          break if url =~ %r!\Ahttps?://(?:mobile\.)?twitter\.com/\Z!i
         end
 
         artists.inject({}) {|h, x| h[x.name] = x; h}.values.slice(0, 20)

--- a/test/fixtures/vcr_cassettes/artist-test/21e234db9c1ba2648f3b04b47dd84349137691cd.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/21e234db9c1ba2648f3b04b47dd84349137691cd.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198486017030; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:44 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 9024e86230029064210488706cbc303e
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '110'
+      X-Transaction:
+      - 0024242600e32217
+      X-Tsa-Request-Body-Time:
+      - '1'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:44 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/733355069966426113.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1586'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198506537322; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:45 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - c8ec8e7b5cd6cec537c6483d17cab07f
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '173'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '114'
+      X-Transaction:
+      - 0096bf6700365cdb
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Thu May 19 17:54:08 +0000 2016","id":733355069966426113,"id_str":"733355069966426113","text":"\u300c\u30ca\u30e0\u30b3\u30af\u30ed\u30b9\u30ab\u30d7\u30b3\u30f3\u300d\u300c\u7121\u9650\u306e\u30d5\u30ed\u30f3\u30c6\u30a3\u30a2\u300d\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u3067\u6c34\u8c37\u512a\u5b50\u3055\u3093\u304c\u6f14\u3058\u3066\u3044\u305f\u30ad\u30e3\u30e9\u3092\u63cf\u3044\u305f\u3002
+        https:\/\/t.co\/BFGcirPy5q","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":107921105,"id_str":"107921105","name":"\u6625\u5c71\u548c\u5247","screen_name":"kazuharoom","location":"\u5f69\u306e\u56fd","description":"TV\u30a2\u30cb\u30e1\u300c\u7f8e\u7537\u9ad8\u6821\u5730\u7403\u9632\u885b\u90e8LOVE\uff01LOVE\uff01\u300d\u602a\u4eba\u30c7\u30b6\u30a4\u30f3\u30013DS\u30bd\u30d5\u30c8\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3000\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u30b7\u30ea\u30fc\u30ba\u4f1a\u8a71\u7528\u306e\u7acb\u3061\u7d75\u306a\u3069\u3092\u62c5\u5f53\u3002\u305f\u307e\u306b\u300c\u30ed\u30dc\u30c3\u30c8\u30ac\u30fc\u30eb\u30baZ\u300d\u306e\u5468\u308a\u3092\u3046\u308d\u3064\u3044\u3066\u3044\u305f\u308a\u3002\u3053\u3061\u3089\u306eLINE\u30b9\u30bf\u30f3\u30d7\u306e\u30ad\u30e3\u30e9\u30c7\u30b6\u30a4\u30f3\u3057\u3066\u307e\u3059\u3002https:\/\/t.co\/hii7NrHpKL","url":"http:\/\/t.co\/Cg6TEjQoPW","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/Cg6TEjQoPW","expanded_url":"http:\/\/mixi.jp\/show_profile.pl?id=168219&from=navi","display_url":"mixi.jp\/show_profile.p\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/hii7NrHpKL","expanded_url":"http:\/\/line.me\/S\/sticker\/1068890","display_url":"line.me\/S\/sticker\/1068\u2026","indices":[123,146]}]}},"protected":false,"followers_count":4523,"friends_count":501,"listed_count":303,"created_at":"Sun
+        Jan 24 05:52:16 +0000 2010","favourites_count":118,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":19269,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFF04D","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_tile":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/107921105\/1420559479","profile_link_color":"0099CC","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"F6FFD1","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":565,"favorite_count":534,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:45 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198527721830; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:45 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - cbdfc200dc911f34e8e0c7234bed363b
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '111'
+      X-Transaction:
+      - 0012e64c001d98e2
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:45 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/733355069966426113.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1586'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:45 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198548314012; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:45 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 20e3f1e28bc1661f1f9a519b5314f342
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '172'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 00de7d11000e5f70
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Thu May 19 17:54:08 +0000 2016","id":733355069966426113,"id_str":"733355069966426113","text":"\u300c\u30ca\u30e0\u30b3\u30af\u30ed\u30b9\u30ab\u30d7\u30b3\u30f3\u300d\u300c\u7121\u9650\u306e\u30d5\u30ed\u30f3\u30c6\u30a3\u30a2\u300d\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u3067\u6c34\u8c37\u512a\u5b50\u3055\u3093\u304c\u6f14\u3058\u3066\u3044\u305f\u30ad\u30e3\u30e9\u3092\u63cf\u3044\u305f\u3002
+        https:\/\/t.co\/BFGcirPy5q","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":107921105,"id_str":"107921105","name":"\u6625\u5c71\u548c\u5247","screen_name":"kazuharoom","location":"\u5f69\u306e\u56fd","description":"TV\u30a2\u30cb\u30e1\u300c\u7f8e\u7537\u9ad8\u6821\u5730\u7403\u9632\u885b\u90e8LOVE\uff01LOVE\uff01\u300d\u602a\u4eba\u30c7\u30b6\u30a4\u30f3\u30013DS\u30bd\u30d5\u30c8\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3000\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u30b7\u30ea\u30fc\u30ba\u4f1a\u8a71\u7528\u306e\u7acb\u3061\u7d75\u306a\u3069\u3092\u62c5\u5f53\u3002\u305f\u307e\u306b\u300c\u30ed\u30dc\u30c3\u30c8\u30ac\u30fc\u30eb\u30baZ\u300d\u306e\u5468\u308a\u3092\u3046\u308d\u3064\u3044\u3066\u3044\u305f\u308a\u3002\u3053\u3061\u3089\u306eLINE\u30b9\u30bf\u30f3\u30d7\u306e\u30ad\u30e3\u30e9\u30c7\u30b6\u30a4\u30f3\u3057\u3066\u307e\u3059\u3002https:\/\/t.co\/hii7NrHpKL","url":"http:\/\/t.co\/Cg6TEjQoPW","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/Cg6TEjQoPW","expanded_url":"http:\/\/mixi.jp\/show_profile.pl?id=168219&from=navi","display_url":"mixi.jp\/show_profile.p\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/hii7NrHpKL","expanded_url":"http:\/\/line.me\/S\/sticker\/1068890","display_url":"line.me\/S\/sticker\/1068\u2026","indices":[123,146]}]}},"protected":false,"followers_count":4523,"friends_count":501,"listed_count":303,"created_at":"Sun
+        Jan 24 05:52:16 +0000 2010","favourites_count":118,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":19269,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFF04D","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_tile":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/107921105\/1420559479","profile_link_color":"0099CC","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"F6FFD1","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":565,"favorite_count":534,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:45 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/455987fd06411784f89f9eff6832807fe8bab9b4.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/455987fd06411784f89f9eff6832807fe8bab9b4.yml
@@ -1,0 +1,299 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:41 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198197748666; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:41 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 99581b28a886af5fe49d0f165d926dea
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '116'
+      X-Transaction:
+      - 00d30ea8003b55bc
+      X-Tsa-Request-Body-Time:
+      - '1'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:42 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/684338785744637952.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1578'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198219653412; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:42 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - cc45bd586cfbb74075be977013b46108
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '179'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '116'
+      X-Transaction:
+      - 00570d2f00a10b69
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Tue Jan 05 11:40:55 +0000 2016","id":684338785744637952,"id_str":"684338785744637952","text":"\u672b\u671f\u3060\u307f\u3087\u3093
+        https:\/\/t.co\/TRlhcWl2K7","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}},{"id":684338779918741504,"id_str":"684338779918741504","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":1024,"h":768,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":450,"resize":"fit"},"small":{"w":340,"h":255,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"https:\/\/sites.google.com\/site\/tweentwitterclient\/\" rel=\"nofollow\"\u003eTween\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":194115400,"id_str":"194115400","name":"\u30cf\u30de\u30fc\uff20\u79cb\u4f8b\u5927\u796d\u304d-49a","screen_name":"hamaororon","location":"\u30b3\u30c8\u30d6\u30ad\u30b7\u30c6\u30a3","description":"\u5b9a\u671f\u7684\u306b\u7d75\u3092\u5410\u304d\u51fa\u3059bot\u3002\u6210\u4eba\u5411\u3051\u30a4\u30e9\u30b9\u30c8\u306a\u3069\u3082\u6295\u7a3f\u3057\u3066\u3044\u307e\u3059\u306e\u3067\u672a\u6210\u5e74\u306e\u65b9\u306f\u30d5\u30a9\u30ed\u30fc\u3054\u9060\u616e\u304f\u3060\u3055\u3044\u3002
+        \u30ea\u30d7\u306f\u5168\u3066\u8aad\u307e\u305b\u3066\u9802\u3044\u3066\u3044\u307e\u3059\u304c
+        \u3053\u3061\u3089\u767a\u4fe1\u306e\u307f\u306e\u30a2\u30ab\u30a6\u30f3\u30c8\u3068\u306a\u308a\u307e\u3059\u3002
+        \u5fa1\u7528\u304c\u3042\u308c\u3070pixiv\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306a\u3069\u304b\u3089\u3002\n\u7269\u8a9e\u7528\u30a2\u30ab\u30a6\u30f3\u30c8\uff1ahttps:\/\/t.co\/KbFJfOjqXw","url":"http:\/\/t.co\/QH5kbb6GBO","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/QH5kbb6GBO","expanded_url":"http:\/\/www.pixiv.net\/member.php?id=34904","display_url":"pixiv.net\/member.php?id=\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/KbFJfOjqXw","expanded_url":"https:\/\/twitter.com\/hama_mono","display_url":"twitter.com\/hama_mono","indices":[122,145]}]}},"protected":false,"followers_count":14983,"friends_count":359,"listed_count":414,"created_at":"Thu
+        Sep 23 13:30:52 +0000 2010","favourites_count":136,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":16843,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"1A1B1F","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_tile":false,"profile_image_url":"http:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_image_url_https":"https:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/194115400\/1438312835","profile_link_color":"2FC2EF","profile_sidebar_border_color":"181A1E","profile_sidebar_fill_color":"252429","profile_text_color":"666666","profile_use_background_image":true,"has_extended_profile":false,"default_profile":false,"default_profile_image":true,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":327,"favorite_count":575,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:42 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198240563621; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:42 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 19dc0c966bfa46569e3c3be68541e1fc
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '112'
+      X-Transaction:
+      - 0048c4800056d7c0
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:42 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/684338785744637952.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1578'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198261090925; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:42 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - fde8c199bdacb71ee8dedf1fff895002
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '178'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '168'
+      X-Transaction:
+      - 003c0571007943b0
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Tue Jan 05 11:40:55 +0000 2016","id":684338785744637952,"id_str":"684338785744637952","text":"\u672b\u671f\u3060\u307f\u3087\u3093
+        https:\/\/t.co\/TRlhcWl2K7","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}},{"id":684338779918741504,"id_str":"684338779918741504","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":1024,"h":768,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":450,"resize":"fit"},"small":{"w":340,"h":255,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"https:\/\/sites.google.com\/site\/tweentwitterclient\/\" rel=\"nofollow\"\u003eTween\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":194115400,"id_str":"194115400","name":"\u30cf\u30de\u30fc\uff20\u79cb\u4f8b\u5927\u796d\u304d-49a","screen_name":"hamaororon","location":"\u30b3\u30c8\u30d6\u30ad\u30b7\u30c6\u30a3","description":"\u5b9a\u671f\u7684\u306b\u7d75\u3092\u5410\u304d\u51fa\u3059bot\u3002\u6210\u4eba\u5411\u3051\u30a4\u30e9\u30b9\u30c8\u306a\u3069\u3082\u6295\u7a3f\u3057\u3066\u3044\u307e\u3059\u306e\u3067\u672a\u6210\u5e74\u306e\u65b9\u306f\u30d5\u30a9\u30ed\u30fc\u3054\u9060\u616e\u304f\u3060\u3055\u3044\u3002
+        \u30ea\u30d7\u306f\u5168\u3066\u8aad\u307e\u305b\u3066\u9802\u3044\u3066\u3044\u307e\u3059\u304c
+        \u3053\u3061\u3089\u767a\u4fe1\u306e\u307f\u306e\u30a2\u30ab\u30a6\u30f3\u30c8\u3068\u306a\u308a\u307e\u3059\u3002
+        \u5fa1\u7528\u304c\u3042\u308c\u3070pixiv\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306a\u3069\u304b\u3089\u3002\n\u7269\u8a9e\u7528\u30a2\u30ab\u30a6\u30f3\u30c8\uff1ahttps:\/\/t.co\/KbFJfOjqXw","url":"http:\/\/t.co\/QH5kbb6GBO","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/QH5kbb6GBO","expanded_url":"http:\/\/www.pixiv.net\/member.php?id=34904","display_url":"pixiv.net\/member.php?id=\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/KbFJfOjqXw","expanded_url":"https:\/\/twitter.com\/hama_mono","display_url":"twitter.com\/hama_mono","indices":[122,145]}]}},"protected":false,"followers_count":14984,"friends_count":359,"listed_count":414,"created_at":"Thu
+        Sep 23 13:30:52 +0000 2010","favourites_count":136,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":16843,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"1A1B1F","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_tile":false,"profile_image_url":"http:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_image_url_https":"https:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/194115400\/1438312835","profile_link_color":"2FC2EF","profile_sidebar_border_color":"181A1E","profile_sidebar_fill_color":"252429","profile_text_color":"666666","profile_use_background_image":true,"has_extended_profile":false,"default_profile":false,"default_profile_image":true,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":327,"favorite_count":575,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:42 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/72b0ef658bb36cb909776b4f4d2c3c1cfd4eaacc.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/72b0ef658bb36cb909776b4f4d2c3c1cfd4eaacc.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198822239170; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:48 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 53ceff98d8112494803f35caa5dd34ef
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '111'
+      X-Transaction:
+      - 002d1ac9002ce02e
+      X-Tsa-Request-Body-Time:
+      - '1'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:48 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198843863564; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:48 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - f40aa94a04458dbf8fe6f0134aa48f55
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '167'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '118'
+      X-Transaction:
+      - 00ce33b400828f67
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:48 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198865396066; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:48 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 351ca8263b5ca4be8487f2453decb2ba
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '112'
+      X-Transaction:
+      - 004a5d9800b2e1ee
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:48 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:48 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198886414190; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:48 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 07bd6f33bbc1a18701b0bf9301f4df36
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '166'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '130'
+      X-Transaction:
+      - 0081de6700ce6fa6
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:48 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/7467395b781080266d00137810930d582aec0648.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/7467395b781080266d00137810930d582aec0648.yml
@@ -1,0 +1,299 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:42 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198292873692; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:42 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 26abbbed507264748cf1ff9fec91e3b2
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '120'
+      X-Transaction:
+      - 00df92fb00315a0f
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:43 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/684338785744637952.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1578'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198314493891; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:43 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 8f4d0465d67d330c18b8c064cb50b9aa
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '177'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '116'
+      X-Transaction:
+      - 0062f3110007bf3d
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Tue Jan 05 11:40:55 +0000 2016","id":684338785744637952,"id_str":"684338785744637952","text":"\u672b\u671f\u3060\u307f\u3087\u3093
+        https:\/\/t.co\/TRlhcWl2K7","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}},{"id":684338779918741504,"id_str":"684338779918741504","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":1024,"h":768,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":450,"resize":"fit"},"small":{"w":340,"h":255,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"https:\/\/sites.google.com\/site\/tweentwitterclient\/\" rel=\"nofollow\"\u003eTween\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":194115400,"id_str":"194115400","name":"\u30cf\u30de\u30fc\uff20\u79cb\u4f8b\u5927\u796d\u304d-49a","screen_name":"hamaororon","location":"\u30b3\u30c8\u30d6\u30ad\u30b7\u30c6\u30a3","description":"\u5b9a\u671f\u7684\u306b\u7d75\u3092\u5410\u304d\u51fa\u3059bot\u3002\u6210\u4eba\u5411\u3051\u30a4\u30e9\u30b9\u30c8\u306a\u3069\u3082\u6295\u7a3f\u3057\u3066\u3044\u307e\u3059\u306e\u3067\u672a\u6210\u5e74\u306e\u65b9\u306f\u30d5\u30a9\u30ed\u30fc\u3054\u9060\u616e\u304f\u3060\u3055\u3044\u3002
+        \u30ea\u30d7\u306f\u5168\u3066\u8aad\u307e\u305b\u3066\u9802\u3044\u3066\u3044\u307e\u3059\u304c
+        \u3053\u3061\u3089\u767a\u4fe1\u306e\u307f\u306e\u30a2\u30ab\u30a6\u30f3\u30c8\u3068\u306a\u308a\u307e\u3059\u3002
+        \u5fa1\u7528\u304c\u3042\u308c\u3070pixiv\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306a\u3069\u304b\u3089\u3002\n\u7269\u8a9e\u7528\u30a2\u30ab\u30a6\u30f3\u30c8\uff1ahttps:\/\/t.co\/KbFJfOjqXw","url":"http:\/\/t.co\/QH5kbb6GBO","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/QH5kbb6GBO","expanded_url":"http:\/\/www.pixiv.net\/member.php?id=34904","display_url":"pixiv.net\/member.php?id=\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/KbFJfOjqXw","expanded_url":"https:\/\/twitter.com\/hama_mono","display_url":"twitter.com\/hama_mono","indices":[122,145]}]}},"protected":false,"followers_count":14984,"friends_count":359,"listed_count":414,"created_at":"Thu
+        Sep 23 13:30:52 +0000 2010","favourites_count":136,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":16843,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"1A1B1F","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_tile":false,"profile_image_url":"http:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_image_url_https":"https:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/194115400\/1438312835","profile_link_color":"2FC2EF","profile_sidebar_border_color":"181A1E","profile_sidebar_fill_color":"252429","profile_text_color":"666666","profile_use_background_image":true,"has_extended_profile":false,"default_profile":false,"default_profile_image":true,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":327,"favorite_count":575,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:43 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198335105667; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:43 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - e5f2a4d980626de79dfefeaeac2b3aea
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '112'
+      X-Transaction:
+      - 00c41eb2007702c9
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:43 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/684338785744637952.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1578'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198355542696; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:43 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - d80772df79e34620988d027bebe110c6
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '176'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '155'
+      X-Transaction:
+      - 0029a83100d4b2ce
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Tue Jan 05 11:40:55 +0000 2016","id":684338785744637952,"id_str":"684338785744637952","text":"\u672b\u671f\u3060\u307f\u3087\u3093
+        https:\/\/t.co\/TRlhcWl2K7","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":684338770687045632,"id_str":"684338770687045632","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfHTUMAAFoBH.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":768,"h":1024,"resize":"fit"},"small":{"w":340,"h":453,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":800,"resize":"fit"}}},{"id":684338779918741504,"id_str":"684338779918741504","indices":[7,30],"media_url":"http:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/CX9CfpsUsAAwMR7.jpg","url":"https:\/\/t.co\/TRlhcWl2K7","display_url":"pic.twitter.com\/TRlhcWl2K7","expanded_url":"http:\/\/twitter.com\/hamaororon\/status\/684338785744637952\/photo\/1","type":"photo","sizes":{"large":{"w":1024,"h":768,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"medium":{"w":600,"h":450,"resize":"fit"},"small":{"w":340,"h":255,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"https:\/\/sites.google.com\/site\/tweentwitterclient\/\" rel=\"nofollow\"\u003eTween\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":194115400,"id_str":"194115400","name":"\u30cf\u30de\u30fc\uff20\u79cb\u4f8b\u5927\u796d\u304d-49a","screen_name":"hamaororon","location":"\u30b3\u30c8\u30d6\u30ad\u30b7\u30c6\u30a3","description":"\u5b9a\u671f\u7684\u306b\u7d75\u3092\u5410\u304d\u51fa\u3059bot\u3002\u6210\u4eba\u5411\u3051\u30a4\u30e9\u30b9\u30c8\u306a\u3069\u3082\u6295\u7a3f\u3057\u3066\u3044\u307e\u3059\u306e\u3067\u672a\u6210\u5e74\u306e\u65b9\u306f\u30d5\u30a9\u30ed\u30fc\u3054\u9060\u616e\u304f\u3060\u3055\u3044\u3002
+        \u30ea\u30d7\u306f\u5168\u3066\u8aad\u307e\u305b\u3066\u9802\u3044\u3066\u3044\u307e\u3059\u304c
+        \u3053\u3061\u3089\u767a\u4fe1\u306e\u307f\u306e\u30a2\u30ab\u30a6\u30f3\u30c8\u3068\u306a\u308a\u307e\u3059\u3002
+        \u5fa1\u7528\u304c\u3042\u308c\u3070pixiv\u306e\u30e1\u30c3\u30bb\u30fc\u30b8\u306a\u3069\u304b\u3089\u3002\n\u7269\u8a9e\u7528\u30a2\u30ab\u30a6\u30f3\u30c8\uff1ahttps:\/\/t.co\/KbFJfOjqXw","url":"http:\/\/t.co\/QH5kbb6GBO","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/QH5kbb6GBO","expanded_url":"http:\/\/www.pixiv.net\/member.php?id=34904","display_url":"pixiv.net\/member.php?id=\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/KbFJfOjqXw","expanded_url":"https:\/\/twitter.com\/hama_mono","display_url":"twitter.com\/hama_mono","indices":[122,145]}]}},"protected":false,"followers_count":14984,"friends_count":359,"listed_count":414,"created_at":"Thu
+        Sep 23 13:30:52 +0000 2010","favourites_count":136,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":16843,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"1A1B1F","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme9\/bg.gif","profile_background_tile":false,"profile_image_url":"http:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_image_url_https":"https:\/\/abs.twimg.com\/sticky\/default_profile_images\/default_profile_3_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/194115400\/1438312835","profile_link_color":"2FC2EF","profile_sidebar_border_color":"181A1E","profile_sidebar_fill_color":"252429","profile_text_color":"666666","profile_use_background_image":true,"has_extended_profile":false,"default_profile":false,"default_profile_image":true,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":327,"favorite_count":575,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:43 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/7e541859685456b205ee26f92edb2311b776f722.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/7e541859685456b205ee26f92edb2311b776f722.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198606801774; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:46 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 83df32bc890d42f08482704e13031251
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 00f6a04300adf126
+      X-Tsa-Request-Body-Time:
+      - '1'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:46 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198628480794; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:46 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 962a0bfafce5b322e85ab8fe35bb3103
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '171'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '114'
+      X-Transaction:
+      - 00776c2800b92fba
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:46 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198649426347; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:46 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 05981c92c18b16f5c46b4718b9d8d387
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '112'
+      X-Transaction:
+      - 006cab2200940696
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:46 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:46 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198670186074; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:46 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - d98670c16c6b4e5753e3f2cb2c331f84
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '170'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '157'
+      X-Transaction:
+      - 00c38c6c00a81b8b
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:46 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/b48b1231489a68e43002dc1f07c0a29e28c4625b.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/b48b1231489a68e43002dc1f07c0a29e28c4625b.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:43 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198385907362; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:43 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 2b641641a0b07cac6476888bfba44280
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '187'
+      X-Transaction:
+      - 00da8f1f00932501
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:44 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/733355069966426113.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1586'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198414204836; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:44 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - c7b85ef56b1bcd3ab46f676c6ae7bb71
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '175'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '112'
+      X-Transaction:
+      - 00e50fb50061ba56
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Thu May 19 17:54:08 +0000 2016","id":733355069966426113,"id_str":"733355069966426113","text":"\u300c\u30ca\u30e0\u30b3\u30af\u30ed\u30b9\u30ab\u30d7\u30b3\u30f3\u300d\u300c\u7121\u9650\u306e\u30d5\u30ed\u30f3\u30c6\u30a3\u30a2\u300d\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u3067\u6c34\u8c37\u512a\u5b50\u3055\u3093\u304c\u6f14\u3058\u3066\u3044\u305f\u30ad\u30e3\u30e9\u3092\u63cf\u3044\u305f\u3002
+        https:\/\/t.co\/BFGcirPy5q","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":107921105,"id_str":"107921105","name":"\u6625\u5c71\u548c\u5247","screen_name":"kazuharoom","location":"\u5f69\u306e\u56fd","description":"TV\u30a2\u30cb\u30e1\u300c\u7f8e\u7537\u9ad8\u6821\u5730\u7403\u9632\u885b\u90e8LOVE\uff01LOVE\uff01\u300d\u602a\u4eba\u30c7\u30b6\u30a4\u30f3\u30013DS\u30bd\u30d5\u30c8\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3000\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u30b7\u30ea\u30fc\u30ba\u4f1a\u8a71\u7528\u306e\u7acb\u3061\u7d75\u306a\u3069\u3092\u62c5\u5f53\u3002\u305f\u307e\u306b\u300c\u30ed\u30dc\u30c3\u30c8\u30ac\u30fc\u30eb\u30baZ\u300d\u306e\u5468\u308a\u3092\u3046\u308d\u3064\u3044\u3066\u3044\u305f\u308a\u3002\u3053\u3061\u3089\u306eLINE\u30b9\u30bf\u30f3\u30d7\u306e\u30ad\u30e3\u30e9\u30c7\u30b6\u30a4\u30f3\u3057\u3066\u307e\u3059\u3002https:\/\/t.co\/hii7NrHpKL","url":"http:\/\/t.co\/Cg6TEjQoPW","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/Cg6TEjQoPW","expanded_url":"http:\/\/mixi.jp\/show_profile.pl?id=168219&from=navi","display_url":"mixi.jp\/show_profile.p\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/hii7NrHpKL","expanded_url":"http:\/\/line.me\/S\/sticker\/1068890","display_url":"line.me\/S\/sticker\/1068\u2026","indices":[123,146]}]}},"protected":false,"followers_count":4523,"friends_count":501,"listed_count":303,"created_at":"Sun
+        Jan 24 05:52:16 +0000 2010","favourites_count":118,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":19269,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFF04D","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_tile":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/107921105\/1420559479","profile_link_color":"0099CC","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"F6FFD1","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":565,"favorite_count":534,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:44 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198435281979; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:44 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 267e022594b6aa8b38193454013f0a09
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 00beb158001a9f87
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:44 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/733355069966426113.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1586'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:44 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198455850094; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:44 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 88428359276b2a5acb8d77337cfa1ca0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '174'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '151'
+      X-Transaction:
+      - 00a134dc00f08eaa
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Thu May 19 17:54:08 +0000 2016","id":733355069966426113,"id_str":"733355069966426113","text":"\u300c\u30ca\u30e0\u30b3\u30af\u30ed\u30b9\u30ab\u30d7\u30b3\u30f3\u300d\u300c\u7121\u9650\u306e\u30d5\u30ed\u30f3\u30c6\u30a3\u30a2\u300d\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u3067\u6c34\u8c37\u512a\u5b50\u3055\u3093\u304c\u6f14\u3058\u3066\u3044\u305f\u30ad\u30e3\u30e9\u3092\u63cf\u3044\u305f\u3002
+        https:\/\/t.co\/BFGcirPy5q","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":733355068179632128,"id_str":"733355068179632128","indices":[59,82],"media_url":"http:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ci1mjI0UUAAUw9x.jpg","url":"https:\/\/t.co\/BFGcirPy5q","display_url":"pic.twitter.com\/BFGcirPy5q","expanded_url":"http:\/\/twitter.com\/kazuharoom\/status\/733355069966426113\/photo\/1","type":"photo","sizes":{"medium":{"w":600,"h":697,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"large":{"w":775,"h":900,"resize":"fit"},"small":{"w":340,"h":395,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":107921105,"id_str":"107921105","name":"\u6625\u5c71\u548c\u5247","screen_name":"kazuharoom","location":"\u5f69\u306e\u56fd","description":"TV\u30a2\u30cb\u30e1\u300c\u7f8e\u7537\u9ad8\u6821\u5730\u7403\u9632\u885b\u90e8LOVE\uff01LOVE\uff01\u300d\u602a\u4eba\u30c7\u30b6\u30a4\u30f3\u30013DS\u30bd\u30d5\u30c8\u300c\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u3000\u30af\u30ed\u30b9\u30be\u30fc\u30f3\u300d\u30b7\u30ea\u30fc\u30ba\u4f1a\u8a71\u7528\u306e\u7acb\u3061\u7d75\u306a\u3069\u3092\u62c5\u5f53\u3002\u305f\u307e\u306b\u300c\u30ed\u30dc\u30c3\u30c8\u30ac\u30fc\u30eb\u30baZ\u300d\u306e\u5468\u308a\u3092\u3046\u308d\u3064\u3044\u3066\u3044\u305f\u308a\u3002\u3053\u3061\u3089\u306eLINE\u30b9\u30bf\u30f3\u30d7\u306e\u30ad\u30e3\u30e9\u30c7\u30b6\u30a4\u30f3\u3057\u3066\u307e\u3059\u3002https:\/\/t.co\/hii7NrHpKL","url":"http:\/\/t.co\/Cg6TEjQoPW","entities":{"url":{"urls":[{"url":"http:\/\/t.co\/Cg6TEjQoPW","expanded_url":"http:\/\/mixi.jp\/show_profile.pl?id=168219&from=navi","display_url":"mixi.jp\/show_profile.p\u2026","indices":[0,22]}]},"description":{"urls":[{"url":"https:\/\/t.co\/hii7NrHpKL","expanded_url":"http:\/\/line.me\/S\/sticker\/1068890","display_url":"line.me\/S\/sticker\/1068\u2026","indices":[123,146]}]}},"protected":false,"followers_count":4523,"friends_count":501,"listed_count":303,"created_at":"Sun
+        Jan 24 05:52:16 +0000 2010","favourites_count":118,"utc_offset":32400,"time_zone":"Tokyo","geo_enabled":false,"verified":false,"statuses_count":19269,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"FFF04D","profile_background_image_url":"http:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_image_url_https":"https:\/\/pbs.twimg.com\/profile_background_images\/208757913\/_____.jpg","profile_background_tile":true,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/700884073913282561\/BpRQai7C_normal.png","profile_banner_url":"https:\/\/pbs.twimg.com\/profile_banners\/107921105\/1420559479","profile_link_color":"0099CC","profile_sidebar_border_color":"FFFFFF","profile_sidebar_fill_color":"F6FFD1","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":false,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":565,"favorite_count":534,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"ja"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:44 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/e49e6da7c554f89861b8d8137c549e01ef2fddf1.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/e49e6da7c554f89861b8d8137c549e01ef2fddf1.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198700939309; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:47 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - e3df2549e21f889a989c93e2e58477d9
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '109'
+      X-Transaction:
+      - 006344d500d45a16
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:47 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198721574072; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:47 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 61110ca7f3350bb7d1333ea9505d570c
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '169'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '122'
+      X-Transaction:
+      - 00b3950e002d2d36
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:47 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198743249192; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:47 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 5f18ec84694a94c4340870ee576688a5
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '110'
+      X-Transaction:
+      - 001359ac0038fe3d
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:47 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:47 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198763574112; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:47 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - c4964c2577ead873e35766dfc26d48d9
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '168'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '116'
+      X-Transaction:
+      - 0002075d00aea21b
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:47 GMT
+recorded_with: VCR 2.9.3

--- a/test/fixtures/vcr_cassettes/artist-test/e806ab9d47b5e3ef6d81d61268e2121c5c7b6356.yml
+++ b/test/fixtures/vcr_cassettes/artist-test/e806ab9d47b5e3ef6d81d61268e2121c5c7b6356.yml
@@ -1,0 +1,293 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198914489890; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:49 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - 64f65224321fedee2a52cf2f8f8706b8
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '116'
+      X-Transaction:
+      - 00d813b40062bffe
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:49 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198935661641; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:49 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 9235c0a75fd43ec385f7d47fdcccedf9
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '165'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 00a5fe2500cdc975
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:49 GMT
+- request:
+    method: post
+    uri: https://SENSITIVE:SENSITIVE@api.twitter.com/oauth2/token
+    body:
+      encoding: UTF-8
+      string: grant_type=client_credentials
+    headers:
+      Accept:
+      - "*/*"
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Content-Type:
+      - application/x-www-form-urlencoded; charset=UTF-8
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '154'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Ml:
+      - A
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198956549088; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:49 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Connection-Hash:
+      - f3ce6c3c55f5a289cfef570b928aead2
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 0092f8ff001c84eb
+      X-Tsa-Request-Body-Time:
+      - '0'
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Ua-Compatible:
+      - IE=edge,chrome=1
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"token_type":"bearer","access_token":"AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:49 GMT
+- request:
+    method: get
+    uri: https://api.twitter.com/1.1/statuses/show/782880825700343808.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - TwitterRubyGem/5.14.0
+      Authorization:
+      - Bearer AAAAAAAAAAAAAAAAAAAAABxDxQAAAAAA9JBLjeoZKkzJhdrk%2BdG7L9juhpI%3DVCHw1cte0d1sovPYOnVc11y98pM7yKZ9LCRqMqJmE9Np7snL5C
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, pre-check=0, post-check=0
+      Content-Disposition:
+      - attachment; filename=json.json
+      Content-Length:
+      - '1190'
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Expires:
+      - Tue, 31 Mar 1981 05:00:00 GMT
+      Last-Modified:
+      - Wed, 05 Oct 2016 07:19:49 GMT
+      Pragma:
+      - no-cache
+      Server:
+      - tsa_f
+      Set-Cookie:
+      - guest_id=v1%3A147565198977368729; Domain=.twitter.com; Path=/; Expires=Fri,
+        05-Oct-2018 07:19:49 UTC
+      Status:
+      - 200 OK
+      Strict-Transport-Security:
+      - max-age=631138519
+      X-Access-Level:
+      - read
+      X-Connection-Hash:
+      - 79d32654ebd946d067a1a59c24c596c6
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Rate-Limit-Limit:
+      - '180'
+      X-Rate-Limit-Remaining:
+      - '164'
+      X-Rate-Limit-Reset:
+      - '1475652882'
+      X-Response-Time:
+      - '113'
+      X-Transaction:
+      - 004b83dc00fa2a25
+      X-Twitter-Response-Tags:
+      - BouncerCompliant
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"created_at":"Mon Oct 03 09:51:48 +0000 2016","id":782880825700343808,"id_str":"782880825700343808","text":"https:\/\/t.co\/HSnE9IVuIj","truncated":false,"entities":{"hashtags":[],"symbols":[],"user_mentions":[],"urls":[],"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"extended_entities":{"media":[{"id":782880811934638080,"id_str":"782880811934638080","indices":[0,23],"media_url":"http:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","media_url_https":"https:\/\/pbs.twimg.com\/media\/Ct1Z81jVYAA17qS.jpg","url":"https:\/\/t.co\/HSnE9IVuIj","display_url":"pic.twitter.com\/HSnE9IVuIj","expanded_url":"https:\/\/twitter.com\/bkub_comic\/status\/782880825700343808\/photo\/1","type":"photo","sizes":{"medium":{"w":393,"h":1200,"resize":"fit"},"large":{"w":450,"h":1375,"resize":"fit"},"thumb":{"w":150,"h":150,"resize":"crop"},"small":{"w":223,"h":680,"resize":"fit"}}}]},"source":"\u003ca
+        href=\"http:\/\/twitter.com\" rel=\"nofollow\"\u003eTwitter Web Client\u003c\/a\u003e","in_reply_to_status_id":null,"in_reply_to_status_id_str":null,"in_reply_to_user_id":null,"in_reply_to_user_id_str":null,"in_reply_to_screen_name":null,"user":{"id":889592953,"id_str":"889592953","name":"\u5927\u5ddd\u3076\u304f\u3076\/bkub","screen_name":"bkub_comic","location":"hyogo.JP","description":"japanese
+        kuso manga boy  \u30a2\u30f3\u30bd\u30ed\u4f5c\u5bb6\u3000\u9023\u7d61\u5148se-bu@hotmail.co.jp","url":"https:\/\/t.co\/zD3dZZYwqs","entities":{"url":{"urls":[{"url":"https:\/\/t.co\/zD3dZZYwqs","expanded_url":"http:\/\/bkub.webcrow.jp\/","display_url":"bkub.webcrow.jp","indices":[0,23]}]},"description":{"urls":[]}},"protected":false,"followers_count":64977,"friends_count":4497,"listed_count":1016,"created_at":"Thu
+        Oct 18 19:33:06 +0000 2012","favourites_count":1307,"utc_offset":28800,"time_zone":"Irkutsk","geo_enabled":false,"verified":false,"statuses_count":5021,"lang":"ja","contributors_enabled":false,"is_translator":false,"is_translation_enabled":false,"profile_background_color":"C0DEED","profile_background_image_url":"http:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_image_url_https":"https:\/\/abs.twimg.com\/images\/themes\/theme1\/bg.png","profile_background_tile":false,"profile_image_url":"http:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_image_url_https":"https:\/\/pbs.twimg.com\/profile_images\/725657446866284544\/bhhCqyPJ_normal.jpg","profile_link_color":"0084B4","profile_sidebar_border_color":"C0DEED","profile_sidebar_fill_color":"DDEEF6","profile_text_color":"333333","profile_use_background_image":true,"has_extended_profile":true,"default_profile":true,"default_profile_image":false,"following":null,"follow_request_sent":null,"notifications":null},"geo":null,"coordinates":null,"place":null,"contributors":null,"is_quote_status":false,"retweet_count":3561,"favorite_count":4347,"favorited":false,"retweeted":false,"possibly_sensitive":false,"possibly_sensitive_appealable":false,"lang":"und"}'
+    http_version: 
+  recorded_at: Wed, 05 Oct 2016 07:19:49 GMT
+recorded_with: VCR 2.9.3


### PR DESCRIPTION
This partially addresses issue #2696. I added some bonus test cases for the artist finder to make sure this didn't cause any regressions. Run them with `ruby -I lib:test test/unit/artist_test.rb -n "/twitter artists/"` to avoid running the whole test suite.