### PR TITLE
Fix broken ugoira player on safebooru.

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,6 +5,7 @@
 //= require jquery-ui-autocomplete-custom.js
 //= require jquery.storageapi.js
 //= require ugoira_player.js
+//= require stupidtable.js
 //= require rails.js
 //= require common.js
 //= require_tree .

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -4,6 +4,7 @@
 //= require jquery.timeout.js
 //= require jquery-ui-autocomplete-custom.js
 //= require jquery.storageapi.js
+//= require ugoira_player.js
 //= require rails.js
 //= require common.js
 //= require_tree .

--- a/app/views/posts/partials/show/_ugoira_original.html.erb
+++ b/app/views/posts/partials/show/_ugoira_original.html.erb
@@ -37,7 +37,6 @@
 </div>
 
 <% content_for(:html_header) do %>
-  <%= javascript_include_tag "ugoira_player" %>
   <script type="text/javascript">
     Danbooru.Ugoira = {};
 

--- a/app/views/reports/contributors.html.erb
+++ b/app/views/reports/contributors.html.erb
@@ -36,7 +36,6 @@
 <% end %>
 
 <%= content_for(:html_header) do %>
-  <%= javascript_include_tag "stupidtable" %>
   <script type="text/javascript">
     $(function() {
       $("#sortable").stupidtable().on("aftertablesort", function() {

--- a/app/views/reports/janitor_trials.html.erb
+++ b/app/views/reports/janitor_trials.html.erb
@@ -47,7 +47,6 @@
 <% end %>
 
 <%= content_for(:html_header) do %>
-  <%= javascript_include_tag "stupidtable" %>
   <script type="text/javascript">
     $(function() {
       $("#sortable").stupidtable().on("aftertablesort", function() {

--- a/app/views/reports/user_promotions.html.erb
+++ b/app/views/reports/user_promotions.html.erb
@@ -40,7 +40,6 @@
 <% end %>
 
 <%= content_for(:html_header) do %>
-  <%= javascript_include_tag "stupidtable" %>
   <script type="text/javascript">
     $(function() {
       $("#sortable").stupidtable().on("aftertablesort", function() {


### PR DESCRIPTION
From http://danbooru.donmai.us/forum_topics/9127?page=144#forum_post_124118: The ugoira player is broken on safebooru. Example: http://safebooru.donmai.us/posts/2568626?original=1. The cause is `ugoira_player.js` not loading due to this error:

    Asset filtered out and will not be served: add
    `Rails.application.config.assets.precompile += %w( ugoira_player.js)`
    to `config/initializers/assets.rb` and restart your server

This PR instead moves it into application.js so it's minified with everything else. Also it fixes a related stupidtable.js error on these pages:

* http://safebooru.donmai.us/reports/user_promotions
* http://safebooru.donmai.us/reports/contributors
* http://safebooru.donmai.us/reports/janitor_trials