### PR TITLE
Add more options to /comments/search

### DIFF
--- a/app/assets/stylesheets/common/simple_form.css.scss
+++ b/app/assets/stylesheets/common/simple_form.css.scss
@@ -43,3 +43,20 @@ form.simple_form {
   }
 }
 
+form.inline-form {
+  display: table;
+
+  > div.input {
+    display: table-row;
+    line-height: 2em;
+
+    label {
+      text-align: right;
+    }
+
+    label, input {
+      display: table-cell;
+      padding-right: 1em;
+    }
+  }
+}

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -90,7 +90,7 @@ private
   end
 
   def index_by_comment
-    @comments = Comment.search(params[:search]).order("comments.id DESC").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @comments = Comment.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@comments) do |format|
       format.html {render :action => "index_by_comment"}
       format.xml do

--- a/app/views/comments/search.html.erb
+++ b/app/views/comments/search.html.erb
@@ -2,13 +2,16 @@
   <div id="a-search">
     <h1>Search Comments</h1>
 
-    <%= form_tag(comments_path, :method => :get, :class => "simple_form") do %>
+    <%= simple_form_for(:search, :method => :get, url: comments_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= hidden_field_tag "group_by", "comment", :id => "group_by_full" %>
-
-      <%= search_field "body_matches", :label => "Body" %>
-      <%= search_field "creator_name", :label => "User" %>
-      <%= search_field "post_tags_match", :label => "Tags" %>
-      <%= submit_tag "Search" %>
+      <%= f.input :creator_name, label: "Commenter" %>
+      <%= f.input :body_matches, label: "Body" %>
+      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.input :is_deleted, label: "Deleted?", collection: [["Yes", true], ["No", false]] %>
+      <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]] %>
+      <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]] %>
+      <%= f.input :order, include_blank: false, collection: [%w(Created id_desc), %w(Updated updated_at_desc), %w(Score score_desc), %w(Post post_id_desc)] %>
+      <%= f.submit "Search" %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
ref: http://danbooru.donmai.us/forum_topics/13649

* Adds more options to /comments/search.
* Restyles the form to use inline labels, since adding these options made the form pretty long. This matches the forms on /tags and /pools, except a bit cleaner as it's done in CSS rather than hardcoded as tables in html.