### PR TITLE
Post#unvote!: Return correct score (fixes #2709).

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1033,11 +1033,7 @@ class Post < ActiveRecord::Base
         vote = PostVote.where("post_id = ? and user_id = ?", id, CurrentUser.user.id).first
         vote.destroy
 
-        if vote.score > 0
-          self.score -= vote.score
-        else
-          self.score += vote.score
-        end
+        self.reload
       end
     end
   end


### PR DESCRIPTION
vote.destroy sets the score in the database but not on the in-memory post. So just reload the post from the db to get the updated score, don't duplicate the logic of setting it again.