### PR TITLE
Fix "'archive_development' database is not configured." exception.

### DIFF
--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -1,5 +1,9 @@
 class PoolArchive < ActiveRecord::Base
-  establish_connection "archive_#{Rails.env}".to_sym
+  def self.enabled?
+    Danbooru.config.aws_sqs_archives_url.present?
+  end
+
+  establish_connection "archive_#{Rails.env}".to_sym if enabled?
   self.table_name = "pool_versions"
 
   module SearchMethods
@@ -28,10 +32,6 @@ class PoolArchive < ActiveRecord::Base
   end
 
   extend SearchMethods
-
-  def self.enabled?
-    Danbooru.config.aws_sqs_archives_url.present?
-  end
 
   def self.sqs_service
     SqsService.new(Danbooru.config.aws_sqs_archives_url)


### PR DESCRIPTION
`/users/1` and `/static/site_map` throw this exception:

    ActiveRecord::AdapterNotSpecified exception raised
    'archive_development' database is not configured. Available: ["development", "test", "production", "ro_development", "ro_test", "ro_production"]
    app/models/pool_archive.rb:6:in `<class:PoolArchive>'
    app/models/pool_archive.rb:1:in `<top (required)>'
    app/views/static/site_map.html.erb:56:in `_app_views_static_site_map_html_erb__2188261936972743716_31997600'

because I don't have an `archive_development` database on my dev instance. This makes it optional.