### PR TITLE
Disable left/right keys for prev/next page on /posts/:id.

### DIFF
--- a/app/assets/javascripts/forum_posts.js
+++ b/app/assets/javascripts/forum_posts.js
@@ -16,7 +16,7 @@
 
     if ($("#c-forum-topics").length) {
       Danbooru.keydown("shift+r", "mark_all_as_read", function(e) {
-        $("#secondary-links-mark-all-as-read a").click();
+        $("#forum-topic-mark-all-as-read a")[0].click();
       });
     }
   }

--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -585,7 +585,7 @@ Danbooru.Note = {
       $("#image").css("cursor", "auto");
       $("#image").click(Danbooru.Note.Box.toggle_all);
       $("#image").off("mousedown", Danbooru.Note.TranslationMode.Drag.start);
-      $(window).mouseup(Danbooru.Note.TranslationMode.Drag.stop);
+      $(window).off("mouseup", Danbooru.Note.TranslationMode.Drag.stop);
       $(document.body).removeClass("mode-translation");
       $("#close-notice-link").click();
       $("#mark-as-translated-section").hide();

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -177,8 +177,8 @@
         e.preventDefault();
       });
 
-      Danbooru.keydown("a left", "prev_page", Danbooru.Post.nav_prev);
-      Danbooru.keydown("d right", "next_page", Danbooru.Post.nav_next);
+      Danbooru.keydown("a", "prev_page", Danbooru.Post.nav_prev);
+      Danbooru.keydown("d", "next_page", Danbooru.Post.nav_next);
 
       Danbooru.keydown("f", "favorite", function(e) {
         if ($("#add-to-favorites").is(":visible")) {


### PR DESCRIPTION
Disables the left/right hotkeys for going to the prev/next page due to complaints that it interferes with horizontal scrolling of wide images.

Also fixes a bug with `shift+r` to mark the forum as read not working, and another issue with a mouseup handler on notes being rebound instead of unbound.