### PR TITLE
Fix notes appearing unsaved after saving them (fix #2747)

### DIFF
--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,7 +1,6 @@
 class NotesController < ApplicationController
   respond_to :html, :xml, :json, :js
   before_filter :member_only, :except => [:index, :show]
-  before_filter :pass_html_id, :only => [:create]
 
   def search
   end
@@ -66,12 +65,6 @@ private
 
   def create_params
     params.require(:note).permit(:x, :y, :width, :height, :body, :post_id, :html_id)
-  end
-
-  def pass_html_id
-    if params[:note] && params[:note][:html_id]
-      response.headers["X-Html-Id"] = params[:note][:html_id]
-    end
   end
 
   def index_by_post

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -65,7 +65,7 @@ private
   end
 
   def create_params
-    params.require(:note).permit(:x, :y, :width, :height, :body, :post_id)
+    params.require(:note).permit(:x, :y, :width, :height, :body, :post_id, :html_id)
   end
 
   def pass_html_id


### PR DESCRIPTION
Bug: creating a note then saving it doesn't remove the red border indicating it's unsaved.

Broken by 8df1496 / PR #2729.

Ref: #2747, http://danbooru.donmai.us/forum_topics/13348
