### PR TITLE
Fix failures in commenting tests. 

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,7 +24,7 @@ module Danbooru
 
     if File.exists?("#{config.root}/REVISION")
       config.x.git_hash = File.read("#{config.root}/REVISION").strip
-    elsif system("type git && git rev-parse --show-toplevel")
+    elsif system("type git > /dev/null && git rev-parse --show-toplevel > /dev/null")
       config.x.git_hash = %x(git rev-parse --short HEAD).strip
     else
       config.x.git_hash = nil

--- a/test/functional/comment_votes_controller_test.rb
+++ b/test/functional/comment_votes_controller_test.rb
@@ -24,9 +24,9 @@ class CommentVotesControllerTest < ActionController::TestCase
       end
 
       should "fail silently on errors" do
-        FactoryGirl.create(:comment_vote, :comment => @comment)
+        FactoryGirl.create(:comment_vote, :comment => @comment, :score => -1)
         assert_difference("CommentVote.count", 0) do
-          post :create, {:format => "json", :comment_id => @comment.id, :score => 1}, {:user_id => @user.id}
+          post :create, {:format => "json", :comment_id => @comment.id, :score => -1}, {:user_id => @user.id}
           assert_response 422
           assert_equal("{\"errors\":{\"user_id\":[\"have already voted for this comment\"]}}", @response.body.strip)
         end
@@ -42,9 +42,9 @@ class CommentVotesControllerTest < ActionController::TestCase
       end
 
       should "fail silently on errors" do
-        FactoryGirl.create(:comment_vote, :comment => @comment)
+        FactoryGirl.create(:comment_vote, :comment => @comment, :score => -1)
         assert_difference("CommentVote.count", 0) do
-          post :create, {:format => "js", :comment_id => @comment.id, :score => 1}, {:user_id => @user.id}
+          post :create, {:format => "js", :comment_id => @comment.id, :score => -1}, {:user_id => @user.id}
           assert_response :success
         end
       end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -58,7 +58,7 @@ class CommentTest < ActiveSupport::TestCase
           end
 
           dmail = Dmail.last
-          assert_equal("You were mentioned in a \"comment\":http://#{Danbooru.config.hostname}/posts/#{@comment.post_id}#comment-#{@comment.id}\n\n---\n\n[i]#{CurrentUser.name} said:[/i]\n\nHey @#{@user2.name} check this out!", dmail.body)
+          assert_equal("You were mentioned in a \"comment\":/posts/#{@comment.post_id}#comment-#{@comment.id}\n\n---\n\n[i]#{CurrentUser.name} said:[/i]\n\nHey @#{@user2.name} check this out!", dmail.body)
         end
       end
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -111,7 +111,7 @@ class UserTest < ActiveSupport::TestCase
       assert(@user.can_comment_vote?)
       10.times do
         comment = FactoryGirl.create(:comment)
-        FactoryGirl.create(:comment_vote, :comment_id => comment.id)
+        FactoryGirl.create(:comment_vote, :comment_id => comment.id, :score => -1)
       end
 
       assert(!@user.can_comment_vote?)


### PR DESCRIPTION
Restricting users from upvoting their own comments broke some tests. Switch these tests to downvoting instead.