### PR TITLE
Posts: don't revalidate md5 uniqueness on every update.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -14,7 +14,7 @@ class Post < ActiveRecord::Base
   before_validation :parse_pixiv_id
   before_validation :blank_out_nonexistent_parents
   before_validation :remove_parent_loops
-  validates_uniqueness_of :md5
+  validates_uniqueness_of :md5, :on => :create
   validates_inclusion_of :rating, in: %w(s q e), message: "rating must be s, q, or e"
   validate :post_is_not_its_own_parent
   validate :updater_can_change_rating


### PR DESCRIPTION
Tiny optimization for updating posts. Fixes a timeout the `bad_id` mass update had:

    	PG::QueryCanceled: ERROR: canceling statement due to statement timeout : SELECT 1 AS one FROM "posts" WHERE ("posts"."md5" = '8c8e17136bc28912abb828a58f0249de' AND "posts"."id" != 304893) LIMIT 1