### PR TITLE
Implement #2863: basic upload tags change report

### DIFF
--- a/app/controllers/upload_tags_report_controller.rb
+++ b/app/controllers/upload_tags_report_controller.rb
@@ -1,0 +1,9 @@
+class UploadTagsReportController < ApplicationController
+  respond_to :html, :xml, :json
+
+  def show
+    @user = User.find(params[:id])
+    @upload_reports = UploadTagsReport.for_user(params[:id]).order("id desc").paginate(params[:page], :limit => params[:limit])
+    respond_with(@upload_reports)
+  end
+end

--- a/app/helpers/upload_tags_report_helper.rb
+++ b/app/helpers/upload_tags_report_helper.rb
@@ -1,0 +1,12 @@
+module UploadTagsReportHelper
+  def diff_to_current(report)
+    html = []
+    report.added_tags_array.each do |tag|
+      html << '<ins>+' + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</ins>'
+    end
+    report.removed_tags_array.each do |tag|
+      html << '<del>-' + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</del>'
+    end
+    return html.join(" ").html_safe
+  end
+end

--- a/app/models/upload_tags_report.rb
+++ b/app/models/upload_tags_report.rb
@@ -1,0 +1,67 @@
+class UploadTagsReport < Post
+
+  def readonly?
+    true
+  end
+
+  module ApiMethods
+
+    def as_json(options = {})
+      options ||= {}
+      options[:only] ||= [:id]
+      super(options)
+    end
+
+    def to_xml(options = {}, &block)
+      options ||= {}
+      options[:only] ||= [:id, :uploader_id]
+      super(options, &block)
+    end
+
+    def method_attributes
+      [:uploader_tags, :added_tags, :removed_tags]
+    end
+
+  end
+
+  include ApiMethods
+
+  def uploader_tags_array
+    @uploader_tags ||= begin
+      added_tags = []
+      PostVersion.where(post_id: id, updater_id: uploader_id).each do |version|
+        added_tags += version.changes[:added_tags]
+      end
+      added_tags.uniq.sort
+    end
+  end
+
+  def current_tags_array
+    latest_tags = tag_array
+    latest_tags << "rating:#{rating}" if rating.present?
+    latest_tags << "parent:#{parent_id}" if parent_id.present?
+    latest_tags << "source:#{source}" if source.present?
+    latest_tags
+  end
+
+  def added_tags_array
+    current_tags_array - uploader_tags_array
+  end
+
+  def removed_tags_array
+    uploader_tags_array - current_tags_array
+  end
+
+  def uploader_tags
+    uploader_tags_array.join(' ')
+  end
+
+  def added_tags
+    added_tags_array.join(' ')
+  end
+
+  def removed_tags
+    removed_tags_array.join(' ')
+  end
+
+end

--- a/app/views/upload_tags_report/show.html.erb
+++ b/app/views/upload_tags_report/show.html.erb
@@ -1,0 +1,35 @@
+<div id="c-post-versions">
+  <div id="a-index">
+    <h1>Upload tag changes report for <%= @user.pretty_name %></h1>
+    <table class="striped">
+      <thead>
+        <tr>
+        <th width="10%">Post ID</th>
+        <th width="45%">Tags added by uploader</th>
+        <th width="45%">Tags changed by other users</th>
+        </tr>
+        </thead>
+      <tbody>
+        <% @upload_reports.each do |upload_report| %>
+          <tr>
+            <td><%= link_to(upload_report.id, post_path(:id => upload_report.id ))%></td>
+            <td>
+              <% upload_report.uploader_tags_array.each do |tag_name| %>
+                <span class="category-<%= Tag.category_for(tag_name) %>">
+                  <%= link_to(tag_name.tr("_", " "), posts_path(:tags => tag_name)) %>
+                </span>
+              <% end %>
+            </td>
+            <td><%= diff_to_current(upload_report) %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+    <%= numbered_paginator(@upload_reports) %>
+    </div>
+</div>
+
+
+<% content_for(:page_title) do %>
+  Upload tag changes for <%= @user.pretty_name %> - <%= Danbooru.config.app_name %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+
   namespace :admin do
     resources :users, :only => [:edit, :update]
     resource  :alias_and_implication_import, :only => [:new, :create]
@@ -321,6 +322,8 @@ Rails.application.routes.draw do
       get :diff
     end
   end
+
+  resources :upload_tags_report, :only => [:show]
 
   # aliases
   resources :wpages, :controller => "wiki_pages"


### PR DESCRIPTION
Quick implementation for  #2863. This is a naive approach: I created a new read-only `UploadTagReport` model by extending `Post` and adding methods for comparing versions. This allows for easy pagination, but I have a sneaking suspicion it doesn't really fit Rails' MVC paradigm, and it should have gone into `logical` instead, with methods like `search` to return collection of some other class having `Post` as an instance variable; but I was completely baffled about applying pagination to such things. @r888888888 ?

Ideally, to make the report more useful, there should also be a way to exclude posts where all tags were added by uploader. This fits numbered pagination even less, unfortunately, and I'm not familiar enough with sequential paginator to make it work on something like that. Besides, it's too hard to determine the condition at SQL level, meaning it'll somehow have to apply pagination AFTER loading enough rows. Unfortunately, I have no idea how to do this, either.