### PR TITLE
Add filetype: metatag.

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -101,7 +101,7 @@
     );
 
     var prefixes = "-|~|general:|gen:|artist:|art:|copyright:|copy:|co:|character:|char:|ch:";
-    var metatags = "order|-status|status|-rating|rating|-locked|locked|child|" +
+    var metatags = "order|-status|status|-rating|rating|-locked|locked|child|filetype|-filetype|" +
       "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-fav|fav|ordfav|" +
       "sub|-pool|pool|ordpool|favgroup";
 
@@ -159,6 +159,8 @@
         case "locked":
         case "-locked":
         case "child":
+        case "filetype":
+        case "-filetype":
           Danbooru.Autocomplete.static_metatag_source(term, resp, metatag);
           return;
         }
@@ -336,7 +338,10 @@
     ],
     child: [
       "any", "none"
-    ]
+    ],
+    filetype: [
+      "jpg", "png", "gif", "swf", "zip", "webm", "mp4"
+    ],
   }
 
   Danbooru.Autocomplete.static_metatag_source = function(term, resp, metatag) {

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -183,6 +183,14 @@ class PostQueryBuilder
       relation = relation.where("posts.is_deleted = FALSE")
     end
 
+    if q[:filetype]
+      relation = relation.where("posts.file_ext": q[:filetype])
+    end
+
+    if q[:filetype_neg]
+      relation = relation.where.not("posts.file_ext": q[:filetype_neg])
+    end
+
     # The SourcePattern SQL function replaces Pixiv sources with "pixiv/[suffix]", where
     # [suffix] is everything past the second-to-last slash in the URL.  It leaves non-Pixiv
     # URLs unchanged.  This is to ease database load for Pixiv source searches.

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 class Tag < ActiveRecord::Base
   COSINE_SIMILARITY_RELATED_TAG_THRESHOLD = 1000
-  METATAGS = "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-pool|pool|ordpool|-favgroup|favgroup|-fav|fav|ordfav|sub|md5|-rating|rating|-locked|locked|width|height|mpixels|ratio|score|favcount|filesize|source|-source|id|-id|date|age|order|limit|-status|status|tagcount|gentags|arttags|chartags|copytags|parent|-parent|child|pixiv_id|pixiv|search|upvote|downvote"
+  METATAGS = "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-pool|pool|ordpool|-favgroup|favgroup|-fav|fav|ordfav|sub|md5|-rating|rating|-locked|locked|width|height|mpixels|ratio|score|favcount|filesize|source|-source|id|-id|date|age|order|limit|-status|status|tagcount|gentags|arttags|chartags|copytags|parent|-parent|child|pixiv_id|pixiv|search|upvote|downvote|filetype|-filetype"
   SUBQUERY_METATAGS = "commenter|comm|noter|noteupdater|artcomm"
   attr_accessible :category, :as => [:moderator, :janitor, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
   attr_accessible :is_locked, :as => [:moderator, :admin]
@@ -605,6 +605,12 @@ class Tag < ActiveRecord::Base
 
           when "status"
             q[:status] = $2.downcase
+
+          when "filetype"
+            q[:filetype] = $2.downcase
+
+          when "-filetype"
+            q[:filetype_neg] = $2.downcase
 
           when "pixiv_id", "pixiv"
             q[:pixiv_id] = parse_helper($2)


### PR DESCRIPTION
Adds a `filetype:` metatag. This is primary for `filetype:png` searches, but it actually works well for other file types even though the column isn't indexed. `filetype:mp4 order:id_asc` is the worst case at ~3.5s on my system.