### PR TITLE
Autotag character_(cosplay) -> character, cosplay.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -608,8 +608,8 @@ class Post < ActiveRecord::Base
       normalized_tags = remove_negated_tags(normalized_tags)
       normalized_tags = normalized_tags.map {|x| Tag.find_or_create_by_name(x).name}
       normalized_tags = %w(tagme) if normalized_tags.empty?
-      normalized_tags = add_automatic_tags(normalized_tags)
       normalized_tags = TagAlias.to_aliased(normalized_tags)
+      normalized_tags = add_automatic_tags(normalized_tags)
       normalized_tags = TagImplication.with_descendants(normalized_tags)
       normalized_tags.sort!
       set_tag_string(normalized_tags.uniq.sort.join(" "))
@@ -677,6 +677,10 @@ class Post < ActiveRecord::Base
       if is_ugoira?
         tags << "ugoira"
       end
+
+      characters = tags.grep(/\A(.+)_\(cosplay\)\Z/) { $1 }
+      tags += characters
+      tags << "cosplay" if characters.present?
 
       return tags
     end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -932,6 +932,20 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      context "with *_(cosplay) tags" do
+        setup do
+          @post.add_tag("hakurei_reimu_(cosplay)")
+          @post.add_tag("hatsune_miku_(cosplay)")
+          @post.save
+        end
+
+        should "add the character tags and the cosplay tag" do
+          assert(@post.has_tag?("hakurei_reimu"))
+          assert(@post.has_tag?("hatsune_miku"))
+          assert(@post.has_tag?("cosplay"))
+        end
+      end
+
       context "that has been updated" do
         should "create a new version if it's the first version" do
           assert_difference("PostVersion.count", 1) do


### PR DESCRIPTION
Make e.g. `hatsune_miku_(cosplay)` automatically add `hatsune_miku` and `cosplay`.

Perform autotagging after aliasing so that `*_(cosplay)` aliases (e.g. `hestia_(dungeon)_(cosplay)` -> `hestia_(danmachi)_(cosplay)`) can take effect first, just in case that matters (honestly, it probably doesn't, but whatever).

ref: http://danbooru.donmai.us/forum_topics/13367