### PR TITLE
IP search fixes

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -89,6 +89,10 @@ module ApplicationHelper
     time_tag(time.strftime("%Y-%m-%d %H:%M"), time)
   end
 
+  def link_to_ip(ip)
+    link_to ip, moderator_ip_addrs_path(:search => {:ip_addr => ip})
+  end
+
   def link_to_user(user, options = {})
     user_class = user.level_class
     user_class = user_class + " user-post-approver" if user.can_approve_posts?

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -55,7 +55,7 @@ module Moderator
       add_row(sums, WikiPageVersion.where(updater: users).group(:updater_ip_addr).count)
       add_row(sums, Comment.where(creator: users).group(:ip_addr).count)
       add_row(sums, Dmail.where(from: users).group(:creator_ip_addr).count)
-      add_row(sums, PostAppeal.where(creator: users).group(:creator_ip_addr).count)
+      add_row(sums, PostAppeal.where(creator: users).where.not(creator_ip_addr: nil).group(:creator_ip_addr).count)
       add_row(sums, PostFlag.where(creator: users).group(:creator_ip_addr).count)
       add_row(sums, Upload.where(uploader: users).group(:uploader_ip_addr).count)
       add_row(sums, User.where(id: users).group(:last_ip_addr).count)

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -22,12 +22,17 @@ module Moderator
     def search_by_ip_addr(ip_addrs)
       sums = Hash.new {|h, k| h[k] = 0}
 
+      add_row(sums, ArtistCommentaryVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
+      add_row(sums, ArtistVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, NoteVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, PoolArchive.where(updater_ip_addr: ip_addrs).group(:updater).count) if PoolArchive.enabled?
       add_row(sums, PostVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, WikiPageVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, Comment.where(ip_addr: ip_addrs).group(:creator).count)
       add_row(sums, Dmail.where(creator_ip_addr: ip_addrs).group(:from).count)
+      add_row(sums, PostAppeal.where(creator_ip_addr: ip_addrs).group(:creator).count)
+      add_row(sums, PostFlag.where(creator_ip_addr: ip_addrs).group(:creator).count)
+      add_row(sums, Upload.where(uploader_ip_addr: ip_addrs).group(:uploader).count)
       add_row(sums, Hash[User.where(last_ip_addr: ip_addrs).collect { |user| [user, 1] }])
 
       sums
@@ -42,12 +47,18 @@ module Moderator
       sums = Hash.new {|h, k| h[k] = 0}
       users = User.find(user_ids)
 
+      add_row(sums, ArtistCommentaryVersion.where(updater: users).group(:updater_ip_addr).count)
+      add_row(sums, ArtistVersion.where(updater: users).group(:updater_ip_addr).count)
       add_row(sums, NoteVersion.where(updater: users).group(:updater_ip_addr).count)
       add_row(sums, PoolArchive.where(updater: users).group(:updater_ip_addr).count) if PoolArchive.enabled?
       add_row(sums, PostVersion.where(updater: users).group(:updater_ip_addr).count)
       add_row(sums, WikiPageVersion.where(updater: users).group(:updater_ip_addr).count)
       add_row(sums, Comment.where(creator: users).group(:ip_addr).count)
       add_row(sums, Dmail.where(from: users).group(:creator_ip_addr).count)
+      add_row(sums, PostAppeal.where(creator: users).group(:creator_ip_addr).count)
+      add_row(sums, PostFlag.where(creator: users).group(:creator_ip_addr).count)
+      add_row(sums, Upload.where(uploader: users).group(:uploader_ip_addr).count)
+      add_row(sums, User.where(id: users).group(:last_ip_addr).count)
 
       sums
     end

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -1,10 +1,9 @@
 module Moderator
   class IpAddrSearch
-    attr_reader :params, :errors
+    attr_reader :params
 
     def initialize(params)
       @params = params
-      @errors = []
     end
 
     def execute
@@ -39,11 +38,8 @@ module Moderator
     end
 
     def search_by_user_name(user_names)
-      user_names = user_names.map do |username|
-        username.downcase.strip.tr(" ", "_")
-      end
-      users = User.where("lower(name) in (?)", user_names)
-      search_by_user_id(users.map(&:id))
+      user_ids = user_names.map { |name| User.name_to_id(name) }
+      search_by_user_id(user_ids)
     end
 
     def search_by_user_id(user_ids)

--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -58,7 +58,7 @@ module Moderator
       add_row(sums, PostAppeal.where(creator: users).where.not(creator_ip_addr: nil).group(:creator_ip_addr).count)
       add_row(sums, PostFlag.where(creator: users).group(:creator_ip_addr).count)
       add_row(sums, Upload.where(uploader: users).group(:uploader_ip_addr).count)
-      add_row(sums, User.where(id: users).group(:last_ip_addr).count)
+      add_row(sums, User.where(id: users).where.not(last_ip_addr: nil).group(:last_ip_addr).count)
 
       sums
     end

--- a/app/views/artist_commentary_versions/index.html.erb
+++ b/app/views/artist_commentary_versions/index.html.erb
@@ -32,7 +32,7 @@
             </td>
             <% if CurrentUser.is_moderator? %>
               <td>
-                <%= commentary_version.updater_ip_addr %>
+                <%= link_to_ip commentary_version.updater_ip_addr %>
               </td>
             <% end %>
             <td><%= link_to_user commentary_version.updater %></td>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -37,7 +37,7 @@
               <td><%= link_to_user artist_version.updater %></td>
               <% if CurrentUser.is_moderator? %>
                 <td>
-                  <%= artist_version.updater_ip_addr %>
+                  <%= link_to_ip artist_version.updater_ip_addr %>
                 </td>
               <% end %>
               <td><%= artist_version.is_active? %></td>

--- a/app/views/dmails/show.html.erb
+++ b/app/views/dmails/show.html.erb
@@ -9,7 +9,7 @@
         <li><strong>Recipient</strong>: <%= link_to_user @dmail.to %></li>
         <li><strong>Date</strong>: <%= compact_time(@dmail.created_at) %></li>
         <% if CurrentUser.user.is_moderator? %>
-          <li><strong>Sender IP</strong>: <%= @dmail.creator_ip_addr %></li>
+          <li><strong>Sender IP</strong>: <%= link_to_ip @dmail.creator_ip_addr %></li>
         <% end %>
       </ul>
 

--- a/app/views/ip_bans/index.html.erb
+++ b/app/views/ip_bans/index.html.erb
@@ -14,7 +14,7 @@
       <tbody>
         <% @ip_bans.each do |ip_ban| %>
           <tr>
-            <td><%= ip_ban.ip_addr %></td>
+            <td><%= link_to_ip ip_ban.ip_addr %></td>
             <td><%= ip_ban.creator.name %></td>
             <td><%= ip_ban.reason %></td>
             <td><%= link_to "Unban", ip_ban_path(ip_ban), :remote => true, :method => :delete, :data => {:confirm => "Do your really want to unban #{ip_ban.ip_addr}?"} %></td>

--- a/app/views/maintenance/user/dmail_filters/edit.html.erb
+++ b/app/views/maintenance/user/dmail_filters/edit.html.erb
@@ -10,7 +10,7 @@
         <li><strong>Recipient</strong>: <%= link_to_user @dmail.to, :raw => true %></li>
         <li><strong>Date</strong>: <%= compact_time(@dmail.created_at) %></li>
         <% if CurrentUser.user.is_moderator? %>
-          <li><strong>Sender IP</strong>: <%= @dmail.creator_ip_addr %></li>
+          <li><strong>Sender IP</strong>: <%= link_to_ip @dmail.creator_ip_addr %></li>
         <% end %>
       </ul>
 

--- a/app/views/moderator/ip_addrs/_ip_listing.erb
+++ b/app/views/moderator/ip_addrs/_ip_listing.erb
@@ -1,4 +1,4 @@
-<p><%= link_to "Search for users with these IP addresses", moderator_ip_addrs_path(:search => {:ip_addr => @results.map {|k, count| k}.reject{|ip| ip == "127.0.0.1"}.join(",")}) %></p>
+<p><%= link_to "Search for users with these IP addresses", moderator_ip_addrs_path(:search => {:ip_addr => @results.keys.reject{|ip| ip == "127.0.0.1"}.join(",")}) %></p>
 
 <table class="striped">
   <thead>

--- a/app/views/moderator/ip_addrs/_ip_listing.erb
+++ b/app/views/moderator/ip_addrs/_ip_listing.erb
@@ -10,7 +10,7 @@
   <tbody>
     <% @results.each do |ip_address, count| %>
       <tr>
-        <td><%= link_to ip_address, moderator_ip_addrs_path(:search => {:ip_addr => ip_address}) %></td>
+        <td><%= link_to_ip ip_address %></td>
         <td><%= count %></td>
       </tr>
     <% end %>

--- a/app/views/moderator/ip_addrs/_user_listing.erb
+++ b/app/views/moderator/ip_addrs/_user_listing.erb
@@ -1,4 +1,4 @@
-<p><%= link_to "Search for IP addresses with these users", moderator_ip_addrs_path(:search => {:user_id => @results.map{|k, count| k}.join(",")}) %></p>
+<p><%= link_to "Search for IP addresses with these users", moderator_ip_addrs_path(:search => {:user_id => @results.map{|user, count| user.id}.join(",")}) %></p>
 
 <table class="striped">
   <thead>
@@ -9,11 +9,11 @@
     </tr>
   </thead>
   <tbody>
-    <% @results.each do |user_id, count| %>
+    <% @results.each do |user, count| %>
       <tr>
-        <td><%= link_to User.id_to_name(user_id), user_path(user_id) %></td>
+        <td><%= link_to_user user %></td>
         <td><%= count %></td>
-        <td><%= link_to "Show IP addresses", moderator_ip_addrs_path(:search => {:user_id => user_id}) %></td>
+        <td><%= link_to "Show IP addresses", moderator_ip_addrs_path(:search => {:user_id => user.id}) %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/note_versions/index.html.erb
+++ b/app/views/note_versions/index.html.erb
@@ -38,7 +38,7 @@
             </td>
             <% if CurrentUser.is_moderator? %>
               <td>
-                <%= note_version.updater_ip_addr %>
+                <%= link_to_ip note_version.updater_ip_addr %>
               </td>
             <% end %>
             <td><%= link_to_user note_version.updater %></td>

--- a/app/views/pool_versions/index.html.erb
+++ b/app/views/pool_versions/index.html.erb
@@ -27,7 +27,7 @@
             <td><%= link_to_user pool_version.updater %></td>
             <% if CurrentUser.is_moderator? %>
               <td>
-                <%= pool_version.updater_ip_addr %>
+                <%= link_to_ip pool_version.updater_ip_addr %>
               </td>
             <% end %>
             <td><%= compact_time pool_version.updated_at %></td>

--- a/app/views/post_versions/_listing.html.erb
+++ b/app/views/post_versions/_listing.html.erb
@@ -30,7 +30,7 @@
           <td><%= post_version.parent_id %></td>
           <% if CurrentUser.is_moderator? %>
             <td>
-              <%= post_version.updater_ip_addr %>
+              <%= link_to_ip post_version.updater_ip_addr %>
             </td>
           <% end %>
           <td><%= post_version_diff(post_version) %></td>

--- a/app/views/wiki_page_versions/index.html.erb
+++ b/app/views/wiki_page_versions/index.html.erb
@@ -54,7 +54,7 @@
                 <td><%= link_to "wiki", wiki_page_path(wiki_page_version.wiki_page_id) %></td>
                 <% if CurrentUser.is_moderator? %>
                   <td>
-                    <%= wiki_page_version.updater_ip_addr %>
+                    <%= link_to_ip wiki_page_version.updater_ip_addr %>
                   </td>
                 <% end %>
                 <td>

--- a/db/migrate/20170112021922_add_ip_addr_indexes_to_tables.rb
+++ b/db/migrate/20170112021922_add_ip_addr_indexes_to_tables.rb
@@ -1,0 +1,9 @@
+class AddIpAddrIndexesToTables < ActiveRecord::Migration
+  def change
+    reversible { execute "set statement_timeout = 0" }
+    add_index :wiki_page_versions, :updater_ip_addr
+    add_index :artist_commentary_versions, :updater_ip_addr
+    add_index :artist_versions, :updater_ip_addr
+    add_index :comments, :ip_addr
+  end
+end

--- a/db/migrate/20170112060921_change_ip_addr_to_inet_on_post_appeals.rb
+++ b/db/migrate/20170112060921_change_ip_addr_to_inet_on_post_appeals.rb
@@ -1,0 +1,11 @@
+class ChangeIpAddrToInetOnPostAppeals < ActiveRecord::Migration
+  def up
+    execute "set statement_timeout = 0"
+    change_column_null :post_appeals, :creator_ip_addr, true
+    execute "ALTER TABLE post_appeals ALTER COLUMN creator_ip_addr TYPE inet USING NULL"
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration, "Can't recover the lost data"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2557,7 +2557,7 @@ CREATE TABLE post_appeals (
     id integer NOT NULL,
     post_id integer NOT NULL,
     creator_id integer NOT NULL,
-    creator_ip_addr integer NOT NULL,
+    creator_ip_addr inet,
     reason text,
     created_at timestamp without time zone,
     updated_at timestamp without time zone
@@ -7438,3 +7438,6 @@ INSERT INTO schema_migrations (version) VALUES ('20161229001201');
 INSERT INTO schema_migrations (version) VALUES ('20170106012138');
 
 INSERT INTO schema_migrations (version) VALUES ('20170112021922');
+
+INSERT INTO schema_migrations (version) VALUES ('20170112060921');
+

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4882,6 +4882,13 @@ CREATE INDEX index_artist_commentary_versions_on_updater_id_and_post_id ON artis
 
 
 --
+-- Name: index_artist_commentary_versions_on_updater_ip_addr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_artist_commentary_versions_on_updater_ip_addr ON artist_commentary_versions USING btree (updater_ip_addr);
+
+
+--
 -- Name: index_artist_urls_on_artist_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4935,6 +4942,13 @@ CREATE INDEX index_artist_versions_on_name ON artist_versions USING btree (name)
 --
 
 CREATE INDEX index_artist_versions_on_updater_id ON artist_versions USING btree (updater_id);
+
+
+--
+-- Name: index_artist_versions_on_updater_ip_addr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_artist_versions_on_updater_ip_addr ON artist_versions USING btree (updater_ip_addr);
 
 
 --
@@ -5033,6 +5047,13 @@ CREATE INDEX index_comments_on_body_index ON comments USING gin (body_index);
 --
 
 CREATE INDEX index_comments_on_creator_id_and_post_id ON comments USING btree (creator_id, post_id);
+
+
+--
+-- Name: index_comments_on_ip_addr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_comments_on_ip_addr ON comments USING btree (ip_addr);
 
 
 --
@@ -7052,6 +7073,13 @@ CREATE UNIQUE INDEX index_users_on_name ON users USING btree (lower((name)::text
 
 
 --
+-- Name: index_wiki_page_versions_on_updater_ip_addr; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wiki_page_versions_on_updater_ip_addr ON wiki_page_versions USING btree (updater_ip_addr);
+
+
+--
 -- Name: index_wiki_page_versions_on_wiki_page_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7409,3 +7437,4 @@ INSERT INTO schema_migrations (version) VALUES ('20161229001201');
 
 INSERT INTO schema_migrations (version) VALUES ('20170106012138');
 
+INSERT INTO schema_migrations (version) VALUES ('20170112021922');

--- a/test/unit/moderator/ip_addr_search_test.rb
+++ b/test/unit/moderator/ip_addr_search_test.rb
@@ -19,17 +19,17 @@ module Moderator
 
       should "find by ip addr" do
         @search = IpAddrSearch.new(:ip_addr => "127.0.0.1")
-        assert_equal({@user.id.to_s => 2}, @search.execute)
+        assert_equal({@user => 2}, @search.execute)
       end
 
       should "find by user id" do
         @search = IpAddrSearch.new(:user_id => @user.id.to_s)
-        assert_equal({"127.0.0.1" => 2}, @search.execute)
+        assert_equal({IPAddr.new("127.0.0.1") => 2}, @search.execute)
       end
 
       should "find by user name" do
         @search = IpAddrSearch.new(:user_name => @user.name)
-        assert_equal({"127.0.0.1" => 2}, @search.execute)
+        assert_equal({IPAddr.new("127.0.0.1") => 2}, @search.execute)
       end
     end
   end


### PR DESCRIPTION
I had some trouble with 63c218d71daaef653d4241a2e369e663cef68f58 still erroring out on the ip search page because it was doing a `select ... from pool_versions` but I didn't have an `archive_development` db with a `pool_versions` table. In dealing with that I fixed various other ip search issues:

* Use `link_to_user` on the ip search page so that usernames are colorized.
* Link ip addresses to ip searches everywhere.
* Search several more tables that had been overlooked.
* Add indexes on ip addrs for tables that didn't have them.
* Fix `creator_ip_addr` on `post_appeals`: it was mistakenly declared as type `integer` instead of `inet`. I think all the current data in that column is garbage because of this, so the migration just nulls it.

Also I learned that postgres has an index type for `inet` that lets you test for subnet inclusion. If the indexes were switched to this type it would be possible to search or ban IPs by subnet. Didn't attempt this but thought it's worth mentioning.

https://www.postgresql.org/docs/current/static/gist-builtin-opclasses.html
https://www.postgresql.org/docs/current/static/functions-net.html