### PR TITLE
Log tag aliases+implications

### DIFF
--- a/test/functional/tag_implication_requests_controller_test.rb
+++ b/test/functional/tag_implication_requests_controller_test.rb
@@ -25,11 +25,31 @@ class TagImplicationRequestsControllerTest < ActionController::TestCase
     end
 
     context "create action" do
-      should "render" do
+      should "create forum post" do
         assert_difference("ForumTopic.count", 1) do
           post :create, {:tag_implication_request => {:antecedent_name => "aaa", :consequent_name => "bbb", :reason => "ccc", :skip_secondary_validations => true}}, {:user_id => @user.id}
         end
         assert_redirected_to(forum_topic_path(ForumTopic.last))
+      end
+
+      should "create a pending implication" do
+        params = {
+          :tag_implication_request => {
+            :antecedent_name => "foo",
+            :consequent_name => "bar",
+            :reason => "blah blah",
+            :skip_secondary_validations => true
+          }
+        }
+
+        post :create, params, {:user_id => @user.id}
+
+        tir = assigns(:tag_implication_request)
+        assert_redirected_to(forum_topic_path(tir.forum_topic))
+
+        assert("foo", tir.tag_implication.antecedent_name)
+        assert("bar", tir.tag_implication.consequent_name)
+        assert("pending", tir.tag_implication.status)
       end
     end
   end


### PR DESCRIPTION
Creates a mod action any time an alias or implication is changed. This includes creations, edits to pending aliases/implications, deletions, and approvals. Also it logs each status change from pending -> queued -> processing -> approved.

Also changes calls from `update_column` to `update` so that the `create_mod_action` callback will run at every point in the lifecycle. 

Note: this breaks a test case in `test/unit/tag_alias_correction_test.rb`. I think it's because the change to `update` causes the `after_save :clear_all_cache` hook on tag aliases to clear the cache more often, which the test doesn't expect.