### PR TITLE
Add order:comment_bumped, order:comment_bumped_asc metatags.

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -316,6 +316,7 @@
       "favcount", "favcount_asc",
       "change", "change_asc",
       "comment", "comment_asc",
+      "comment_bumped", "comment_bumped_asc",
       "note", "note_asc",
       "artcomm", "artcomm_asc",
       "mpixels", "mpixels_asc",

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -415,7 +415,13 @@ class PostQueryBuilder
       relation = relation.order("posts.last_commented_at DESC NULLS LAST, posts.id DESC")
 
     when "comment_asc", "comm_asc"
-      relation = relation.order("posts.last_commented_at ASC NULLS FIRST, posts.id DESC")
+      relation = relation.order("posts.last_commented_at ASC NULLS LAST, posts.id DESC")
+
+    when "comment_bumped"
+      relation = relation.order("posts.last_comment_bumped_at DESC NULLS LAST, posts.id DESC")
+
+    when "comment_bumped_asc"
+      relation = relation.order("posts.last_comment_bumped_at ASC NULLS LAST, posts.id DESC")
 
     when "note"
       relation = relation.order("posts.last_noted_at DESC NULLS LAST, posts.id DESC")

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1797,6 +1797,21 @@ class PostTest < ActiveSupport::TestCase
       assert_equal(post3.id, relation.first.id)
     end
 
+    should "return posts for order:comment_bumped" do
+      post1 = FactoryGirl.create(:post)
+      post2 = FactoryGirl.create(:post)
+      post3 = FactoryGirl.create(:post)
+
+      CurrentUser.scoped(FactoryGirl.create(:gold_user), "127.0.0.1") do
+        comment1 = FactoryGirl.create(:comment, :post => post1)
+        comment2 = FactoryGirl.create(:comment, :post => post2, :do_not_bump_post => true)
+        comment3 = FactoryGirl.create(:comment, :post => post3)
+      end
+
+      assert_equal([post3.id, post1.id, post2.id], Post.tag_match("order:comment_bumped").map(&:id))
+      assert_equal([post1.id, post3.id, post2.id], Post.tag_match("order:comment_bumped_asc").map(&:id))
+    end
+
     should "return posts for a filesize search" do
       post = FactoryGirl.create(:post, :file_size => 1.megabyte)
       assert_equal(1, Post.tag_match("filesize:1mb").count)


### PR DESCRIPTION
Also fixes an issue with `order:comment_asc` returning uncommented on posts first. This lists them last so that `order:comment_asc` properly returns the list of least-recently-commented-on posts.