### PR TITLE
Fix artist commentary dialog submitting wrong form.

### DIFF
--- a/app/assets/javascripts/artist_commentaries.js
+++ b/app/assets/javascripts/artist_commentaries.js
@@ -36,7 +36,7 @@
       width: 500,
       buttons: {
         "Submit": function() {
-          $("#add-commentary-dialog form").submit();
+          $("#add-commentary-dialog #edit-commentary").submit();
           $(this).dialog("close");
         },
         "Cancel": function() {
@@ -45,7 +45,7 @@
       }
     });
 
-    $('#add-commentary-dialog form').submit(function() {
+    $('#add-commentary-dialog #edit-commentary').submit(function() {
       $('#add-commentary-dialog').dialog('close');
     });
 

--- a/app/views/artist_commentaries/_form.html.erb
+++ b/app/views/artist_commentaries/_form.html.erb
@@ -4,36 +4,36 @@
   <div class="input">
     <label>Copy from</label>
     <%= select_tag :commentary_source_type, options_for_select(%w[Source Post]) %>
-    <%= text_field_tag :commentary_source, @post.source %>
-    <%= text_field_tag :commentary_post_id, (@post.parent.try(&:id) || @post.children.first.try(&:id)), :style => "display: none;" %>
+    <%= text_field_tag :commentary_source, post.source %>
+    <%= text_field_tag :commentary_post_id, (post.parent.try(&:id) || post.children.first.try(&:id)), :style => "display: none;" %>
     <%= button_tag "Fetch" %>
   </div>
 </form>
 
 <%= form_tag(create_or_update_artist_commentaries_path(:format => :js), :remote => true, :id => "edit-commentary", :class => "simple_form", :method => :put) do %>
-  <%= hidden_field :artist_commentary, :post_id, :value => @post.id %>
+  <%= hidden_field :artist_commentary, :post_id, :value => post.id %>
 
   <div class="input">
     <label for="artist_commentary_original_title">Original title</label>
-    <%= text_field :artist_commentary, :original_title, :value => artist_commentary.try(:original_title) %>
+    <%= text_field :artist_commentary, :original_title, :value => post.artist_commentary.try(:original_title) %>
   </div>
 
   <div class="input">
     <label for="artist_commentary_original_description">Original description</label>
-    <%= text_area :artist_commentary, :original_description, :size => "40x6", :value => artist_commentary.try(:original_description) %>
+    <%= text_area :artist_commentary, :original_description, :size => "40x6", :value => post.artist_commentary.try(:original_description) %>
   </div>
 
   <div class="input">
     <label for="artist_commentary_translated_title">Translated title</label>
-    <%= text_field :artist_commentary, :translated_title, :value => artist_commentary.try(:translated_title) %>
+    <%= text_field :artist_commentary, :translated_title, :value => post.artist_commentary.try(:translated_title) %>
   </div>
 
   <div class="input">
     <label for="artist_commentary_translated_description">Translated description</label>
-    <%= text_area :artist_commentary, :translated_description, :size => "40x6", :value => artist_commentary.try(:translated_description) %>
+    <%= text_area :artist_commentary, :translated_description, :size => "40x6", :value => post.artist_commentary.try(:translated_description) %>
   </div>
 
-  <% if @post.has_tag?("commentary") %>
+  <% if post.has_tag?("commentary") %>
     <div class="input">
       <label>
         <%= check_box :artist_commentary, :remove_commentary_tag %>
@@ -49,7 +49,7 @@
     </div>
   <% end %>
 
-  <% if @post.has_tag?("commentary_request") %>
+  <% if post.has_tag?("commentary_request") %>
     <div class="input">
       <label>
         <%= check_box :artist_commentary, :remove_commentary_request_tag %>
@@ -65,7 +65,7 @@
     </div>  
   <% end %>
 
-  <% if @post.has_tag?("check_commentary") %>
+  <% if post.has_tag?("check_commentary") %>
     <div class="input">
       <label>
         <%= check_box :artist_commentary, :remove_commentary_check_tag %>

--- a/app/views/artist_commentaries/_form.html.erb
+++ b/app/views/artist_commentaries/_form.html.erb
@@ -10,7 +10,7 @@
   </div>
 </form>
 
-<%= form_tag(create_or_update_artist_commentaries_path(:format => :js), :remote => true, :class => "simple_form", :method => :put) do %>
+<%= form_tag(create_or_update_artist_commentaries_path(:format => :js), :remote => true, :id => "edit-commentary", :class => "simple_form", :method => :put) do %>
   <%= hidden_field :artist_commentary, :post_id, :value => @post.id %>
 
   <div class="input">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -130,7 +130,7 @@
   </div>
 
   <div id="add-commentary-dialog" title="Add artist commentary" style="display: none;">
-    <%= render "artist_commentaries/form", :artist_commentary => @post.artist_commentary %>
+    <%= render "artist_commentaries/form", :post => @post %>
   </div>
 
   <div id="add-to-favgroup-dialog" title="Add to favorite group" style="display: none;">


### PR DESCRIPTION
ref: http://danbooru.donmai.us/forum_topics/9127?page=152#forum_post_125482

The bug was `$('#add-commentary-dialog form')` selecting the wrong form to submit.

Also included is a minor clean up of the artcomm partial to pass in the post, not just use `@post` implicitly.