### PR TITLE
Don't send failed uploads to IQDB (possible fix for #2867).

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,7 +22,6 @@ class Post < ActiveRecord::Base
   before_save :set_tag_counts
   before_save :set_pool_category_pseudo_tags
   before_create :autoban
-  after_create :update_iqdb_async
   after_save :create_version
   after_save :update_parent_on_save
   after_save :apply_post_metatags
@@ -30,6 +29,7 @@ class Post < ActiveRecord::Base
   after_destroy :remove_iqdb_async
   after_destroy :delete_files
   after_destroy :delete_remote_files
+  after_commit :update_iqdb_async, :on => :create
   after_commit :notify_pubsub
 
   belongs_to :updater, :class_name => "User"


### PR DESCRIPTION
As described in [topic #13677](http://danbooru.donmai.us/forum_topics/13677), I think Danbooru is sending failed uploads to IQDBS. This could happen if an `after_save` callback times out, since `after_create` runs before `after_save`.

The IQDB database will also have to be regenerated to purge invalid post IDs from it. I think it would be better if MD5s were stored in IQDB instead of post IDs, that way it'd be easier to maintain consistency.