### PR TITLE
Reduce SQL queries on /posts/:id

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -44,7 +44,7 @@ class Post < ActiveRecord::Base
   has_many :versions, lambda {order("post_versions.updated_at ASC, post_versions.id ASC")}, :class_name => "PostVersion", :dependent => :destroy
   has_many :votes, :class_name => "PostVote", :dependent => :destroy
   has_many :notes, :dependent => :destroy
-  has_many :comments, lambda {order("comments.id")}, :dependent => :destroy
+  has_many :comments, lambda {includes(:creator, :updater).order("comments.id")}, :dependent => :destroy
   has_many :children, lambda {order("posts.id")}, :class_name => "Post", :foreign_key => "parent_id"
   has_many :disapprovals, :class_name => "PostDisapproval", :dependent => :destroy
   has_many :favorites, :dependent => :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -965,9 +965,7 @@ class Post < ActiveRecord::Base
     end
 
     def favorited_users
-      favorited_user_ids.map {|id| User.find(id)}.select do |x|
-        !x.hide_favorites?
-      end
+      User.find(favorited_user_ids).reject(&:hide_favorites?)
     end
 
     def favorite_groups(active_id=nil)

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if CurrentUser.is_moderator? || !comment.is_deleted? %>
   <a name="comment-<%= comment.id %>"></a>
-  <article class="comment" data-post-id="<%= comment.post_id %>" data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>" data-creator="<%= comment.creator.name %>" data-is-sticky="<%= comment.is_sticky %>">
+  <article class="comment" data-post-id="<%= comment.post_id %>" data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>" data-creator="<%= comment.creator_name %>" data-is-sticky="<%= comment.is_sticky %>">
     <div class="author">
       <h1>
         <%= link_to_user comment.creator %>


### PR DESCRIPTION
6e62a4c: Pageloads of posts with large numbers of favorites are slowed down by the favorites list in the sidebar loading users one at a time. This costs hundreds of queries for some posts. 

4e8006a fixes a similar problem with each commenter being loaded one at a time instead of all at once.

Test case: `post #1` has ~300 favorites and ~140 comments. It's ~500ms slower to load when logged in (fav list is rendered) versus logged out (fav list isn't rendered). This PR reduces the number of queries on this page from 400+ to 25.