### PR TITLE
Fix `undefined method `is_deleted?' for nil` on /post_appeals.

### DIFF
--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -3,7 +3,7 @@ class PostAppeal < ActiveRecord::Base
 
   belongs_to :creator, :class_name => "User"
   belongs_to :post
-  validates_presence_of :reason, :creator_id, :creator_ip_addr
+  validates_presence_of :post, :reason, :creator_id, :creator_ip_addr
   validate :validate_post_is_inactive
   validate :validate_creator_is_not_limited
   before_validation :initialize_creator, :on => :create
@@ -69,7 +69,7 @@ class PostAppeal < ActiveRecord::Base
   extend SearchMethods
 
   def resolved?
-    !post.is_deleted? && !post.is_flagged?
+    post.present? && !post.is_deleted? && !post.is_flagged?
   end
 
   def is_resolved
@@ -86,7 +86,7 @@ class PostAppeal < ActiveRecord::Base
   end
 
   def validate_post_is_inactive
-    if !post.is_deleted? && !post.is_flagged?
+    if resolved?
       errors[:post] << "is active"
       false
     else


### PR DESCRIPTION
Fix this exception:

    undefined method `is_deleted?' for nil:NilClass
    app/models/post_appeal.rb:72:in `resolved?'
    app/views/post_appeals/index.html.erb:23:in `block in _app_views_post_appeals_index_html_erb__2678117644687662585_70170674603580'
    app/views/post_appeals/index.html.erb:17:in `_app_views_post_appeals_index_html_erb__2678117644687662585_70170674603580'
    app/controllers/post_appeals_controller.rb:13:in `index'

that occurs on these pages:

* http://danbooru.donmai.us/post_appeals?limit=1&page=a2928
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2929
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2930
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2931
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2934
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2936
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2937
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2945
* http://danbooru.donmai.us/post_appeals?limit=1&page=a2949

I guess these are appeals for expunged posts? That shouldn't be possible though. Or maybe someone created appeals for invalid post IDs? I don't know. Maybe it'd be better to just delete these appeals from the database if they're invalid.