### PR TITLE
Fix voting not showing 'undo vote' link if you already voted.

### DIFF
--- a/app/views/post_votes/create.js.erb
+++ b/app/views/post_votes/create.js.erb
@@ -3,6 +3,7 @@
 <% else %>
   Danbooru.notice("Vote saved");
   $("#score-for-post-<%= @post.id %>").html(<%= @post.score %>);
-  $("#vote-links-for-post-<%= @post.id %>").hide();
-  $("#unvote-link-for-post-<%= @post.id %>").show();
 <% end %>
+
+$("#vote-links-for-post-<%= @post.id %>").hide();
+$("#unvote-link-for-post-<%= @post.id %>").show();


### PR DESCRIPTION
ref: http://danbooru.donmai.us/forum_topics/9127?page=152#forum_post_125487

Introduced in 5445b341bcd77dee941623ed7e36e751fa2b64a1. Toggling the voting links only on success made it so that the unvote link wasn't shown after an "already voted" error.