### PR TITLE
Various minor comment code cleanups

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -13,9 +13,6 @@ Danbooru.Note = {
 
       $inner_border.css({
         opacity: opacity,
-        "-ms-filter": "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)",
-        "filter": "alpha(opacity=50)",
-        zoom: 1
       });
 
       var $note_box = $('<div/>');

--- a/app/assets/stylesheets/common/000_vars.css.scss
+++ b/app/assets/stylesheets/common/000_vars.css.scss
@@ -49,13 +49,6 @@ $preview_flagged_color: #F00;
   text-shadow: $val;
 }
 
-@mixin transparency($value) {
-  opacity: $value;
-  -ms-filter: unqoute("progid:DXImageTransform.Microsoft.Alpha(Opacity=#{$value * 100})");
-  filter: unquote("alpha(opacity=#{$value * 100})");
-  zoom: 1;
-}
-
 @mixin inline-block {
   display: -moz-inline-box;
   -moz-box-orient: vertical;

--- a/app/assets/stylesheets/specific/comments.css.scss
+++ b/app/assets/stylesheets/specific/comments.css.scss
@@ -41,16 +41,10 @@ div.comments-for-post {
     }
 
     article.comment.below-threshold {
-      -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=30);
-      filter: alpha(opacity=30);
-      zoom: 1;
       opacity: 0.3;
     }
 
     article.comment.below-threshold:hover {
-      -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100);
-      filter: alpha(opacity=100);
-      zoom: 1;
       opacity: 1.0;
     }
   }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -48,9 +48,7 @@ class CommentsController < ApplicationController
 
   def show
     @comment = Comment.find(params[:id])
-    respond_with(@comment) do |format|
-      format.json {render :json => @comment.to_json(:methods => [:creator_name])}
-    end
+    respond_with(@comment)
   end
 
   def destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,6 @@
 class CommentsController < ApplicationController
   respond_to :html, :xml, :json
-  before_filter :member_only, :only => [:update, :create, :edit, :destroy]
+  before_filter :member_only, :except => [:index, :search, :show]
   rescue_from ActiveRecord::StatementInvalid, :with => :rescue_exception
 
   def index

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -199,6 +199,10 @@ class Comment < ActiveRecord::Base
     super + [:body_index]
   end
 
+  def method_attributes
+    super + [:creator_name, :updater_name]
+  end
+
   def delete!
     update_attributes(:is_deleted => true)
   end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -58,7 +58,7 @@ class Comment < ActiveRecord::Base
     end
 
     def for_creator_name(user_name)
-      where("creator_id = (select _.id from users _ where lower(_.name) = lower(?))", user_name.mb_chars.downcase)
+      for_creator(User.name_to_id(user_name).id)
     end
 
     def search(params)
@@ -82,7 +82,7 @@ class Comment < ActiveRecord::Base
       end
 
       if params[:creator_name].present?
-        q = q.for_creator_name(params[:creator_name].tr(" ", "_"))
+        q = q.for_creator_name(params[:creator_name])
       end
 
       if params[:creator_id].present?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -69,8 +69,12 @@ class Comment < ActiveRecord::Base
         q = q.body_matches(params[:body_matches])
       end
 
+      if params[:id].present?
+        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
+      end
+
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where("post_id in (?)", params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:post_tags_match].present?

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -54,11 +54,11 @@ class Comment < ActiveRecord::Base
     end
 
     def for_creator(user_id)
-      where("creator_id = ?", user_id)
+      user_id.present? ? where("creator_id = ?", user_id) : where("false")
     end
 
     def for_creator_name(user_name)
-      for_creator(User.name_to_id(user_name).id)
+      for_creator(User.name_to_id(user_name))
     end
 
     def search(params)

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -1,5 +1,9 @@
 class PoolArchive < ActiveRecord::Base
-  establish_connection "archive_#{Rails.env}".to_sym
+  def self.enabled?
+    Danbooru.config.aws_sqs_archives_url.present?
+  end
+
+  establish_connection "archive_#{Rails.env}".to_sym if enabled?
   self.table_name = "pool_versions"
 
   module SearchMethods
@@ -28,10 +32,6 @@ class PoolArchive < ActiveRecord::Base
   end
 
   extend SearchMethods
-
-  def self.enabled?
-    Danbooru.config.aws_sqs_archives_url.present?
-  end
 
   def self.sqs_service
     SqsService.new(Danbooru.config.aws_sqs_archives_url)

--- a/app/views/comments/partials/index/_threshold.html.erb
+++ b/app/views/comments/partials/index/_threshold.html.erb
@@ -1,3 +1,0 @@
-<% if post.hidden_comment_count(@current_user) > 0 %>
-  <span class="info" id="threshold-comments-notice-for-<%= post.id %>"><%= link_to_remote "#{pluralize post.hidden_comment_count(@current_user), 'comment'} below threshold", :url => index_all_comments_path(:post_id => post.id) %>.</span>
-<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,7 +102,6 @@ Rails.application.routes.draw do
     resources :votes, :controller => "comment_votes", :only => [:create, :destroy]
     collection do
       get :search
-      get :index_all
     end
     member do
       put :unvote


### PR DESCRIPTION
* `/comments.json`: accept `id` param and allow `id` and `post_id` to take comma-delimited lists of ids (cf. #1345, #2455).
* `/comments/1.json`: return `updater_name` too.
* Other minor cleanups, should be self-explanatory.