### PR TITLE
Fix upload bookmarklet for Pixiv whitecube URLs.

### DIFF
--- a/app/logical/downloads/rewrite_strategies/pixiv.rb
+++ b/app/logical/downloads/rewrite_strategies/pixiv.rb
@@ -103,7 +103,7 @@ module Downloads
       # Cache the source data so it gets fetched at most once.
       def source
         @source ||= begin
-          source = ::Sources::Strategies::Pixiv.new(url)
+          source = ::Sources::Site.new(url)
           source.get
 
           source

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -5,9 +5,9 @@ module Sources
     attr_reader :url, :strategy
     delegate :get, :get_size, :site_name, :artist_name, 
       :profile_url, :image_url, :tags, :artist_record, :unique_id, 
-      :page_count, :file_url, :ugoira_frame_data, :image_urls, 
+      :page_count, :file_url, :ugoira_frame_data, :ugoira_content_type, :image_urls,
       :has_artist_commentary?, :artist_commentary_title,
-      :artist_commentary_desc, :to => :strategy
+      :artist_commentary_desc, :rewrite_thumbnails, :to => :strategy
 
     def self.strategies
       [Strategies::PixivWhitecube, Strategies::Pixiv, Strategies::NicoSeiga, Strategies::DeviantArt, Strategies::Nijie, Strategies::Twitter, Strategies::Tumblr]

--- a/app/logical/sources/strategies/pixiv_whitecube.rb
+++ b/app/logical/sources/strategies/pixiv_whitecube.rb
@@ -1,6 +1,8 @@
 module Sources
   module Strategies
     class PixivWhitecube < Base
+      attr_reader :artist_commentary_title, :artist_commentary_desc, :ugoira_frame_data, :ugoira_content_type
+
       # sample: http://www.pixiv.net/whitecube/user/277898/illust/59182257
       WHITECUBE_ILLUST = %r!^https?://www\.pixiv\.net/whitecube/user/\d+/illust/\d+!i
 
@@ -43,7 +45,7 @@ module Sources
         @artist_name = @data.name
         @profile_url = "https://www.pixiv.net/whitecube/user/" + @data.user_id.to_s
         @pixiv_moniker = @data.moniker
-        @zip_url, @ugoira_frame_data = get_zip_url_from_api(@data)
+        @zip_url, @ugoira_frame_data, @ugoira_content_type = get_zip_url_from_api(@data)
         @tags = @data.tags
         @page_count = @data.page_count
         @artist_commentary_title = @data.artist_commentary_title
@@ -54,6 +56,14 @@ module Sources
         if !@zip_url
           @image_url = @data.pages.first
         end
+      end
+
+      def file_url
+        @image_url || @zip_url
+      end
+
+      def rewrite_thumbnails(url)
+        url
       end
 
       def illust_id_from_url
@@ -75,7 +85,7 @@ module Sources
           zip_url = data.json["metadata"]["zip_urls"]["ugoira600x600"].sub("_ugoira600x600.zip", "_ugoira1920x1080.zip")
           frame_data = data.json["metadata"]["frames"]
 
-          return [zip_url, frame_data]
+          return [zip_url, frame_data, "image/png"]
         end
       end
     end


### PR DESCRIPTION
Make the bookmarklet work for URLs like this:

* http://www.pixiv.net/whitecube/user/607414/illust/59510800
* http://www.pixiv.net/whitecube/user/772090/illust/59595705 (ugoira)