### PR TITLE
Add additional hotkeys

### DIFF
--- a/app/assets/javascripts/artists.js
+++ b/app/assets/javascripts/artists.js
@@ -4,6 +4,7 @@
   Danbooru.Artist.initialize_all = function() {
     if ($("#c-artists").length) {
       Danbooru.Artist.initialize_check_name();
+      Danbooru.Artist.initialize_shortcuts();
 
       if (Danbooru.meta("enable-auto-complete") === "true") {
         Danbooru.Artist.initialize_autocomplete();
@@ -30,6 +31,18 @@
       }
     });
   }
+
+  Danbooru.Artist.initialize_shortcuts = function() {
+    if ($("#c-artists #a-show").length) {
+      Danbooru.keydown("e", "edit", function(e) {
+        $("#artist-edit a")[0].click();
+      });
+
+      Danbooru.keydown("shift+d", "delete", function(e) {
+        $("#artist-delete a")[0].click();
+      });
+    }
+  };
 
   Danbooru.Artist.initialize_autocomplete = function() {
     var $fields = $("#search_name,#quick_search_name");

--- a/app/assets/javascripts/favorite_groups.js
+++ b/app/assets/javascripts/favorite_groups.js
@@ -4,7 +4,7 @@
   Danbooru.FavoriteGroup.initialize_all = function() {
     if ($("#c-posts").length && $("#a-show").length) {
       this.initialize_add_to_favgroup_dialog();
-      $(document).bind("keydown", "1 2 3 4 5 6 7 8 9 0", Danbooru.FavoriteGroup.add_to_favgroup);
+      Danbooru.keydown("1 2 3 4 5 6 7 8 9 0", "add_to_favgroup", Danbooru.FavoriteGroup.add_to_favgroup);
     }
   }
 
@@ -33,7 +33,7 @@
       e.preventDefault();
     }
 
-    $(document).bind("keydown", "g", open_favgroup_dialog);
+    Danbooru.keydown("g", "open_favgroup_dialog", open_favgroup_dialog);
     $("#open-favgroup-dialog-link").click(open_favgroup_dialog);
   }
 

--- a/app/assets/javascripts/forum_posts.js
+++ b/app/assets/javascripts/forum_posts.js
@@ -2,8 +2,22 @@
   Danbooru.ForumPost = {};
 
   Danbooru.ForumPost.initialize_all = function() {
-    if ($("#c-forum-topics").length && $("#a-show").length) {;
+    if ($("#c-forum-topics #a-show").length) {;
       this.initialize_edit_links();
+
+      Danbooru.keydown("e", "edit", function(e) {
+        $(".edit_forum_topic_link")[0].click();
+      });
+
+      Danbooru.keydown("shift+d", "delete", function(e) {
+        $("#forum-topic-delete a")[0].click();
+      });
+    }
+
+    if ($("#c-forum-topics").length) {
+      Danbooru.keydown("shift+r", "mark_all_as_read", function(e) {
+        $("#secondary-links-mark-all-as-read a").click();
+      });
     }
   }
 

--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -62,7 +62,7 @@ Danbooru.Note = {
     },
 
     bind_events: function($note_box) {
-      $note_box.bind(
+      $note_box.on(
         "dragstart resizestart",
         function(e) {
           var $note_box_inner = $(e.currentTarget);
@@ -80,8 +80,7 @@ Danbooru.Note = {
         }
       );
 
-      $note_box.bind(
-        "resize",
+      $note_box.resize(
         function(e) {
           var $note_box_inner = $(e.currentTarget);
           Danbooru.Note.Box.resize_inner_border($note_box_inner);
@@ -89,7 +88,7 @@ Danbooru.Note = {
         }
       );
 
-      $note_box.bind(
+      $note_box.on(
         "dragstop resizestop",
         function(e) {
           Danbooru.Note.dragging = false;
@@ -105,7 +104,7 @@ Danbooru.Note = {
         }
       );
 
-      $note_box.bind(
+      $note_box.on(
         "mouseover mouseout",
         function(e) {
           if (Danbooru.Note.dragging) {
@@ -407,7 +406,7 @@ Danbooru.Note = {
       }
       $dialog.dialog("option", "title", 'Edit note (<a href="/wiki_pages/help:notes">view help</a>)');
 
-      $dialog.bind("dialogclose", function() {
+      $dialog.on("dialogclose", function() {
         Danbooru.Note.editing = false;
         $(".note-box").resizable("enable");
         $(".note-box").draggable("enable");
@@ -570,9 +569,9 @@ Danbooru.Note = {
       Danbooru.Note.TranslationMode.active = true;
       $(document.body).addClass("mode-translation");
       $("#original-file-link").click();
-      $("#image").unbind("click", Danbooru.Note.Box.toggle_all);
-      $("#image").bind("mousedown", Danbooru.Note.TranslationMode.Drag.start);
-      $(window).bind("mouseup", Danbooru.Note.TranslationMode.Drag.stop);
+      $("#image").off("click", Danbooru.Note.Box.toggle_all);
+      $("#image").mousedown(Danbooru.Note.TranslationMode.Drag.start);
+      $(window).mouseup(Danbooru.Note.TranslationMode.Drag.stop);
       $("#mark-as-translated-section").show();
 
       Danbooru.notice('Translation mode is on. Drag on the image to create notes. <a href="#">Turn translation mode off</a> (shortcut is <span class="key">n</span>).');
@@ -584,9 +583,9 @@ Danbooru.Note = {
 
       Danbooru.Note.TranslationMode.active = false;
       $("#image").css("cursor", "auto");
-      $("#image").bind("click", Danbooru.Note.Box.toggle_all);
-      $("#image").unbind("mousedown", Danbooru.Note.TranslationMode.Drag.start);
-      $(window).unbind("mouseup", Danbooru.Note.TranslationMode.Drag.stop);
+      $("#image").click(Danbooru.Note.Box.toggle_all);
+      $("#image").off("mousedown", Danbooru.Note.TranslationMode.Drag.start);
+      $(window).mouseup(Danbooru.Note.TranslationMode.Drag.stop);
       $(document.body).removeClass("mode-translation");
       $("#close-notice-link").click();
       $("#mark-as-translated-section").hide();
@@ -689,7 +688,7 @@ Danbooru.Note = {
         if (Danbooru.Note.TranslationMode.Drag.dragStartX === 0) {
           return; /* 'stop' is bound to window, don't create note if start wasn't triggered */
         }
-        $(window).unbind("mousemove");
+        $(window).off("mousemove");
 
         if (Danbooru.Note.TranslationMode.Drag.dragging) {
           $('#note-preview').css({display:'none'});
@@ -782,11 +781,11 @@ Danbooru.Note = {
 $(function() {
   if ($("#c-posts").length && $("#a-show").length && $("#image").length && !$("video#image").length) {
     if ($("#note-locked-notice").length == 0) {
-      $("#translate").bind("click", Danbooru.Note.TranslationMode.toggle);
-      $(document).bind("keydown", "n", Danbooru.Note.TranslationMode.toggle);
+      $("#translate").click(Danbooru.Note.TranslationMode.toggle);
+      Danbooru.keydown("n", "translation_mode", Danbooru.Note.TranslationMode.toggle);
     }
     Danbooru.Note.embed = (Danbooru.meta("post-has-embedded-notes") === "true");
     Danbooru.Note.load_all();
-    $("#image").bind("click", Danbooru.Note.Box.toggle_all);
+    $("#image").click(Danbooru.Note.Box.toggle_all);
   }
 });

--- a/app/assets/javascripts/paginator.js
+++ b/app/assets/javascripts/paginator.js
@@ -17,9 +17,9 @@
 })();
 
 $(function() {
-  if ($(".paginator").length && (Danbooru.meta("enable-js-navigation") === "true")) {
-    $(document).bind("keydown", "d", Danbooru.Paginator.next_page);
-    $(document).bind("keydown", "a", Danbooru.Paginator.prev_page);
+  if ($(".paginator").length) {
+    Danbooru.keydown("d", "next_page", Danbooru.Paginator.next_page);
+    Danbooru.keydown("a", "prev_page", Danbooru.Paginator.prev_page);
   }
 });
 

--- a/app/assets/javascripts/paginator.js
+++ b/app/assets/javascripts/paginator.js
@@ -18,8 +18,8 @@
 
 $(function() {
   if ($(".paginator").length) {
-    Danbooru.keydown("d", "next_page", Danbooru.Paginator.next_page);
-    Danbooru.keydown("a", "prev_page", Danbooru.Paginator.prev_page);
+    Danbooru.keydown("d right", "next_page", Danbooru.Paginator.next_page);
+    Danbooru.keydown("a left", "prev_page", Danbooru.Paginator.prev_page);
   }
 });
 

--- a/app/assets/javascripts/pools.js
+++ b/app/assets/javascripts/pools.js
@@ -3,6 +3,7 @@
 
   Danbooru.Pool.initialize_all = function() {
     if ($("#c-pools").length) {
+      this.initialize_shortcuts();
       if (Danbooru.meta("enable-auto-complete") === "true") {
         this.initialize_autocomplete_for("#search_name_matches,#quick_search_name_matches");
       }
@@ -69,6 +70,18 @@
       $("#pool_name").val($(this).html());
     });
   }
+
+  Danbooru.Pool.initialize_shortcuts = function() {
+    if ($("#c-pools #a-show").length) {
+      Danbooru.keydown("e", "edit", function(e) {
+        $("#pool-edit a")[0].click();
+      });
+
+      Danbooru.keydown("shift+d", "delete", function(e) {
+        $("#pool-delete a")[0].click();
+      });
+    }
+  };
 
   Danbooru.Pool.initialize_simple_edit = function() {
     $("#sortable").sortable({

--- a/app/assets/javascripts/post_mode_menu.js
+++ b/app/assets/javascripts/post_mode_menu.js
@@ -13,7 +13,7 @@
   }
 
   Danbooru.PostModeMenu.initialize_shortcuts = function() {
-    $(document).bind("keydown", "1 2 3 4 5 6 7 8 9 0", Danbooru.PostModeMenu.change_tag_script);
+    Danbooru.keydown("1 2 3 4 5 6 7 8 9 0", "change_tag_script", Danbooru.PostModeMenu.change_tag_script);
   }
 
   Danbooru.PostModeMenu.show_notice = function(i) {

--- a/app/assets/javascripts/post_popular.js
+++ b/app/assets/javascripts/post_popular.js
@@ -25,8 +25,8 @@
 
   Danbooru.PostPopular.initialize_all = function() {
     if ($("#c-explore-posts").length) {
-      Danbooru.keydown("a", "prev_page", Danbooru.PostPopular.nav_prev);
-      Danbooru.keydown("d", "next_page", Danbooru.PostPopular.nav_next);
+      Danbooru.keydown("a left", "prev_page", Danbooru.PostPopular.nav_prev);
+      Danbooru.keydown("d right", "next_page", Danbooru.PostPopular.nav_next);
     }
   }
 })();

--- a/app/assets/javascripts/post_popular.js
+++ b/app/assets/javascripts/post_popular.js
@@ -1,37 +1,32 @@
 (function() {
   Danbooru.PostPopular = {};
 
-  Danbooru.PostPopular.nav_prev = function() {
+  Danbooru.PostPopular.nav_prev = function(e) {
     if ($("#popular-nav-links").length) {
       var href = $("#popular-nav-links a[rel=prev]").attr("href");
       if (href) {
         location.href = href;
       }
     }
+
+    e.preventDefault();
   }
 
-  Danbooru.PostPopular.nav_next = function() {
+  Danbooru.PostPopular.nav_next = function(e) {
     if ($("#popular-nav-links").length) {
       var href = $("#popular-nav-links a[rel=next]").attr("href");
       if (href) {
         location.href = href;
       }
     }
+
+    e.preventDefault();
   }
 
   Danbooru.PostPopular.initialize_all = function() {
     if ($("#c-explore-posts").length) {
-      if (Danbooru.meta("enable-js-navigation") === "true") {
-        $(document).bind("keydown", "a", function(e) {
-          Danbooru.PostPopular.nav_prev();
-          e.preventDefault();
-        });
-
-        $(document).bind("keydown", "d", function(e) {
-          Danbooru.PostPopular.nav_next();
-          e.preventDefault();
-        });
-      }
+      Danbooru.keydown("a", "prev_page", Danbooru.PostPopular.nav_prev);
+      Danbooru.keydown("d", "next_page", Danbooru.PostPopular.nav_next);
     }
   }
 })();

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -7,9 +7,7 @@
     this.initialize_post_previews();
 
     if ($("#c-posts").length) {
-      if (Danbooru.meta("enable-js-navigation") === "true") {
-        this.initialize_shortcuts();
-      }
+      this.initialize_shortcuts();
     }
 
     if ($("#c-posts").length && $("#a-index").length) {
@@ -141,7 +139,7 @@
     });
   }
 
-  Danbooru.Post.nav_prev = function() {
+  Danbooru.Post.nav_prev = function(e) {
     if ($("#search-seq-nav").length) {
       var href = $("#search-seq-nav a[rel~=prev]").attr("href");
       if (href) {
@@ -153,9 +151,11 @@
         location.href = href;
       }
     }
+
+    e.preventDefault();
   }
 
-  Danbooru.Post.nav_next = function() {
+  Danbooru.Post.nav_next = function(e) {
     if ($("#search-seq-nav").length) {
       var href = $("#search-seq-nav a[rel~=next]").attr("href");
       location.href = href;
@@ -165,27 +165,22 @@
         location.href = href;
       }
     }
+
+    e.preventDefault();
   }
 
   Danbooru.Post.initialize_shortcuts = function() {
     if ($("#a-show").length) {
-      $(document).bind("keydown", "e", function(e) {
+      Danbooru.keydown("e", "edit", function(e) {
         $("#post-edit-link").trigger("click");
         $("#post_tag_string").focus();
         e.preventDefault();
       });
 
-      $(document).bind("keydown", "a", function(e) {
-        Danbooru.Post.nav_prev();
-        e.preventDefault();
-      });
+      Danbooru.keydown("a", "prev_page", Danbooru.Post.nav_prev);
+      Danbooru.keydown("d", "next_page", Danbooru.Post.nav_next);
 
-      $(document).bind("keydown", "d", function(e) {
-        Danbooru.Post.nav_next();
-        e.preventDefault();
-      });
-
-      $(document).bind("keydown", "f", function(e) {
+      Danbooru.keydown("f", "favorite", function(e) {
         if ($("#add-to-favorites").is(":visible")) {
           $("#add-to-favorites").click();
         } else {
@@ -331,8 +326,8 @@
       e.preventDefault();
     });
 
-    if ($("#image-resize-notice").length && Danbooru.meta("enable-js-navigation") === "true") {
-      $(document).bind("keydown", "v", function(e) {
+    if ($("#image-resize-notice").length) {
+      Danbooru.keydown("v", "resize", function(e) {
         if ($("#image-resize-notice").is(":visible")) {
           $("#image-resize-link").click();
         } else {

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -177,8 +177,8 @@
         e.preventDefault();
       });
 
-      Danbooru.keydown("a", "prev_page", Danbooru.Post.nav_prev);
-      Danbooru.keydown("d", "next_page", Danbooru.Post.nav_next);
+      Danbooru.keydown("a left", "prev_page", Danbooru.Post.nav_prev);
+      Danbooru.keydown("d right", "next_page", Danbooru.Post.nav_next);
 
       Danbooru.keydown("f", "favorite", function(e) {
         if ($("#add-to-favorites").is(":visible")) {

--- a/app/assets/javascripts/shortcuts.js
+++ b/app/assets/javascripts/shortcuts.js
@@ -2,21 +2,16 @@
   Danbooru.Shortcuts = {};
 
   Danbooru.Shortcuts.initialize = function() {
-    $(document).bind("keydown", "s", function(e) {
-      Danbooru.Shortcuts.nav_scroll_down();
-    });
+    Danbooru.keydown("s", "scroll_down", Danbooru.Shortcuts.nav_scroll_down);
+    Danbooru.keydown("w", "scroll_up", Danbooru.Shortcuts.nav_scroll_up);
 
-    $(document).bind("keydown", "w", function(e) {
-      Danbooru.Shortcuts.nav_scroll_up();
-    });
-
-    $(document).bind("keydown", "q", function(e) {
+    Danbooru.keydown("q", "focus_search", function(e) {
       $("#tags, #search_name, #search_name_matches, #query").trigger("focus").selectEnd();
       e.preventDefault();
     });
 
     if ($("#image").length) { // post page or bookmarklet upload page
-      $(document).bind("keydown", "shift+e", function(e) {
+      Danbooru.keydown("shift+e", "edit_dialog", function(e) {
         if (Danbooru.meta("current-user-id") == "") { // anonymous
           return;
         }
@@ -36,25 +31,15 @@
     }
 
     if ($("#c-posts").length && $("#a-show").length) {
-      $(document).bind("keydown", "shift+o", function(e) {
+      Danbooru.keydown("shift+o", "approve", function(e) {
         if (Danbooru.meta("current-user-can-approve-posts") === "true") {
           Danbooru.Post.approve(Danbooru.meta("post-id"));
         }
       });
-
-      $(document).bind("keydown", "r", function(e) {
-        $("#random-post")[0].click();
-      });
     }
 
-    if ($("#c-posts").length && $("#a-index").length) {
-      $(document).bind("keydown", "r", function(e) {
-        $("#random-post")[0].click();
-      });
-    }
-
-    if ($("#c-favorites").length && $("#a-index").length) {
-      $(document).bind("keydown", "r", function(e) {
+    if ($("#c-posts #a-index, #c-posts #a-show, #c-favorites #a-index").length) {
+      Danbooru.keydown("r", "random", function(e) {
         $("#random-post")[0].click();
       });
     }
@@ -76,7 +61,5 @@
 
 
 $(document).ready(function() {
-  if (Danbooru.meta("enable-js-navigation") === "true") {
-    Danbooru.Shortcuts.initialize();
-  }
+  Danbooru.Shortcuts.initialize();
 });

--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -27,11 +27,11 @@
   }
 
   Danbooru.Upload.initialize_enter_on_tags = function() {
-    $("#upload_tag_string,#post_tag_string").bind("keydown", "return", function(e) {
+    $("#upload_tag_string,#post_tag_string").on("keydown.danbooru.submit", null, "return", function(e) {
       if (!Danbooru.autocompleting) {
         $("#form").trigger("submit");
         $("#quick-edit-form").trigger("submit");
-        $("#upload_tag_string,#post_tag_string").unbind("keydown");
+        $("#upload_tag_string,#post_tag_string").off(".submit");
       }
 
       e.preventDefault();

--- a/app/assets/javascripts/utility.js
+++ b/app/assets/javascripts/utility.js
@@ -45,6 +45,12 @@
     }
   }
 
+  Danbooru.keydown = function(keys, namespace, handler) {
+    if (Danbooru.meta("enable-js-navigation") === "true") {
+      $(document).on("keydown" + ".danbooru." + namespace, null, keys, handler);
+    }
+  };
+
   Danbooru.is_subset = function(array, subarray) {
     var all = true;
 

--- a/app/assets/javascripts/wiki_pages.js
+++ b/app/assets/javascripts/wiki_pages.js
@@ -50,8 +50,11 @@
   Danbooru.WikiPage.initialize_shortcuts = function() {
     if ($("#a-show").length) {
       Danbooru.keydown("e", "edit", function(e) {
-        $("#wiki-page-edit-link")[0].click();
-        e.preventDefault();
+        $("#wiki-page-edit a")[0].click();
+      });
+
+      Danbooru.keydown("shift+d", "delete", function(e) {
+        $("#wiki-page-delete a")[0].click();
       });
     }
   }

--- a/app/assets/javascripts/wiki_pages.js
+++ b/app/assets/javascripts/wiki_pages.js
@@ -7,9 +7,7 @@
         this.initialize_autocomplete();
       }
 
-      if (Danbooru.meta("enable-js-navigation") === "true") {
-        this.initialize_shortcuts();
-      }
+      this.initialize_shortcuts();
     }
   }
 
@@ -51,7 +49,7 @@
 
   Danbooru.WikiPage.initialize_shortcuts = function() {
     if ($("#a-show").length) {
-      $(document).bind("keydown", "e", function(e) {
+      Danbooru.keydown("e", "edit", function(e) {
         $("#wiki-page-edit-link")[0].click();
         e.preventDefault();
       });

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -10,12 +10,12 @@
       <li><%= link_to "Posts (#{Post.fast_count(@artist.name)})", posts_path(:tags => @artist.name) %></li>
       <li><%= link_to "Show", artist_path(@artist) %></li>
       <% if CurrentUser.is_member? %>
-        <li><%= link_to "Edit", edit_artist_path(@artist) %></li>
+        <li id="artist-edit"><%= link_to "Edit", edit_artist_path(@artist) %></li>
       <% end %>
       <li><%= link_to "History", artist_versions_path(:search => {:artist_id => @artist.id}) %></li>
       <% if @artist.deletable_by?(CurrentUser.user) %>
         <% if @artist.is_active? %>
-          <li><%= link_to "Delete", artist_path(@artist), :method => :delete, :data => {:confirm => "Are you sure you want to delete this artist?"} %></li>
+          <li id="artist-delete"><%= link_to "Delete", artist_path(@artist), :method => :delete, :data => {:confirm => "Are you sure you want to delete this artist?"} %></li>
         <% else %>
           <li><%= link_to "Undelete", undelete_artist_path(@artist), :method => :post, :data => {:confirm => "Are you sure you want to undelete this artist?"} %></li>
         <% end %>

--- a/app/views/forum_topics/_secondary_links.html.erb
+++ b/app/views/forum_topics/_secondary_links.html.erb
@@ -7,7 +7,7 @@
       <li><%= link_to "New", new_forum_topic_path %></li>
       <li><%= link_to "Request alias", new_tag_alias_request_path %></li>
       <li><%= link_to "Request implication", new_tag_implication_request_path %></li>
-      <li><%= link_to "Mark all as read", mark_all_as_read_forum_topics_path, :method => :post %></li>
+      <li id="forum-topic-mark-all-as-read"><%= link_to "Mark all as read", mark_all_as_read_forum_topics_path, :method => :post %></li>
     <% end %>
     
     <li><%= link_to "Search", search_forum_posts_path %></li>
@@ -26,7 +26,7 @@
           <% if @forum_topic.is_deleted? %>
             <li><%= link_to "Undelete", undelete_forum_topic_path(@forum_topic), :method => :post %></li>
           <% else %>
-            <li><%= link_to "Delete", forum_topic_path(@forum_topic), :method => :delete, :data => {:confirm => "Are you sure you want to delete this forum topic?"} %></li>
+            <li id="forum-topic-delete"><%= link_to "Delete", forum_topic_path(@forum_topic), :method => :delete, :data => {:confirm => "Are you sure you want to delete this forum topic?"} %></li>
           <% end %>
           <% if @forum_topic.is_locked? %>
             <li><%= link_to "Unlock", forum_topic_path(@forum_topic, :forum_topic => {:is_locked => false}), :method => :put %></li>

--- a/app/views/pools/_secondary_links.html.erb
+++ b/app/views/pools/_secondary_links.html.erb
@@ -10,13 +10,13 @@
       <li><%= link_to "Show", pool_path(@pool) %></li>
       <li><%= link_to "Posts", posts_path(:tags => "pool:#{@pool.id}") %></li>
       <% if CurrentUser.is_member? %>
-        <li><%= link_to "Edit", edit_pool_path(@pool) %></li>
+        <li id="pool-edit"><%= link_to "Edit", edit_pool_path(@pool) %></li>
       <% end %>
       <% if @pool.deletable_by?(CurrentUser.user) %>
         <% if @pool.is_deleted? %>
-          <li><%= link_to "Undelete", undelete_pool_path(@pool), :method => :post, :remote => true %></li>
+          <li id="pool-delete"><%= link_to "Undelete", undelete_pool_path(@pool), :method => :post, :remote => true %></li>
         <% else %>
-          <li><%= link_to "Delete", pool_path(@pool), :method => :delete, :data => {:confirm => "Are you sure you want to delete this pool?"}, :remote => true %></li>
+          <li id="pool-delete"><%= link_to "Delete", pool_path(@pool), :method => :delete, :data => {:confirm => "Are you sure you want to delete this pool?"}, :remote => true %></li>
         <% end %>
       <% end %>
       <% if PoolArchive.enabled? %>

--- a/app/views/static/keyboard_shortcuts.html.erb
+++ b/app/views/static/keyboard_shortcuts.html.erb
@@ -5,12 +5,13 @@
     <section>
       <h1>Listing</h1>
       <ul>
-        <li><kbd class="key">a</kbd> Previous page</li>
-        <li><kbd class="key">d</kbd> Next page</li>
+        <li><kbd class="key">a</kbd>, <kbd class="key">⇦</kbd> Previous page</li>
+        <li><kbd class="key">d</kbd>, <kbd class="key">⇨</kbd> Next page</li>
         <li><kbd class="key">q</kbd> Search</li>
         <li><kbd class="key">w</kbd> Scroll up</li>
         <li><kbd class="key">s</kbd> Scroll down</li>
         <li><kbd class="key">r</kbd> Go to random post</li>
+        <li><kbd class="key">1</kbd>, <kbd class="key">2</kbd>, <kbd class="key">3</kbd>... Switch tag script</li>
       </ul>
     </section>
 
@@ -29,8 +30,36 @@
         <li><kbd class="key">d</kbd> Next post</li>
         <li><kbd class="key">f</kbd> Favorite post</li>
         <li><kbd class="key">g</kbd> Add post to favorite group</li>
+        <li><kbd class="key">1</kbd>, <kbd class="key">2</kbd>, <kbd class="key">3</kbd>... Add post to favorite group #N</li>
         <li><kbd class="key">r</kbd> Go to random post</li>
         <li><kbd class="key">v</kbd> Toggle between sample and full size</li>
+      </ul>
+    </section>
+
+    <section>
+      <h1>Artists</h1>
+      <ul>
+        <li><kbd class="key">e</kbd> Edit artist</li>
+        <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete artist</li>
+      </ul>
+
+      <h1>Forum</h1>
+      <ul>
+        <li><kbd class="key">e</kbd> Edit topic</li>
+        <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete topic</li>
+        <li><kbd class="key">shift</kbd>+<kbd class="key">r</kbd> Mark all as read</li>
+      </ul>
+
+      <h1>Pools</h1>
+      <ul>
+        <li><kbd class="key">e</kbd> Edit pool</li>
+        <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete pool</li>
+      </ul>
+
+      <h1>Wiki</h1>
+      <ul>
+        <li><kbd class="key">e</kbd> Edit wiki page</li>
+        <li><kbd class="key">shift</kbd>+<kbd class="key">d</kbd> Delete wiki page</li>
       </ul>
     </section>
   </div>

--- a/app/views/wiki_pages/_secondary_links.html.erb
+++ b/app/views/wiki_pages/_secondary_links.html.erb
@@ -16,10 +16,10 @@
       <% unless @wiki_page.new_record? %>
         <li><%= link_to "History", wiki_page_versions_path(:search => {:wiki_page_id => @wiki_page.id}) %></li>
         <% if CurrentUser.is_member? %>
-          <li><%= link_to "Edit", edit_wiki_page_path(@wiki_page), :id => "wiki-page-edit-link" %></li>
+          <li id="wiki-page-edit"><%= link_to "Edit", edit_wiki_page_path(@wiki_page) %></li>
         <% end %>
         <% if CurrentUser.is_builder? && !@wiki_page.is_deleted? %>
-          <li><%= link_to "Delete", wiki_page_path(@wiki_page), :remote => true, :method => :delete, :data => {:confirm => "Are you sure you want to delete this wiki page?"} %></li>
+          <li id="wiki-page-delete"><%= link_to "Delete", wiki_page_path(@wiki_page), :remote => true, :method => :delete, :data => {:confirm => "Are you sure you want to delete this wiki page?"} %></li>
         <% end %>
       <% end %>
     <% end %>


### PR DESCRIPTION
* Adds E to edit, shift+D to delete hotkeys to artists, pools, wiki, forum.
* Adds left arrow, right arrow bindings for prev/next page. (cc @RaisingK and @Moebius-Strip, I think their userscripts do this).
* Refactors hotkeys to use `.on()` instead of `.bind()`. `.bind()` is deprecated as of jquery 3.0. ref: https://api.jquery.com/bind/
* Binds hotkeys using jquery event namespaces so that it's possible for userscripts to override our keybindings. e.g. `$(document).off("danbooru.edit")` unbinds the `edit` hotkey. ref: https://api.jquery.com/on/#event-names:

> An event name can be qualified by event namespaces that simplify removing or triggering the event. For example, "click.myPlugin.simple" defines both the myPlugin and simple namespaces for this particular click event. A click event handler attached via that string could be removed with .off("click.myPlugin") or .off("click.simple") without disturbing other click handlers attached to the elements.