### PR TITLE
Fix #2851: Account deletion should remove name change requests.

### DIFF
--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -8,18 +8,18 @@ class UserFeedbacksController < ApplicationController
   end
 
   def edit
-    @user_feedback = UserFeedback.find(params[:id])
+    @user_feedback = UserFeedback.visible.find(params[:id])
     check_privilege(@user_feedback)
     respond_with(@user_feedback)
   end
 
   def show
-    @user_feedback = UserFeedback.find(params[:id])
+    @user_feedback = UserFeedback.visible.find(params[:id])
     respond_with(@user_feedback)
   end
 
   def index
-    @search = UserFeedback.search(params[:search])
+    @search = UserFeedback.visible.search(params[:search])
     @user_feedbacks = @search.paginate(params[:page], :limit => params[:limit]).order("created_at desc")
     respond_with(@user_feedbacks) do |format|
       format.xml do
@@ -34,14 +34,14 @@ class UserFeedbacksController < ApplicationController
   end
 
   def update
-    @user_feedback = UserFeedback.find(params[:id])
+    @user_feedback = UserFeedback.visible.find(params[:id])
     check_privilege(@user_feedback)
     @user_feedback.update_attributes(params[:user_feedback])
     respond_with(@user_feedback)
   end
 
   def destroy
-    @user_feedback = UserFeedback.find(params[:id])
+    @user_feedback = UserFeedback.visible.find(params[:id])
     check_privilege(@user_feedback)
     @user_feedback.destroy
     respond_with(@user_feedback)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -729,6 +729,16 @@ class User < ActiveRecord::Base
       where("level = ?", Levels::ADMIN)
     end
 
+    # UserDeletion#rename renames deleted users to `user_<1234>~`. Tildes
+    # are appended if the username is taken.
+    def deleted
+      where("name ~ 'user_[0-9]+~*'")
+    end
+
+    def undeleted
+      where("name !~ 'user_[0-9]+~*'")
+    end
+
     def with_email(email)
       if email.blank?
         where("FALSE")

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -34,6 +34,15 @@ class UserFeedback < ActiveRecord::Base
       where("user_id = ?", user_id)
     end
 
+    def visible(viewer = CurrentUser.user)
+      if viewer.is_admin?
+        all
+      else
+        # joins(:user).merge(User.undeleted).or(where("body !~ 'Name changed from [^\s:]+ to [^\s:]+'"))
+        joins(:user).where.not("users.name ~ 'user_[0-9]+~*' AND user_feedback.body ~ 'Name changed from [^\s:]+ to [^\s:]+'")
+      end
+    end
+
     def search(params)
       q = where("true")
       return q if params.blank?

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -19,11 +19,11 @@ class UserNameChangeRequest < ActiveRecord::Base
     where(:status => "approved")
   end
 
-  def self.visible
-    if CurrentUser.is_admin?
+  def self.visible(viewer = CurrentUser.user)
+    if viewer.is_admin?
       all
-    elsif CurrentUser.is_member?
-      where("user_name_change_requests.status = 'approved' OR user_name_change_requests.user_id = ?", CurrentUser.id)
+    elsif viewer.is_member?
+      joins(:user).merge(User.undeleted).where("user_name_change_requests.status = 'approved' OR user_name_change_requests.user_id = ?", viewer.id)
     else
       none
     end


### PR DESCRIPTION
Hides name change requests and feedbacks for deleted users (usernames matching /user_[0-9]+~*/).