### PR TITLE
Fix #2839: "Original" tag shows up twice in Pixiv source data

### DIFF
--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -83,7 +83,7 @@ module Sources
       end
 
       def tags
-        @tags || []
+        @tags.uniq || []
       end
 
       # Should be set to a url for sites that prevent hotlinking, or left nil for sites that don't.


### PR DESCRIPTION
The root cause is [here](https://github.com/r888888888/danbooru/blob/3ad639521ff70db4198be0d1e44f808503c102c6/app/logical/sources/strategies/pixiv.rb#L314-L316). Pixiv posts can be in an "Original" category, so we fake up a tag in that case, but that can create a duplicate. I deemed it better to uniq the tags for all sources.