### PR TITLE
Fix #2772: Topics set as mod+ can't be reverted to public ones.

### DIFF
--- a/app/helpers/forum_topics_helper.rb
+++ b/app/helpers/forum_topics_helper.rb
@@ -4,12 +4,6 @@ module ForumTopicsHelper
   end
 
   def available_min_user_levels
-    if CurrentUser.is_admin?
-      [["Moderator", User::Levels::MODERATOR], ["Admin", User::Levels::ADMIN]]
-    elsif CurrentUser.is_moderator?
-      [["Moderator", User::Levels::MODERATOR]]
-    else
-      []
-    end
+    ForumTopic::MIN_LEVELS.select { |name, level| level <= CurrentUser.level }.to_a
   end
 end

--- a/app/helpers/forum_topics_helper.rb
+++ b/app/helpers/forum_topics_helper.rb
@@ -2,4 +2,14 @@ module ForumTopicsHelper
   def forum_topic_category_select(object, field)
     select(object, field, ForumTopic.reverse_category_mapping.to_a)
   end
+
+  def available_min_user_levels
+    if CurrentUser.is_admin?
+      [["Moderator", User::Levels::MODERATOR], ["Admin", User::Levels::ADMIN]]
+    elsif CurrentUser.is_moderator?
+      [["Moderator", User::Levels::MODERATOR]]
+    else
+      []
+    end
+  end
 end

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -5,6 +5,12 @@ class ForumTopic < ActiveRecord::Base
     2 => "Bugs & Features"
   }
 
+  MIN_LEVELS = {
+    None: 0,
+    Moderator: User::Levels::MODERATOR,
+    Admin: User::Levels::ADMIN,
+  }
+
   attr_accessible :title, :original_post_attributes, :category_id, :as => [:member, :builder, :gold, :platinum, :janitor, :moderator, :admin, :default]
   attr_accessible :is_sticky, :is_locked, :is_deleted, :min_level, :as => [:admin, :moderator]
   belongs_to :creator, :class_name => "User"
@@ -18,7 +24,7 @@ class ForumTopic < ActiveRecord::Base
   validates_presence_of :title, :creator_id
   validates_associated :original_post
   validates_inclusion_of :category_id, :in => CATEGORIES.keys
-  validates_inclusion_of :min_level, :in => [0, User::Levels::MODERATOR, User::Levels::ADMIN]
+  validates_inclusion_of :min_level, :in => MIN_LEVELS.values
   accepts_nested_attributes_for :original_post
   after_update :update_orignal_post
 

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -119,27 +119,10 @@ class ForumTopic < ActiveRecord::Base
     end
   end
 
-  module UserLevelMethods
-    extend ActiveSupport::Concern
-
-    module ClassMethods
-      def available_min_user_levels
-        if CurrentUser.is_admin?
-          [["Moderator", User::Levels::MODERATOR], ["Admin", User::Levels::ADMIN]]
-        elsif CurrentUser.is_moderator?
-          [["Moderator", User::Levels::MODERATOR]]
-        else
-          []
-        end
-      end
-    end
-  end
-
   extend SearchMethods
   include CategoryMethods
   include VisitMethods
   include SubscriptionMethods
-  include UserLevelMethods
 
   def editable_by?(user)
     (creator_id == user.id || user.is_moderator?) && visible?(user)

--- a/app/views/forum_topics/_form.html.erb
+++ b/app/views/forum_topics/_form.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <% if CurrentUser.is_moderator? %>
-      <%= f.input :min_level, :as => :select, :collection => available_min_user_levels.to_a %>
+      <%= f.input :min_level, :include_blank => false, :collection => available_min_user_levels %>
       <%= f.input :is_sticky, :label => "Sticky" %>
       <%= f.input :is_locked, :label => "Locked" %>
     <% end %>

--- a/app/views/forum_topics/_form.html.erb
+++ b/app/views/forum_topics/_form.html.erb
@@ -18,7 +18,7 @@
     <% end %>
 
     <% if CurrentUser.is_moderator? %>
-      <%= f.input :min_level, :as => :select, :collection => ForumTopic.available_min_user_levels.to_a %>
+      <%= f.input :min_level, :as => :select, :collection => available_min_user_levels.to_a %>
       <%= f.input :is_sticky, :label => "Sticky" %>
       <%= f.input :is_locked, :label => "Locked" %>
     <% end %>


### PR DESCRIPTION
* Replaces the blank option in the level dropdown with a `Public` option.
* Refactors stuff so that the allowed levels are defined in one place. Edit `MIN_LEVELS` to change the allowed levels.