### PR TITLE
Prevent double uploading when hitting enter key in tag edit box more than once.

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -31,7 +31,9 @@
       if (!Danbooru.autocompleting) {
         $("#form").trigger("submit");
         $("#quick-edit-form").trigger("submit");
+        $("#upload_tag_string,#post_tag_string").unbind("keydown");
       }
+
       e.preventDefault();
     });
   }


### PR DESCRIPTION
From http://danbooru.donmai.us/forum_topics/9127?page=143#forum_post_124074: when uploading, if you hit the enter key in the tag edit box multiple times it will cause a double post.

The submit button is disabled after first press to prevent this, but the enter key isn't. This disables the enter key after first press as well.