### PR TITLE
Fix upload preview image displayed at full size (fixes #1375, #2471)

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -8,7 +8,7 @@
     }
 
     if ($("#c-uploads").length) {
-      this.initialize_image();
+      $("#image").load(this.initialize_image);
       this.initialize_info_bookmarklet();
       this.initialize_similar();
       $("#related-tags-button").trigger("click");
@@ -128,11 +128,6 @@
             $("#scale").html("Scaled " + parseInt(100 * ratio) + "% (original: " + origin_width + "x" + origin_height + ")");
           }
         });
-      } else if (height === 0) {
-        if (!this.tries || this.tries < 10) {
-          this.tries = (this.tries || 0) + 1;
-          window.setTimeout(Danbooru.Upload.initialize_image, 200);
-        }
       } else {
         $("#scale").html("(original: " + width + "x" + height + ")");
       }


### PR DESCRIPTION
I'm still getting issue #1375 (upload preview image is displayed at full size) when uploading http://i2.pixiv.net/img-original/img/2016/06/02/23/45/45/57194045_p0.jpg with the bookmarklet.

The issue seems to be that the resizer attempts to poll the image's height before resizing it, but that fails if the image takes >2 seconds to download. This just waits until the image is fully downloaded before resizing it instead.