### PR TITLE
Related tags html page (fixes #2750)

### DIFF
--- a/app/controllers/related_tags_controller.rb
+++ b/app/controllers/related_tags_controller.rb
@@ -1,5 +1,6 @@
 class RelatedTagsController < ApplicationController
   respond_to :json
+  respond_to :html, :only=>[:show]
   before_filter :require_reportbooru_key, only: [:update]
 
   def show

--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -26,6 +26,10 @@ class RelatedTagQuery
     results
   end
 
+  def tags_for_html
+    map_with_category_data(tags)
+  end
+
   def to_json
     {:query => query, :category => category, :tags => map_with_category_data(tags), :wiki_page_tags => map_with_category_data(wiki_page_tags)}.to_json
   end

--- a/app/views/related_tags/show.html.erb
+++ b/app/views/related_tags/show.html.erb
@@ -1,0 +1,37 @@
+<div>
+  <h1>Related tags</h1>
+  <section>
+    <%= form_tag(related_tag_path, :method => :get) do %>
+      <%= text_field_tag "query", params[:query] %>
+      <%= select_tag "category", options_for_select([""] + Danbooru.config.canonical_tag_category_mapping.map{|x| [x.first, x.first.downcase]}, params[:category]) %>
+      <%= submit_tag "Show"%>
+    <% end %>
+  </section>
+  <% if params[:query].present? %>
+    <section>
+      <table class="striped">
+        <thead>
+          <tr>
+            <th>Name</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @query.tags_for_html.each do |tag, category| %>
+            <tr>
+              <td class="category-<%= category %>">
+                <%= link_to("?", show_or_new_wiki_pages_path(:title => tag)) %>
+                <%= link_to(tag, posts_path(:tags => tag)) %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </section>
+   <% end %>
+</div>
+
+<%= render "tags/secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Related tags - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/tags/_secondary_links.html.erb
+++ b/app/views/tags/_secondary_links.html.erb
@@ -3,6 +3,7 @@
     <li><%= render "tags/quick_search" %></li>
     <li><%= link_to "Listing", tags_path %></li>
     <li><%= link_to "MetaSearch", meta_searches_tags_path %></li>
+    <li><%= link_to "Related tags", related_tag_path %></li>
     <li><%= link_to "Cheatsheet", wiki_pages_path(:search => {:title => "help:cheatsheet"}) %></li>
     <li><%= link_to "Help", wiki_pages_path(:search => {:title => "help:tags"}) %></li>
     <% if @tag %>


### PR DESCRIPTION
Made a very basic search form and listing for related tags, mostly using existing methods that handle JSON requests. I feel like there's a lot of room for the improvement, like for example actually displaying tag count, but this works, too.