### PR TITLE
Fix user name change reasons being public in API

### DIFF
--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -89,4 +89,12 @@ class UserNameChangeRequest < ActiveRecord::Base
       return true
     end
   end
+
+  def hidden_attributes
+    if CurrentUser.is_admin? || user == CurrentUser.user
+      []
+    else
+      super + [:change_reason, :rejection_reason]
+    end
+  end
 end

--- a/app/views/user_name_change_requests/new.html.erb
+++ b/app/views/user_name_change_requests/new.html.erb
@@ -1,6 +1,8 @@
 <h1>Name Change Request</h1>
 
-<p>You can request a name change but it must be approved. Factors that go into consideration include your upload and update history, and your user feedback.</p>
+<p>You can request a name change once per week. Your previous names will still
+be visible on your profile to other Danbooru members, but they won't be visible
+to search engines.</p>
 
 <%= error_messages_for "change_request" %>
 
@@ -8,11 +10,6 @@
   <div class="input">
     <label for="desired_name">Desired Name</label>
     <%= text_field_tag "desired_name" %>
-  </div>
-
-  <div class="input">
-    <label for="desired_name">Reason</label>
-    <%= text_field_tag "reason" %>
   </div>
   
   <div class="input">


### PR DESCRIPTION
PR #2842 introduced an exploit making username change reasons visible in the API. orz. This fixes it.

This also removes the reason field from the request form. There's no point in asking for a reason when requests are auto-approved now.