### PR TITLE
Add locked:{rating,status,notes} + upvote:/downvote: metatags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -680,7 +680,7 @@ class Post < ActiveRecord::Base
 
     def filter_metatags(tags)
       @pre_metatags, tags = tags.partition {|x| x =~ /\A(?:rating|parent|-parent|source|-?locked):/i}
-      @post_metatags, tags = tags.partition {|x| x =~ /\A(?:-pool|pool|newpool|fav|-fav|child|-favgroup|favgroup):/i}
+      @post_metatags, tags = tags.partition {|x| x =~ /\A(?:-pool|pool|newpool|fav|-fav|child|-favgroup|favgroup|upvote|downvote):/i}
       apply_pre_metatags
       return tags
     end
@@ -718,6 +718,9 @@ class Post < ActiveRecord::Base
 
         when /^-fav:(.+)$/i
           remove_favorite!(CurrentUser.user)
+
+        when /^(up|down)vote:(.+)$/i
+          vote!($1)
 
         when /^child:(.+)$/i
           child = Post.find($1)
@@ -1030,12 +1033,16 @@ class Post < ActiveRecord::Base
     end
 
     def vote!(score)
-      if can_be_voted_by?(CurrentUser.user)
-        vote = PostVote.create(:post_id => id, :score => score)
-        self.score += vote.score
-      else
+      unless CurrentUser.is_voter?
+        raise PostVote::Error.new("You do not have permission to vote")
+      end
+
+      unless can_be_voted_by?(CurrentUser.user)
         raise PostVote::Error.new("You have already voted for this post")
       end
+
+      PostVote.create(:post_id => id, :score => score)
+      reload # PostVote.create modifies our score. Reload to get the new score.
     end
 
     def unvote!

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -679,7 +679,7 @@ class Post < ActiveRecord::Base
     end
 
     def filter_metatags(tags)
-      @pre_metatags, tags = tags.partition {|x| x =~ /\A(?:rating|parent|-parent|source):/i}
+      @pre_metatags, tags = tags.partition {|x| x =~ /\A(?:rating|parent|-parent|source|-?locked):/i}
       @post_metatags, tags = tags.partition {|x| x =~ /\A(?:-pool|pool|newpool|fav|-fav|child|-favgroup|favgroup):/i}
       apply_pre_metatags
       return tags
@@ -773,6 +773,15 @@ class Post < ActiveRecord::Base
 
         when /^rating:([qse])/i
           self.rating = $1.downcase
+
+        when /^(-?)locked:notes?$/i
+          assign_attributes({ is_note_locked: $1 != "-" }, as: CurrentUser.role)
+
+        when /^(-?)locked:rating$/i
+          assign_attributes({ is_rating_locked: $1 != "-" }, as: CurrentUser.role)
+
+        when /^(-?)locked:status$/i
+          assign_attributes({ is_status_locked: $1 != "-" }, as: CurrentUser.role)
         end
       end
     end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     default_image_size "large"
     base_upload_limit 10
     level 20
+    created_at {Time.now}
     last_logged_in_at {Time.now}
     favorite_count 0
     bit_prefs 0

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -731,6 +731,75 @@ class PostTest < ActiveSupport::TestCase
             assert_equal(14901720, @post.pixiv_id)
           end
         end
+
+        context "of" do
+          setup do
+            @builder = FactoryGirl.build(:builder_user)
+          end
+
+          context "locked:notes" do
+            context "by a member" do
+              should "not lock the notes" do
+                @post.update(:tag_string => "locked:notes")
+                assert_equal(false, @post.is_note_locked)
+              end
+            end
+
+            context "by a builder" do
+              should "lock/unlock the notes" do
+                CurrentUser.scoped(@builder) do
+                  @post.update(:tag_string => "locked:notes")
+                  assert_equal(true, @post.is_note_locked)
+
+                  @post.update(:tag_string => "-locked:notes")
+                  assert_equal(false, @post.is_note_locked)
+                end
+              end
+            end
+          end
+
+          context "locked:rating" do
+            context "by a member" do
+              should "not lock the rating" do
+                @post.update(:tag_string => "locked:rating")
+                assert_equal(false, @post.is_rating_locked)
+              end
+            end
+
+            context "by a builder" do
+              should "lock/unlock the rating" do
+                CurrentUser.scoped(@builder) do
+                  @post.update(:tag_string => "locked:rating")
+                  assert_equal(true, @post.is_rating_locked)
+
+                  @post.update(:tag_string => "-locked:rating")
+                  assert_equal(false, @post.is_rating_locked)
+                end
+              end
+            end
+          end
+
+          context "locked:status" do
+            context "by a member" do
+              should "not lock the status" do
+                @post.update(:tag_string => "locked:status")
+                assert_equal(false, @post.is_status_locked)
+              end
+            end
+
+            context "by an admin" do
+              should "lock/unlock the status" do
+                CurrentUser.scoped(FactoryGirl.build(:admin_user)) do
+                  @post.update(:tag_string => "locked:status")
+                  assert_equal(true, @post.is_status_locked)
+
+                  @post.update(:tag_string => "-locked:status")
+                  assert_equal(false, @post.is_status_locked)
+                end
+              end
+            end
+          end
+        end
       end
 
       context "tagged with a negated tag" do


### PR DESCRIPTION
Enables these metatags to be added to posts:

* `locked:rating` / `-locked:rating`
* `locked:notes` / `-locked:notes`
* `locked:status` / `-locked:status`
* `upvote:yes` / `downvote:yes`

`locked:` is for #1716.

`upvote:` / `downvote:` are for completeness, since we already have `fav:`. They're a little strange in that you can say `upvote:whatever` and still upvote the post, but that's how `fav:` works too.