### PR TITLE
Fix bug preventing Platinum users from commenting.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -362,28 +362,7 @@ class User < ActiveRecord::Base
     end
 
     def role
-      case level
-      when Levels::MEMBER
-        :member
-
-      when Levels::GOLD
-        :gold
-
-      when Levels::PLATINUM
-        :platinum
-
-      when Levels::BUILDER
-        :builder
-
-      when Levels::MODERATOR
-        :moderator
-
-      when Levels::JANITOR
-        :janitor
-
-      when Levels::ADMIN
-        :admin
-      end
+      level_string.downcase.to_sym
     end
 
     def level_string_was

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -369,6 +369,9 @@ class User < ActiveRecord::Base
       when Levels::GOLD
         :gold
 
+      when Levels::PLATINUM
+        :platinum
+
       when Levels::BUILDER
         :builder
 


### PR DESCRIPTION
ref: http://danbooru.donmai.us/forum_topics/9127?page=148#forum_post_124769

Bug:

Platinum users get this error when commenting:

    No route matches {:action=>"show", :controller=>"posts", :id=>nil} missing required keys: [:id]

Fix:

The issue was that `CurrentUser.role` was nil for Platinum users, which caused `Comment.create(create_params, :as => CurrentUser.role)` to silently ignore the create_params because the nil role wasn't in the attr_accessible whitelist.

Despite this, things worked accidentally for other models because they had `attr_accessible ..., :as => [:default]` in their whitelists, where the comment model didn't.