### PR TITLE
Update gems for ruby-2.4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,10 +196,10 @@ GEM
       semver2
     jmespath (1.0.2)
       multi_json (~> 1.0)
-    json (1.8.3)
+    json (1.8.6)
     jwt (1.5.6)
     kgio (2.10.0)
-    libv8 (3.16.14.11)
+    libv8 (3.16.14.17)
     little-plugger (1.1.4)
     logging (2.1.0)
       little-plugger (~> 1.1)
@@ -374,8 +374,8 @@ GEM
       rest-client (~> 1.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -485,4 +485,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.6
+   1.14.3


### PR DESCRIPTION
This fixes a couple gems that had problems with ruby 2.4's [Integer unification](https://blog.heroku.com/ruby-2-4-features-hashes-integers-rounding#unified-integers). Note that rails 4.2.7.1 also has an issue (see: github.com/rails/rails/issues/25125), so Danbooru still doesn't run under 2.4 yet.