### PR TITLE
Don't display hidden posts on pool/favgroups order pages (fix #2762).

### DIFF
--- a/app/views/favorite_group_orders/edit.html.erb
+++ b/app/views/favorite_group_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <ul id="sortable">
       <% @favorite_group.posts(:limit => 1_000).each do |post| %>
         <li class="ui-state-default" id="favorite_group[post_id_array]_<%= post.id %>">
-          <%= PostPresenter.preview(post).presence || "Hidden" %>
+          <%= PostPresenter.preview(post).presence || "Hidden: Post ##{post.id}" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/favorite_group_orders/edit.html.erb
+++ b/app/views/favorite_group_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <ul id="sortable">
       <% @favorite_group.posts(:limit => 1_000).each do |post| %>
         <li class="ui-state-default" id="favorite_group[post_id_array]_<%= post.id %>">
-          <%= link_to(image_tag(post.preview_file_url), post_path(post)) %>
+          <%= PostPresenter.preview(post).presence || "Hidden" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <ul id="sortable">
       <% @pool.posts(:limit => 1_000).each do |post| %>
         <li class="ui-state-default" id="pool[post_id_array]_<%= post.id %>">
-          <%= PostPresenter.preview(post).presence || "Hidden" %>
+          <%= PostPresenter.preview(post).presence || "Hidden: Post ##{post.id}" %>
         </li>
       <% end %>
     </ul>

--- a/app/views/pool_orders/edit.html.erb
+++ b/app/views/pool_orders/edit.html.erb
@@ -6,7 +6,7 @@
     <ul id="sortable">
       <% @pool.posts(:limit => 1_000).each do |post| %>
         <li class="ui-state-default" id="pool[post_id_array]_<%= post.id %>">
-          <%= link_to(image_tag(post.preview_file_url), post_path(post)) %>
+          <%= PostPresenter.preview(post).presence || "Hidden" %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
Fix #2762.