### PR TITLE
Fix various failing tests

### DIFF
--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -148,6 +148,7 @@ class Note < ActiveRecord::Base
 
   def create_version
     User.where(id: CurrentUser.id).update_all("note_update_count = note_update_count + 1")
+    CurrentUser.reload
 
     if merge_version?
       merge_version

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1436,6 +1436,8 @@ class Post < ActiveRecord::Base
 
     def create_new_version
       User.where(id: CurrentUser.id).update_all("post_update_count = post_update_count + 1")
+      CurrentUser.reload
+
       versions.create(
         :rating => rating,
         :source => source,

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -22,6 +22,7 @@ class PostsControllerTest < ActionController::TestCase
           @post = FactoryGirl.create(:post)
           @bucket = TokenBucket.create(user_id: @user.id, token_count: 5, last_touched_at: Time.now)
           User.any_instance.stubs(:api_burst_limit).returns(5)
+          User.any_instance.stubs(:api_regen_multiplier).returns(0)
         end
         
         should "work" do
@@ -30,7 +31,7 @@ class PostsControllerTest < ActionController::TestCase
             assert_response :success
           end
 
-            post :update, {:format => "json", :id => @post.id, :post => {:rating => "q"}, :login => @user.name, :api_key => @user.api_key.key}
+          post :update, {:format => "json", :id => @post.id, :post => {:rating => "q"}, :login => @user.name, :api_key => @user.api_key.key}
           assert_response 429
         end
       end

--- a/test/helpers/saved_search_test_helper.rb
+++ b/test/helpers/saved_search_test_helper.rb
@@ -16,5 +16,8 @@ module SavedSearchTestHelper
 
     service = mock_sqs_service.new
     SavedSearch.stubs(:sqs_service).returns(service)
+    Danbooru.config.stubs(:aws_sqs_saved_search_url).returns("http://localhost:3002")
+    Danbooru.config.stubs(:listbooru_auth_key).returns("blahblahblah")
+    Danbooru.config.stubs(:listbooru_server).returns("http://localhost:3001")
   end
 end

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -159,16 +159,15 @@ class CommentTest < ActiveSupport::TestCase
         user = FactoryGirl.create(:user)
         post = FactoryGirl.create(:post)
         c1 = FactoryGirl.create(:comment, :post => post)
-        comment_vote = c1.vote!("down")
-        assert_equal([], comment_vote.errors.full_messages)
-        comment_vote = c1.vote!("down")
-        assert_equal(["You have already voted for this comment"], comment_vote.errors.full_messages)
+
+        assert_nothing_raised { c1.vote!("down") }
+        exception = assert_raises(ActiveRecord::RecordInvalid) { c1.vote!("down") }
+        assert_equal("Validation failed: You have already voted for this comment", exception.message)
         assert_equal(1, CommentVote.count)
         assert_equal(-1, CommentVote.last.score)
 
         c2 = FactoryGirl.create(:comment, :post => post)
-        comment_vote = c2.vote!("down")
-        assert_equal([], comment_vote.errors.full_messages)
+        assert_nothing_raised { c2.vote!("down") }
         assert_equal(2, CommentVote.count)
       end
 
@@ -176,9 +175,9 @@ class CommentTest < ActiveSupport::TestCase
         user = FactoryGirl.create(:user)
         post = FactoryGirl.create(:post)
         c1 = FactoryGirl.create(:comment, :post => post)
-        comment_vote = c1.vote!("up")
 
-        assert_equal(["You cannot upvote your own comments"], comment_vote.errors.full_messages)
+        exception = assert_raises(ActiveRecord::RecordInvalid) { c1.vote!("up") }
+        assert_equal("Validation failed: You cannot upvote your own comments", exception.message)
       end
 
       should "allow undoing of votes" do

--- a/test/unit/moderator/tag_batch_change_test.rb
+++ b/test/unit/moderator/tag_batch_change_test.rb
@@ -8,8 +8,6 @@ module Moderator
     def setup
       super
       mock_saved_search_service!
-      Danbooru.config.stubs(:listbooru_auth_key).returns("blahblahblah")
-      Danbooru.config.stubs(:listbooru_server).returns("http://localhost:3001")
     end
 
     context "a tag batch change" do

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1,8 +1,10 @@
 require 'test_helper'
 require 'helpers/pool_archive_test_helper'
+require 'helpers/saved_search_test_helper'
 
 class PostTest < ActiveSupport::TestCase
   include PoolArchiveTestHelper
+  include SavedSearchTestHelper
 
   setup do
     Timecop.travel(2.weeks.ago) do
@@ -12,6 +14,7 @@ class PostTest < ActiveSupport::TestCase
     CurrentUser.ip_addr = "127.0.0.1"
     MEMCACHE.flush_all
     Delayed::Worker.delay_jobs = false
+    mock_saved_search_service!
   end
 
   teardown do
@@ -767,7 +770,7 @@ class PostTest < ActiveSupport::TestCase
 
         context "of" do
           setup do
-            @builder = FactoryGirl.build(:builder_user)
+            @builder = FactoryGirl.create(:builder_user)
           end
 
           context "locked:notes" do
@@ -822,7 +825,7 @@ class PostTest < ActiveSupport::TestCase
 
             context "by an admin" do
               should "lock/unlock the status" do
-                CurrentUser.scoped(FactoryGirl.build(:admin_user)) do
+                CurrentUser.scoped(FactoryGirl.create(:admin_user)) do
                   @post.update(:tag_string => "locked:status")
                   assert_equal(true, @post.is_status_locked)
 
@@ -836,7 +839,7 @@ class PostTest < ActiveSupport::TestCase
 
         context "of" do
           setup do
-            @gold = FactoryGirl.build(:gold_user)
+            @gold = FactoryGirl.create(:gold_user)
           end
 
           context "upvote:self or downvote:self" do

--- a/test/unit/saved_search_test.rb
+++ b/test/unit/saved_search_test.rb
@@ -8,8 +8,6 @@ class SavedSearchTest < ActiveSupport::TestCase
   def setup
     super
     mock_saved_search_service!
-    Danbooru.config.stubs(:listbooru_auth_key).returns("blahblahblah")
-    Danbooru.config.stubs(:listbooru_server).returns("http://localhost:3001")
   end
 
   context "Fetching the post ids for a search" do
@@ -34,7 +32,7 @@ class SavedSearchTest < ActiveSupport::TestCase
 
     context "without a name" do
       setup do
-        FakeWeb.register_uri(:get, "http://localhost:3001/users?key=blahblahblah&user_id=1&name", :body => [1,2,3,4].to_json)
+        FakeWeb.register_uri(:get, "http://localhost:3001/users?key=blahblahblah&user_id=1", :body => [1,2,3,4].to_json)
       end
 
       should "return a list of ids" do

--- a/test/unit/tag_alias_test.rb
+++ b/test/unit/tag_alias_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'helpers/saved_search_test_helper'
 
 class TagAliasTest < ActiveSupport::TestCase
+  include SavedSearchTestHelper
+
   context "A tag alias" do
     setup do
       Timecop.travel(1.month.ago) do
@@ -10,6 +13,7 @@ class TagAliasTest < ActiveSupport::TestCase
       CurrentUser.ip_addr = "127.0.0.1"
       MEMCACHE.flush_all
       Delayed::Worker.delay_jobs = false
+      mock_saved_search_service!
     end
 
     teardown do


### PR DESCRIPTION
Fixes various failing test cases, see the commits for details.

I still get some failures, particularly a bunch of `Net::HTTP::Persistent::Error: too many connection resets (due to closed stream - IOError)` exceptions in the pixiv tests. Not sure why.