### PR TITLE
Pull upload/flag notices from wiki pages.

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -5,6 +5,7 @@ class UploadsController < ApplicationController
 
   def new
     @upload = Upload.new
+    @upload_notice_wiki = WikiPage.titled(Danbooru.config.upload_notice_wiki_page).first
     if params[:url]
       @normalized_url = params[:url]
       headers = default_headers()

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -1,20 +1,4 @@
-<p>If you believe a post does not belong on this site, you can flag for its deletion. As a reminder, the following are some common reasons for flagging a post:</p>
-
-<ul>
-  <li>Not anime-related</li>
-  <li>Third-Party Watermark: text or logo inserted by someone besides the original artist</li>
-  <li>Poor compression: JPEG artifacts</li>
-  <li>Bad proportions: extremely large breasts or penises</li>
-  <li>Manga: Multiple pages of a manga, doujinshi, or comic that don't stand up to individual scrutiny</li>
-  <li>Fake translations: Made up translations are banned</li>
-</ul>
-
-<p>The following are <strong>NOT</strong> valid reasons for flagging a post:</p>
-
-<ul>
-  <li>Duplicate: just parent to the original</li>
-  <li>Banned artist: request that a member of site staff ban this post instead</li>
-</ul>
+<%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body)) %>
 
 <p>Enter a reason:</p>
 

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -4,20 +4,11 @@
 
     <% if CurrentUser.can_upload? %>
       <div id="upload-guide-notice">
-        <p><strong>Before uploading, please read the <%= link_to "how to upload guide", wiki_pages_path(:title => "howto:upload") %></strong>.
-        If you plan to upload your own art, you should read <%= Danbooru.config.app_name %>'s
-        <%= link_to "specific policy guidance", wiki_pages_path(:title => "howto:upload", :anchor => "dtext-self-upload") %>
-        first. More suitable sites to uploading your own artwork include DeviantArt, Tumblr, Twitter, Pixiv, etc.</p>
+        <%= format_text(@upload_notice_wiki.body) %>
       </div>
 
       <% unless CurrentUser.can_upload_free? %>
         <p>You can upload <strong><%= pluralize CurrentUser.upload_limit, "more post" %></strong> today.</p>
-      <% end %>
-
-      <% if params[:url].blank? %>
-        <div id="bookmarklet-notice">
-          <p><span style="font-weight: bold;">You should be using Danbooru's official <%= link_to "upload bookmarklet", bookmarklet_path %> to upload!</span> It makes uploading more convenient and does several things for you automatically such as fixing incorrect sources and optionally copying the artist's commentary.</p>
-        </div>
       <% end %>
 
       <%= render "image" %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -4,7 +4,7 @@
 
     <% if CurrentUser.can_upload? %>
       <div id="upload-guide-notice">
-        <%= format_text(@upload_notice_wiki.body) %>
+        <%= format_text(@upload_notice_wiki.try(&:body)) %>
       </div>
 
       <% unless CurrentUser.can_upload_free? %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -241,6 +241,10 @@ module Danbooru
       nil
     end
 
+    def upload_notice_wiki_page
+      "help:upload_notice"
+    end
+
     # The number of posts displayed per page.
     def posts_per_page
       20

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -245,6 +245,10 @@ module Danbooru
       "help:upload_notice"
     end
 
+    def flag_notice_wiki_page
+      "help:flag_notice"
+    end
+
     # The number of posts displayed per page.
     def posts_per_page
       20


### PR DESCRIPTION
Does #2767: pulls the upload/flag notices from wiki pages so that adjusting them doesn't require code changes. Also removes the bookmarklet notice, I think that should go in the wiki so it can be edited too.