### PR TITLE
Fix @mention autocomplete for comments & forum posts.

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -37,7 +37,7 @@
   }
 
   Danbooru.Autocomplete.initialize_mention_autocomplete = function() {
-    var $fields = $("#forum_post_body,#forum_post_body_for_,.comment-form textarea");
+    var $fields = $(".autocomplete-mentions textarea");
     $fields.autocomplete({
       delay: 500,
       minLength: 2,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,6 +127,7 @@ module ApplicationHelper
     options[:input_name] ||= "#{object}[#{name}]"
     options[:value] ||= instance_variable_get("@#{object}").try(name)
     options[:preview_id] ||= "dtext-preview"
+    options[:classes] ||= ""
 
     render "dtext/form", options
   end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= simple_form_for(comment, :html => {:class => "edit_comment"}) do |f| %>
   <%= f.hidden_field :post_id %>
-  <%= dtext_field "comment", "body", :value => comment.body, :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
+  <%= dtext_field "comment", "body", :classes => "autocomplete-mentions", :value => comment.body, :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
   <%= f.button :submit, "Submit", :data => { :disable_with => "Submitting..." } %>
   <%= dtext_preview_button "comment", "body", :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
   <% if comment.new_record? %>

--- a/app/views/dtext/_form.html.erb
+++ b/app/views/dtext/_form.html.erb
@@ -5,7 +5,7 @@
 - preview_id
 - value
  -->
-<div class="input text optional">
+<div class="input text optional <%= classes %>">
   <label class="text optional" for="<%= input_id %>"><%= name %></label>
 
   <div class="dtext-previewable">

--- a/app/views/forum_posts/partials/edit/_form.html.erb
+++ b/app/views/forum_posts/partials/edit/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= simple_form_for(forum_post) do |f| %>
   <%= f.input :topic_id, :as => :hidden %>
-  <%= dtext_field "forum_post", "body", :value => forum_post.body, :input_id => "forum_post_body_for_#{forum_post.id}", :preview_id => "dtext-preview-for-#{forum_post.id}" %>
+  <%= dtext_field "forum_post", "body", :value => forum_post.body, :classes => "autocomplete-mentions", :input_id => "forum_post_body_for_#{forum_post.id}", :preview_id => "dtext-preview-for-#{forum_post.id}" %>
 
   <%= f.button :submit, "Submit" %>
   <%= dtext_preview_button "forum_post", "body", :input_id => "forum_post_body_for_#{forum_post.id}", :preview_id => "dtext-preview-for-#{forum_post.id}" %>

--- a/app/views/forum_posts/partials/new/_form.html.erb
+++ b/app/views/forum_posts/partials/new/_form.html.erb
@@ -2,7 +2,7 @@
 
 <%= simple_form_for(forum_post) do |f| %>
   <%= f.input :topic_id, :as => :hidden %>
-  <%= dtext_field "forum_post", "body" %>
+  <%= dtext_field "forum_post", "body", :classes => "autocomplete-mentions" %>
 
   <%= f.button :submit, "Submit", :data => { :disable_with => "Submitting..." } %>
   <%= dtext_preview_button "forum_post", "body" %>

--- a/app/views/forum_topics/_form.html.erb
+++ b/app/views/forum_topics/_form.html.erb
@@ -14,7 +14,7 @@
         <%= hidden_field_tag "forum_topic[original_post_attributes][topic_id]", forum_topic.id %>
       <% end %>
 
-      <%= dtext_field "forum_post", "body", :input_name => "forum_topic[original_post_attributes][body]", :value => forum_topic.original_post.body, :input_id => "forum_post_body_for_#{forum_topic.original_post.id}", :preview_id => "dtext-preview-for-#{forum_topic.original_post.id}" %>
+      <%= dtext_field "forum_post", "body", :classes => "autocomplete-mentions", :input_name => "forum_topic[original_post_attributes][body]", :value => forum_topic.original_post.body, :input_id => "forum_post_body_for_#{forum_topic.original_post.id}", :preview_id => "dtext-preview-for-#{forum_topic.original_post.id}" %>
     <% end %>
 
     <% if CurrentUser.is_moderator? %>


### PR DESCRIPTION
Fix comment @mention autocomplete (broken in 1257639). Also fix forum post autocomplete (didn't work when editing forum posts). Does so by adding an `autocomplete-mentions` class to dtext fields where autocomplete should happen.