### PR TITLE
Normalize yande.re sources from image URL -> html page URL.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -478,6 +478,20 @@ class Post < ActiveRecord::Base
         
       when %r{\Ahttps?://pic0[1-4]\.nijie\.info/nijie_picture/(?:diff/main/)?\d+_(\d+)_(?:\d+{10}|\d+_\d+{14})}i
         "http://nijie.info/view.php?id=#{$1}"
+
+      # http://ayase.yande.re/image/2d0d229fd8465a325ee7686fcc7f75d2/yande.re%20192481%20animal_ears%20bunny_ears%20garter_belt%20headphones%20mitha%20stockings%20thighhighs.jpg
+      # https://yuno.yande.re/image/1764b95ae99e1562854791c232e3444b/yande.re%20281544%20cameltoe%20erect_nipples%20fundoshi%20horns%20loli%20miyama-zero%20sarashi%20sling_bikini%20swimsuits.jpg
+      # https://files.yande.re/image/2a5d1d688f565cb08a69ecf4e35017ab/yande.re%20349790%20breast_hold%20kurashima_tomoyasu%20mahouka_koukou_no_rettousei%20naked%20nipples.jpg
+      # https://files.yande.re/sample/0d79447ce2c89138146f64ba93633568/yande.re%20290757%20sample%20seifuku%20thighhighs%20tsukudani_norio.jpg
+      when %r{\Ahttps?://(?:ayase\.|yuno\.|files\.)?yande\.re/(?:sample|image)/[a-z0-9]{32}/yande\.re%20(?<post_id>[0-9]+)%20}i
+        "https://yande.re/post/show/#{$~[:post_id]}"
+
+      # https://yande.re/jpeg/0c9ec0ffcaa40470093cb44c3fd40056/yande.re%2064649%20animal_ears%20cameltoe%20fixme%20nekomimi%20nipples%20ryohka%20school_swimsuit%20see_through%20shiraishi_nagomi%20suzuya%20swimsuits%20tail%20thighhighs.jpg
+      # https://yande.re/jpeg/22577d2344fe694cf47f80563031b3cd.jpg
+      # https://yande.re/image/b4b1d11facd1700544554e4805d47bb6/.png
+      # https://yande.re/sample/ceb6a12e87945413a95b90fada406f91/.jpg
+      when %r{\Ahttps?://(?:ayase\.|yuno\.|files\.)?yande\.re/(?:image|jpeg|sample)/(?<md5>[a-z0-9]{32})(?:/yande\.re.*|/?\.(?:jpg|png))\Z}i
+        "https://yande.re/post?tags=md5:#{$~[:md5]}"
         
       when %r{\Ahttps?://(?:o|image-proxy-origin)\.twimg\.com/\d/proxy\.jpg\?t=(\w+)&}i
         str = Base64.decode64($1)


### PR DESCRIPTION
Normalize http://yande.re sources to either

    https://yande.re/post/show/1234

or

    https://yande.re/post?tags=md5:7289b37841079917485c8403aeebc28d

for the sidebar. See [this bigquery](https://bigquery.cloud.google.com:443/savedquery/446593546541:825b3514deef49c0b5dd2e2e227f1c13) for a test of these regexes against the database; everything is handled except for a few hundred posts from dl.dropbox.com.