### PR TITLE
Fix missing JSON/XML templates, make more pages public (#2721)

### DIFF
--- a/app/controllers/artist_commentaries_controller.rb
+++ b/app/controllers/artist_commentaries_controller.rb
@@ -1,6 +1,6 @@
 class ArtistCommentariesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_filter :member_only
+  before_filter :member_only, :except => [:index]
 
   def index
     @commentaries = ArtistCommentary.search(params[:search]).order("artist_commentaries.id desc").paginate(params[:page], :limit => params[:limit])

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -1,5 +1,6 @@
 class BansController < ApplicationController
   before_filter :moderator_only, :except => [:show, :index]
+  respond_to :html, :xml, :json
 
   def new
     @ban = Ban.new(params[:ban])
@@ -12,10 +13,12 @@ class BansController < ApplicationController
   def index
     @search = Ban.search(params[:search]).order("id desc")
     @bans = @search.paginate(params[:page], :limit => params[:limit])
+    respond_with(@bans)
   end
 
   def show
     @ban = Ban.find(params[:id])
+    respond_with(@ban)
   end
 
   def create

--- a/app/controllers/delayed_jobs_controller.rb
+++ b/app/controllers/delayed_jobs_controller.rb
@@ -1,5 +1,7 @@
 class DelayedJobsController < ApplicationController
+  respond_to :html, :xml, :json
   def index
     @delayed_jobs = Delayed::Job.order("created_at desc").paginate(params[:page], :limit => params[:limit])
+    respond_with(@delayed_jobs)
   end
 end

--- a/app/controllers/ip_bans_controller.rb
+++ b/app/controllers/ip_bans_controller.rb
@@ -1,4 +1,5 @@
 class IpBansController < ApplicationController
+  respond_to :html, :xml, :json
   before_filter :moderator_only
 
   def new
@@ -7,21 +8,18 @@ class IpBansController < ApplicationController
 
   def create
     @ip_ban = IpBan.create(params[:ip_ban])
-
-    if @ip_ban.errors.any?
-      render :action => "new"
-    else
-      redirect_to ip_bans_path
-    end
+    respond_with(@ip_ban)
   end
 
   def index
     @search = IpBan.search(params[:search])
     @ip_bans = @search.order("id desc").paginate(params[:page], :limit => params[:limit])
+    respond_with(@ip_bans)
   end
 
   def destroy
     @ip_ban = IpBan.find(params[:id])
     @ip_ban.destroy
+    respond_with(@ip_ban)
   end
 end

--- a/app/controllers/mod_actions_controller.rb
+++ b/app/controllers/mod_actions_controller.rb
@@ -1,5 +1,8 @@
 class ModActionsController < ApplicationController
+  respond_to :html, :xml, :json
+
   def index
     @mod_actions = ModAction.search(params[:search]).order("id desc").paginate(params[:page], :limit => params[:limit])
+    respond_with(@mod_actions)
   end
 end

--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -1,6 +1,5 @@
 class NoteVersionsController < ApplicationController
   respond_to :html, :xml, :json
-  before_filter :member_only, :except => [:index, :show]
 
   def index
     @note_versions = NoteVersion.search(params[:search]).order("note_versions.id desc").paginate(params[:page], :limit => params[:limit])

--- a/app/controllers/post_appeals_controller.rb
+++ b/app/controllers/post_appeals_controller.rb
@@ -1,5 +1,5 @@
 class PostAppealsController < ApplicationController
-  before_filter :member_only
+  before_filter :member_only, :except => [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def new

--- a/app/controllers/post_events_controller.rb
+++ b/app/controllers/post_events_controller.rb
@@ -1,5 +1,4 @@
 class PostEventsController < ApplicationController
-  before_filter :member_only
   respond_to :html, :xml, :json
 
   def index

--- a/app/controllers/post_events_controller.rb
+++ b/app/controllers/post_events_controller.rb
@@ -1,7 +1,9 @@
 class PostEventsController < ApplicationController
   before_filter :member_only
+  respond_to :html, :xml, :json
 
   def index
     @events = PostEvent.find_for_post(params[:post_id])
+    respond_with(@events)
   end
 end

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -1,5 +1,5 @@
 class PostFlagsController < ApplicationController
-  before_filter :member_only
+  before_filter :member_only, :except => [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def new

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -26,11 +26,13 @@ class SavedSearchesController < ApplicationController
       CurrentUser.disable_categorized_saved_searches = true
       CurrentUser.save
     end
+    respond_with(@saved_search)
   end
 
   def destroy
     @saved_search = saved_searches.find(params[:id])
     @saved_search.destroy
+    respond_with(@saved_search)
   end
 
   def edit

--- a/app/controllers/super_voters_controller.rb
+++ b/app/controllers/super_voters_controller.rb
@@ -1,5 +1,4 @@
 class SuperVotersController < ApplicationController
-  before_filter :member_only
   respond_to :html, :xml, :json
 
   def index
@@ -7,4 +6,3 @@ class SuperVotersController < ApplicationController
     respond_with(@super_voters)
   end
 end
-

--- a/app/controllers/super_voters_controller.rb
+++ b/app/controllers/super_voters_controller.rb
@@ -1,8 +1,10 @@
 class SuperVotersController < ApplicationController
   before_filter :member_only
+  respond_to :html, :xml, :json
 
   def index
     @super_voters = SuperVoter.all
+    respond_with(@super_voters)
   end
 end
 

--- a/config/initializers/active_record_api_extensions.rb
+++ b/config/initializers/active_record_api_extensions.rb
@@ -26,6 +26,12 @@ module Danbooru
   end
 end
 
+class Delayed::Job
+  def hidden_attributes
+    [:handler]
+  end
+end
+
 class ActiveRecord::Base
   include Danbooru::Extensions::ActiveRecordApi
 end


### PR DESCRIPTION
Don't see any reason /artist_commentaries shouldn't be public.

Also make /bans.json and /mod_actions.json accessible in the API.

EDIT: Added missing JSON/XML responses for a few more things (super voters, saved searches, posts events, and ip bans), and made a few more pages that were blocked for logged out users public (note versions, posts appeals, post flags, post events, and super voters).