### PR TITLE
Fix "conflicting wikis" message; fix alias/implication approvers in BURs (#2715)

### DIFF
--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -31,7 +31,7 @@ class BulkUpdateRequestsController < ApplicationController
   end
 
   def approve
-    @bulk_update_request.approve!(CurrentUser.user.id)
+    @bulk_update_request.approve!(CurrentUser.user)
     respond_with(@bulk_update_request, :location => bulk_update_requests_path)
   end
 

--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -43,7 +43,7 @@ class TagAliasesController < ApplicationController
 
   def approve
     @tag_alias = TagAlias.find(params[:id])
-    @tag_alias.approve!(CurrentUser.user.id)
+    @tag_alias.approve!(CurrentUser.user)
     respond_with(@tag_alias, :location => tag_alias_path(@tag_alias))
   end
 

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -48,7 +48,7 @@ class TagImplicationsController < ApplicationController
 
   def approve
     @tag_implication = TagImplication.find(params[:id])
-    @tag_implication.approve!(CurrentUser.user.id)
+    @tag_implication.approve!(CurrentUser.user)
     respond_with(@tag_implication, :location => tag_implication_path(@tag_implication))
   end
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -318,7 +318,7 @@ class Artist < ActiveRecord::Base
           # potential race condition but unlikely
           unless TagImplication.where(:antecedent_name => name, :consequent_name => "banned_artist").exists?
             tag_implication = TagImplication.create!(:antecedent_name => name, :consequent_name => "banned_artist", :skip_secondary_validations => true, :status => "pending")
-            tag_implication.delay(:queue => "default").process!
+            tag_implication.approve!(CurrentUser.user)
           end
 
           update_column(:is_banned, true)

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -33,12 +33,10 @@ class BulkUpdateRequest < ActiveRecord::Base
 
   extend SearchMethods
 
-  def approve!(approver_id)
-    self.approver_id = approver_id
-    AliasAndImplicationImporter.new(script, forum_topic_id, "1", true).process!
-    self.status = "approved"
-    self.skip_secondary_validations = true
-    save
+  def approve!(approver)
+    AliasAndImplicationImporter.new(script, forum_topic_id, "1", true).process!(approver)
+
+    update({ :status => "approved", :approver_id => approver.id, :skip_secondary_validations => true }, :as => approver.role)
     update_forum_topic_for_approve
 
   rescue Exception => x

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -155,7 +155,10 @@ class TagImplication < ActiveRecord::Base
 
       update_forum_topic_for_error(e)
       update({ :status => "error: #{e}" }, :as => CurrentUser.role)
-      NewRelic::Agent.notice_error(e, :custom_params => {:tag_implication_id => id, :antecedent_name => antecedent_name, :consequent_name => consequent_name})
+
+      if Rails.env.production?
+        NewRelic::Agent.notice_error(e, :custom_params => {:tag_implication_id => id, :antecedent_name => antecedent_name, :consequent_name => consequent_name})
+      end
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -87,6 +87,7 @@ class User < ActiveRecord::Base
   has_many :note_versions, :foreign_key => "updater_id"
   has_many :dmails, lambda {order("dmails.id desc")}, :foreign_key => "owner_id"
   has_many :saved_searches
+  has_many :forum_posts, lambda {order("forum_posts.created_at")}, :foreign_key => "creator_id"
   belongs_to :inviter, :class_name => "User"
   after_update :create_mod_action
   accepts_nested_attributes_for :dmail_filter

--- a/test/factories/tag_alias.rb
+++ b/test/factories/tag_alias.rb
@@ -7,7 +7,8 @@ FactoryGirl.define do
 
     after(:create) do |tag_alias|
       unless tag_alias.status == "pending"
-        tag_alias.process!
+        approver = FactoryGirl.create(:admin_user) unless approver.present?
+        tag_alias.approve!(approver)
       end
     end
   end

--- a/test/factories/tag_implication.rb
+++ b/test/factories/tag_implication.rb
@@ -7,7 +7,8 @@ FactoryGirl.define do
     
     after(:create) do |tag_implication|
       unless tag_implication.status == "pending"
-        tag_implication.process!
+        approver = FactoryGirl.create(:admin_user) unless approver.present?
+        tag_implication.approve!(approver)
       end
     end
   end

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -62,7 +62,8 @@ class ArtistTest < ActiveSupport::TestCase
       setup do
         @post = FactoryGirl.create(:post, :tag_string => "aaa")
         @artist = FactoryGirl.create(:artist, :name => "aaa")
-        @artist.ban!
+        @admin = FactoryGirl.create(:admin_user)
+        CurrentUser.scoped(@admin) { @artist.ban! }
         @post.reload
       end
 
@@ -88,6 +89,11 @@ class ArtistTest < ActiveSupport::TestCase
       should "create a new tag implication" do
         assert_equal(1, TagImplication.where(:antecedent_name => "aaa", :consequent_name => "banned_artist").count)
         assert_equal("aaa banned_artist", @post.tag_string)
+      end
+
+      should "set the approver of the banned_artist implication" do
+        ta = TagImplication.where(:antecedent_name => "aaa", :consequent_name => "banned_artist").first
+        assert_equal(@admin.id, ta.approver.id)
       end
     end
 

--- a/test/unit/bulk_update_request_test.rb
+++ b/test/unit/bulk_update_request_test.rb
@@ -22,7 +22,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
         )
 
         @bur = FactoryGirl.create(:bulk_update_request, :script => @script)
-        @bur.approve!(@admin.id)
+        @bur.approve!(@admin)
 
         @ta = TagAlias.where(:antecedent_name => "foo", :consequent_name => "bar").first
         @ti = TagImplication.where(:antecedent_name => "bar", :consequent_name => "baz").first
@@ -72,7 +72,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
       should "handle errors gracefully" do
         @req.stubs(:update_forum_topic_for_approve).raises(RuntimeError.new("blah"))
         assert_difference("Dmail.count", 1) do
-          @req.approve!(@admin.id)
+          @req.approve!(@admin)
         end
         assert_match(/Exception: RuntimeError/, Dmail.last.body)
         assert_match(/Message: blah/, Dmail.last.body)
@@ -84,7 +84,7 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
 
       should "update the topic when processed" do
         assert_difference("ForumPost.count") do
-          @req.approve!(@admin.id)
+          @req.approve!(@admin)
         end
       end
 


### PR DESCRIPTION
Several bugfixes:

* Attribute the "tag alias has conflicting wiki pages" message to the alias approver, not to the first admin.
* Merge the conflicting wiki pages message and the alias approval message into one forum post.
* Fix a bug with approvers not being set on aliases/implications in bulk update requests.
* Fix a bug with the approver not being set on the banned_artist implication when banning an artist.