### PR TITLE
Fix #2830: Lower Permission to See Previous Usernames

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -89,6 +89,7 @@ class User < ActiveRecord::Base
   has_many :dmails, lambda {order("dmails.id desc")}, :foreign_key => "owner_id"
   has_many :saved_searches
   has_many :forum_posts, lambda {order("forum_posts.created_at")}, :foreign_key => "creator_id"
+  has_many :user_name_change_requests, lambda {visible.order("user_name_change_requests.created_at desc")}
   belongs_to :inviter, :class_name => "User"
   after_update :create_mod_action
   accepts_nested_attributes_for :dmail_filter

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -18,6 +18,16 @@ class UserNameChangeRequest < ActiveRecord::Base
   def self.approved
     where(:status => "approved")
   end
+
+  def self.visible
+    if CurrentUser.is_admin?
+      all
+    elsif CurrentUser.is_member?
+      where("user_name_change_requests.status = 'approved' OR user_name_change_requests.user_id = ?", CurrentUser.id)
+    else
+      none
+    end
+  end
   
   def rejected?
     status == "rejected"

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -233,7 +233,7 @@ class UserPresenter
     end
   end
   
-  def previous_names
-    UserNameChangeRequest.approved.where("user_id = ?", user.id).map(&:original_name).join(", ")
+  def previous_names(template)
+    user.user_name_change_requests.map { |req| template.link_to req.original_name, req }.join(", ").html_safe
   end
 end

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -138,10 +138,10 @@
         </td>
       </tr>
       
-      <% if CurrentUser.is_moderator? && presenter.previous_names.present? %>
+      <% if presenter.previous_names(self).present? %>
         <tr>
           <th>Previous Names</th>
-          <td><%= presenter.previous_names %></td>
+          <td><%= presenter.previous_names(self) %></td>
         </tr>
       <% end %>
 


### PR DESCRIPTION
Does a few things:

* Makes previous names visible to member+.
* Makes all previous name change requests visible to admins or the requester. This is so rejected name changes are accessible. Rejections don't actually happen any more, but still.
* Links to the actual name change request. Mainly intended for admins.

Example: http://devbooru.evazion.ml/users/52664