### PR TITLE
Use raw note body instead of sanitized body for note edit box.

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -714,7 +714,7 @@ Danbooru.Note = {
   timeouts: [],
   pending: {},
 
-  add: function(container, id, x, y, w, h, text) {
+  add: function(container, id, x, y, w, h, original_body, sanitized_body) {
     var $note_box = Danbooru.Note.Box.create(id);
     var $note_body = Danbooru.Note.Body.create(id);
 
@@ -724,11 +724,11 @@ Danbooru.Note = {
     $note_box.data('height', h);
     container.appendChild($note_box[0]);
     container.appendChild($note_body[0]);
-    $note_body.data("original-body", text);
+    $note_body.data("original-body", original_body);
     Danbooru.Note.Box.scale($note_box);
-    Danbooru.Note.Body.display_text($note_body, text);
+    Danbooru.Note.Body.display_text($note_body, sanitized_body);
     if (Danbooru.Note.embed) {
-      Danbooru.Note.Body.display_text($note_box.children("div.note-box-inner-border"), text);
+      Danbooru.Note.Body.display_text($note_box.children("div.note-box-inner-border"), sanitized_body);
     }
   },
 
@@ -769,6 +769,7 @@ Danbooru.Note = {
         $article.data("y"),
         $article.data("width"),
         $article.data("height"),
+        $article.data("body"),
         $article.html()
       );
     });

--- a/app/views/notes/_note.html.erb
+++ b/app/views/notes/_note.html.erb
@@ -1,1 +1,1 @@
-<article data-width="<%= note.width %>" data-height="<%= note.height %>" data-x="<%= note.x %>" data-y="<%= note.y %>" data-id="<%= note.id %>"><%= raw DText.sanitize(note.body) %></article>
+<article data-width="<%= note.width %>" data-height="<%= note.height %>" data-x="<%= note.x %>" data-y="<%= note.y %>" data-id="<%= note.id %>" data-body="<%= note.body %>"><%= raw DText.sanitize(note.body) %></article>


### PR DESCRIPTION
Problem: Create a note with body `<i>foo&shy;bar`. Save it, refresh the page, and edit the note. Now you see `<i>foobar</i>` in the edit box even though that is not the actual note body.

The issue is the sanitized body is used instead of the raw body for the edit box. This prevents translators from being able to see and edit the unsanitized note text. So this patch just switches to using the raw note instead.