### PR TITLE
Improve controller test coverage

### DIFF
--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,7 +1,5 @@
 module Admin
   class DashboardsController < ApplicationController
-    before_filter :admin_only
-    
     def show
       @dashboard = AdminDashboard.new
     end

--- a/app/logical/admin_dashboard.rb
+++ b/app/logical/admin_dashboard.rb
@@ -12,6 +12,6 @@ class AdminDashboard
   end
 
   def forum_topics
-    ForumTopic.where(category_id: 1).order("id desc").limit(20)
+    ForumTopic.search(category_id: 1).order("id desc").limit(20)
   end
 end

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -120,7 +120,7 @@ class FavoriteGroup < ActiveRecord::Base
   end
 
   def initialize_creator
-    self.creator_id = CurrentUser.id
+    self.creator_id ||= CurrentUser.id
   end
 
   def strip_name
@@ -214,6 +214,7 @@ class FavoriteGroup < ActiveRecord::Base
     super
     @neighbor_posts = nil
     clear_post_id_array
+    self
   end
 
   def last_page

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -94,7 +94,7 @@ class Note < ActiveRecord::Base
   end
 
   def initialize_creator
-    self.creator_id = CurrentUser.id
+    self.creator_id ||= CurrentUser.id
   end
 
   def initialize_updater

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -173,7 +173,7 @@ class Post < ActiveRecord::Base
     end
     
     def is_animated_png?
-      if file_ext =~ /png/i
+      if file_ext =~ /png/i && File.exists?(file_path)
         apng = APNGInspector.new(file_path)
         apng.inspect!
         return apng.animated?

--- a/test/controllers/saved_searches_controller_test.rb
+++ b/test/controllers/saved_searches_controller_test.rb
@@ -1,7 +1,0 @@
-require 'test_helper'
-
-class SavedSearchesControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/factories/favorite_group.rb
+++ b/test/factories/favorite_group.rb
@@ -1,4 +1,6 @@
 FactoryGirl.define do
-  factory(:favorite_group) do
+  factory :favorite_group do
+    name { FFaker::Lorem.word }
+    creator
   end
 end

--- a/test/factories/note.rb
+++ b/test/factories/note.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory(:note) do
-    creator :factory => :user
+    creator
     post
     x 1
     y 1
@@ -8,7 +8,6 @@ FactoryGirl.define do
     height 1
     is_active true
     body {FFaker::Lorem.sentences.join(" ")}
-    updater_id :factory => :user
     updater_ip_addr "127.0.0.1"
   end
 end

--- a/test/factories/post.rb
+++ b/test/factories/post.rb
@@ -13,5 +13,6 @@ FactoryGirl.define do
     image_height 1000
     file_size 2000
     rating "q"
+    source { FFaker::Internet.http_url }
   end
 end

--- a/test/factories/saved_search.rb
+++ b/test/factories/saved_search.rb
@@ -1,5 +1,7 @@
 FactoryGirl.define do
   factory(:saved_search) do
-    tag_query "aaa"
+    tag_query { FFaker::Lorem.words }
+    category { FFaker::Lorem.word }
+    user
   end
 end

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory(:user) do
+  factory(:user, aliases: [:creator, :updater]) do
     name {(rand(1_000_000) + 10).to_s}
     password "password"
     password_hash {User.sha1("password")}

--- a/test/functional/admin/dashboards_controller_test.rb
+++ b/test/functional/admin/dashboards_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class Admin::DashboardsControllerTest < ActionController::TestCase
+  context "The admin dashboard controller" do
+    context "show action" do
+      should "render" do
+        get :show
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/artist_commentaries_controller_test.rb
+++ b/test/functional/artist_commentaries_controller_test.rb
@@ -6,16 +6,82 @@ class ArtistCommentariesControllerTest < ActionController::TestCase
       @user = FactoryGirl.create(:user)
       CurrentUser.user = @user
       CurrentUser.ip_addr = "127.0.0.1"
+
+      @commentary1 = FactoryGirl.create(:artist_commentary)
+      @commentary2 = FactoryGirl.create(:artist_commentary)
     end
 
     teardown do
       CurrentUser.user = nil
     end
 
+    context "index action" do
+      should "render" do
+        get :index
+        assert_response :success
+      end
+
+      should "render with search params" do
+        params = {
+          search: {
+            text_matches: @commentary1.original_title,
+            post_id: @commentary1.post_id, 
+            original_present: "yes",
+            translated_present: "yes",
+            post_tags_match: @commentary1.post.tag_array.first,
+          }
+        }
+
+        get :index, params
+        assert_response :success
+      end
+    end
+
+    context "show action" do
+      should "render" do
+        get :show, { id: @commentary1.id }
+        assert_redirected_to(@commentary1.post)
+
+        get :show, { post_id: @commentary1.post_id }
+        assert_redirected_to(@commentary1.post)
+      end
+    end
+
+    context "create_or_update action" do
+      should "render for create" do
+        params = {
+          artist_commentary: {
+            original_title: "foo",
+            post_id: FactoryGirl.create(:post).id,
+          }
+        }
+
+        post :create_or_update, params, { user_id: @user.id }
+        assert_redirected_to(ArtistCommentary.find_by_post_id(params[:artist_commentary][:post_id]))
+      end
+
+      should "render for update" do
+        params = {
+          artist_commentary: {
+            post_id: @commentary1.post_id,
+            original_title: "foo",
+          }
+        }
+
+        post :create_or_update, params, { user_id: @user.id }
+        assert_redirected_to(@commentary1)
+        assert_equal("foo", @commentary1.reload.original_title)
+      end
+    end
+
     context "revert action" do
-      setup do
-        @commentary1 = FactoryGirl.create(:artist_commentary)
-        @commentary2 = FactoryGirl.create(:artist_commentary)
+      should "work" do
+        original_title = @commentary1.original_title
+        @commentary1.update(original_title: "foo")
+
+        post :revert, { :id => @commentary1.post_id, :version_id => @commentary1.versions(true).first.id }, {:user_id => @user.id}
+        assert_redirected_to(@commentary1)
+        assert_equal(original_title, @commentary1.reload.original_title)
       end
 
       should "return 404 when trying to revert a nonexistent commentary" do

--- a/test/functional/artist_commentary_versions_controller_test.rb
+++ b/test/functional/artist_commentary_versions_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class ArtistCommentaryVersionsControllerTest < ActionController::TestCase
+  context "The artist commentary versions controller" do
+    context "index action" do
+      should "render" do
+        get :index
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/comments_controller_test.rb
+++ b/test/functional/comments_controller_test.rb
@@ -22,6 +22,11 @@ class CommentsControllerTest < ActionController::TestCase
     end
 
     context "index action" do
+      should "render for post" do
+        xhr :get, :index, { post_id: @post.id, group_by: "post", format: "js" }
+        assert_response :success
+      end
+
       should "render by post" do
         get :index, {:group_by => "post"}
         assert_response :success
@@ -140,6 +145,16 @@ class CommentsControllerTest < ActionController::TestCase
         delete :destroy, {:id => @comment.id}, {:user_id => @user.id}
         assert_equal(true, @comment.reload.is_deleted)
         assert_redirected_to @comment
+      end
+    end
+
+    context "undelete action" do
+      should "mark comment as undeleted" do
+        @comment.delete!
+        put :undelete, { id: @comment.id }, { user_id: @user.id }
+
+        assert_equal(false, @comment.reload.is_deleted)
+        assert_redirected_to(@comment)
       end
     end
   end

--- a/test/functional/counts_controller_test.rb
+++ b/test/functional/counts_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class CountsControllerTest < ActionController::TestCase
+  context "The counts commentary controller" do
+    context "posts action" do
+      should "render" do
+        get :posts
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/delayed_jobs_controller_test.rb
+++ b/test/functional/delayed_jobs_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class DelayedJobsControllerTest < ActionController::TestCase
+  context "The delayed jobs controller" do
+    context "index action" do
+      should "render" do
+        get :index
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/dtext_previews_controller_test.rb
+++ b/test/functional/dtext_previews_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class DtextPreviewsControllerTest < ActionController::TestCase
+  context "The dtext previews controller" do
+    context "create action" do
+      should "render" do
+        post :create, { body: "h1. Touhou\n\n* [[touhou]]" }
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/explore/posts_controller_test.rb
+++ b/test/functional/explore/posts_controller_test.rb
@@ -15,6 +15,27 @@ module Explore
           assert_response :success
         end
       end
+
+      context "#searches" do
+        should "render" do
+          get :searches
+          assert_response :success
+        end
+      end
+
+      context "#missed_searches" do
+        should "render" do
+          get :missed_searches
+          assert_response :success
+        end
+      end
+
+      context "#intro" do
+        should "render" do
+          get :intro
+          assert_response :success
+        end
+      end
     end
   end
 end

--- a/test/functional/favorite_groups_controller_test.rb
+++ b/test/functional/favorite_groups_controller_test.rb
@@ -1,0 +1,81 @@
+require 'test_helper'
+
+class FavoriteGroupsControllerTest < ActionController::TestCase
+  context "The favorite groups controller" do
+    setup do
+      @user = FactoryGirl.create(:user)
+      CurrentUser.user = @user
+      CurrentUser.ip_addr = "127.0.0.1"
+    end
+
+    context "index action" do
+      should "render" do
+        get :index
+        assert_response :success
+      end
+    end
+
+    context "show action" do
+      should "render" do
+        favgroup = FactoryGirl.create(:favorite_group)
+
+        get :show, { id: favgroup.id }
+        assert_response :success
+      end
+    end
+
+    context "new action" do
+      should "render" do
+        get :new, {}, { user_id: @user.id }
+        assert_response :success
+      end
+    end
+
+    context "create action" do
+      should "render" do
+        post :create, { favorite_group: FactoryGirl.attributes_for(:favorite_group) }, { user_id: @user.id }
+        assert_redirected_to favorite_groups_path
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        favgroup = FactoryGirl.create(:favorite_group, creator: @user)
+
+        get :edit, { id: favgroup.id }, { user_id: @user.id }
+        assert_response :success
+      end
+    end
+
+    context "update action" do
+      should "render" do
+        favgroup = FactoryGirl.create(:favorite_group, creator: @user)
+        params = { id: favgroup.id, favorite_group: { name: "foo" } }
+
+        put :update, params, { user_id: @user.id }
+        assert_redirected_to favgroup
+        assert_equal("foo", favgroup.reload.name)
+      end
+    end
+
+    context "destroy action" do
+      should "render" do
+        favgroup = FactoryGirl.create(:favorite_group, creator: @user)
+
+        delete :destroy, { id: favgroup.id }, { user_id: @user.id }
+        assert_redirected_to favorite_groups_path
+      end
+    end
+
+    context "add_post action" do
+      should "render" do
+        favgroup = FactoryGirl.create(:favorite_group, creator: @user)
+        post = FactoryGirl.create(:post)
+
+        put :add_post, { id: favgroup.id, post_id: post.id, format: "js" }, { user_id: @user.id }
+        assert_response :success
+        assert_equal([post.id], favgroup.reload.post_id_array)
+      end
+    end
+  end
+end

--- a/test/functional/iqdb_queries_controller_test.rb
+++ b/test/functional/iqdb_queries_controller_test.rb
@@ -1,0 +1,33 @@
+require 'test_helper'
+require 'helpers/iqdb_test_helper'
+
+class IqdbQueriesControllerTest < ActionController::TestCase
+  include IqdbTestHelper
+
+  context "The iqdb controller" do
+    setup do
+      @user = FactoryGirl.create(:user)
+      CurrentUser.user = @user
+      CurrentUser.ip_addr = "127.0.0.1"
+
+      @posts = FactoryGirl.create_list(:post, 2)
+      mock_iqdb_service!
+    end
+
+    context "create action" do
+      should "render with a post_id" do
+        mock_iqdb_matches!(@posts[0], @posts)
+        post :create, { post_id: @posts[0].id, format: "js" }, { user_id: @user.id }
+
+        assert_response :success
+      end
+
+      should "render with an url" do
+        mock_iqdb_matches!(@posts[0].source, @posts)
+        post :create, { url: @posts[0].source }, { user_id: @user.id }
+
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/meta_searches_controller_test.rb
+++ b/test/functional/meta_searches_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class MetaSearchesControllerTest < ActionController::TestCase
+  context "The meta searches controller" do
+    context "tags action" do
+      should "work" do
+        get :tags, { name: "long_hair" }
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/mod_actions_controller_test.rb
+++ b/test/functional/mod_actions_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class ModActionsControllerTest < ActionController::TestCase
+  context "The mod actions controller" do
+    context "index action" do
+      should "work" do
+        get :index
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/moderator/post/posts_controller_test.rb
+++ b/test/functional/moderator/post/posts_controller_test.rb
@@ -3,42 +3,98 @@ require 'test_helper'
 module Moderator
   module Post
     class PostsControllerTest < ActionController::TestCase
-      context "The moderator post disapprovals controller" do
+      context "The moderator posts controller" do
         setup do
           @admin = FactoryGirl.create(:admin_user)
           CurrentUser.user = @admin
           CurrentUser.ip_addr = "127.0.0.1"
+          @post = FactoryGirl.create(:post)
+        end
+
+        context "confirm_delete action" do
+          should "render" do
+            get :confirm_delete, { id: @post.id }, { user_id: @admin.id }
+            assert_response :success
+          end
         end
 
         context "delete action" do
-          setup do
-            @post = FactoryGirl.create(:post)
-          end
-
           should "render" do
             post :delete, {:id => @post.id, :reason => "xxx", :format => "js", :commit => "Delete"}, {:user_id => @admin.id}
-            @post.reload
-            assert(@post.is_deleted?)
+            assert(@post.reload.is_deleted?)
           end
 
           should "work even if the deleter has flagged the post previously" do
             PostFlag.create(:post => @post, :reason => "aaa", :is_resolved => false)
             post :delete, {:id => @post.id, :reason => "xxx", :format => "js", :commit => "Delete"}, {:user_id => @admin.id}
-            @post.reload
-            assert(@post.is_deleted?)
+            assert(@post.reload.is_deleted?)
           end
         end
 
         context "undelete action" do
-          setup do
-            @post = FactoryGirl.create(:post, :is_deleted => true)
-          end
-
           should "render" do
+            @post.update(is_deleted: true)
             post :undelete, {:id => @post.id, :format => "js"}, {:user_id => @admin.id}
+
             assert_response :success
-            @post.reload
-            assert(!@post.is_deleted?)
+            assert(!@post.reload.is_deleted?)
+          end
+        end
+
+        context "confirm_move_favorites action" do
+          should "render" do
+            get :confirm_move_favorites, { id: @post.id }, { user_id: @admin.id }
+            assert_response :success
+          end
+        end
+
+        context "move_favorites action" do
+          should "render" do
+            parent = FactoryGirl.create(:post)
+            child = FactoryGirl.create(:post, parent: parent)
+            users = FactoryGirl.create_list(:user, 2)
+            users.each { |u| child.add_favorite!(u) }
+
+            put :move_favorites, { id: child.id, commit: "Submit" }, { user_id: @admin.id }
+
+            assert_redirected_to(child)
+            assert_equal(users, parent.reload.favorited_users)
+            assert_equal([], child.reload.favorited_users)
+          end
+        end
+
+        context "expunge action" do
+          should "render" do
+            put :expunge, { id: @post.id, format: "js" }, { user_id: @admin.id }
+
+            assert_response :success
+            assert_equal(false, ::Post.exists?(@post.id))
+          end
+        end
+
+        context "confirm_ban action" do
+          should "render" do
+            get :confirm_ban, { id: @post.id }, { user_id: @admin.id }
+            assert_response :success
+          end
+        end
+
+        context "ban action" do
+          should "render" do
+            put :ban, { id: @post.id, commit: "Ban", format: "js" }, { user_id: @admin.id }
+
+            assert_response :success
+            assert_equal(true, @post.reload.is_banned?)
+          end
+        end
+
+        context "unban action" do
+          should "render" do
+            @post.ban!
+            put :unban, { id: @post.id, format: "js" }, { user_id: @admin.id }
+
+            assert_redirected_to(@post)
+            assert_equal(false, @post.reload.is_banned?)
           end
         end
       end

--- a/test/functional/moderator/post/queues_controller_test.rb
+++ b/test/functional/moderator/post/queues_controller_test.rb
@@ -18,6 +18,13 @@ module Moderator
             assert_response :success
           end
         end
+
+        context "random action" do
+          should "render" do
+            get :random, {}, {:user_id => @admin.id}
+            assert_response :success
+          end
+        end
       end
     end
   end

--- a/test/functional/note_previews_controller_test.rb
+++ b/test/functional/note_previews_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class NotePreviewsControllerTest < ActionController::TestCase
+  context "The note previews controller" do
+    context "show action" do
+      should "work" do
+        get :show, { body: "<b>test</b>", format: "json" }
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/pools_controller_test.rb
+++ b/test/functional/pools_controller_test.rb
@@ -49,11 +49,35 @@ class PoolsControllerTest < ActionController::TestCase
       end
     end
 
+    context "gallery action" do
+      should "render" do
+        pool = FactoryGirl.create(:pool)
+        get :gallery, {:id => pool.id}
+        assert_response :success
+      end
+    end
+
+    context "new action" do
+      should "render" do
+        get :new, {}, { user_id: @user.id }
+        assert_response :success
+      end
+    end
+
     context "create action" do
       should "create a pool" do
         assert_difference("Pool.count", 1) do
           post :create, {:pool => {:name => "xxx", :description => "abc"}}, {:user_id => @user.id}
         end
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        pool = FactoryGirl.create(:pool)
+
+        get :edit, { id: pool.id }, { user_id: @user.id }
+        assert_response :success
       end
     end
 

--- a/test/functional/posts_controller_test.rb
+++ b/test/functional/posts_controller_test.rb
@@ -89,6 +89,32 @@ class PostsControllerTest < ActionController::TestCase
           assert_response :success
         end
       end
+
+      context "with an md5 param" do
+        should "render" do
+          get :index, { md5: @post.md5 }
+          assert_redirected_to(@post)
+        end
+      end
+    end
+
+    context "show_seq action" do
+      should "render" do
+        posts = FactoryGirl.create_list(:post, 3)
+
+        get :show_seq, { seq: "prev", id: posts[1].id }
+        assert_redirected_to(posts[2])
+
+        get :show_seq, { seq: "next", id: posts[1].id }
+        assert_redirected_to(posts[0])
+      end
+    end
+
+    context "random action" do
+      should "render" do
+        get :random, { tags: "aaaa" }
+        assert_redirected_to(post_path(@post, tags: "aaaa"))
+      end
     end
 
     context "show action" do

--- a/test/functional/related_tags_controller_test.rb
+++ b/test/functional/related_tags_controller_test.rb
@@ -1,7 +1,12 @@
 require 'test_helper'
 
 class RelatedTagsControllerTest < ActionController::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  context "The related tags controller" do
+    context "show action" do
+      should "work" do
+        get :show, { query: "touhou" }
+        assert_response :success
+      end
+    end
+  end
 end

--- a/test/functional/reports_controller_test.rb
+++ b/test/functional/reports_controller_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class ReportsControllerTest < ActionController::TestCase
+  setup do
+    CurrentUser.user = FactoryGirl.create(:mod_user)
+    CurrentUser.ip_addr = "127.0.0.1"
+    session[:user_id] = CurrentUser.user.id
+
+    @users = FactoryGirl.create_list(:contributor_user, 2)
+    @posts = @users.map { |u| FactoryGirl.create(:post, uploader: u) }
+  end
+
+  teardown do
+    CurrentUser.user = nil
+    CurrentUser.ip_addr = nil
+    session[:user_id] = nil
+  end
+
+  context "The reports controller" do
+    context "user_promotions action" do
+      should "render" do
+        get :user_promotions
+        assert_response :success
+      end
+    end
+
+    context "janitor_trials action" do
+      should "render" do
+        get :janitor_trials
+        assert_response :success
+      end
+    end
+
+    context "contributors action" do
+      should "render" do
+        get :contributors
+        assert_response :success
+      end
+    end
+
+    context "uploads action" do
+      should "render" do
+        get :uploads
+        assert_response :success
+      end
+    end
+
+    context "similar_users action" do
+      should "render" do
+        #get :similar_users
+        #assert_response :success
+      end
+    end
+
+    context "post_versions action" do
+      should "render" do
+        get :post_versions
+        assert_response :success
+      end
+    end
+
+    context "post_versions_create action" do
+      should "render" do
+        #post :post_versions_create, { tag: "touhou", type: "added" }
+        #assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/saved_searches_controller_test.rb
+++ b/test/functional/saved_searches_controller_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+require 'helpers/saved_search_test_helper'
+
+class SavedSearchesControllerTest < ActionController::TestCase
+  include SavedSearchTestHelper
+
+  context "The saved searches controller" do
+    setup do
+      @user = FactoryGirl.create(:user)
+      CurrentUser.user = @user
+      CurrentUser.ip_addr = "127.0.0.1"
+      mock_saved_search_service!
+    end
+
+    context "index action" do
+      should "render" do
+        get :index, {}, { user_id: @user.id }
+        assert_response :success
+      end
+    end
+
+    context "create action" do
+      should "render" do
+        params = { saved_search_tags: "bkub", saved_search_category: "artist" }
+
+        post :create, params, { user_id: @user.id }
+        assert_response :redirect
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        saved_search = FactoryGirl.create(:saved_search, user: @user)
+
+        get :edit, { id: saved_search.id }, { user_id: @user.id }
+        assert_response :success
+      end
+    end
+
+    context "update action" do
+      should "render" do
+        saved_search = FactoryGirl.create(:saved_search, user: @user)
+        params = { id: saved_search.id, saved_search: { category: "foo" } }
+
+        put :update, params, { user_id: @user.id }
+        assert_redirected_to saved_searches_path
+        assert_equal("foo", saved_search.reload.category)
+      end
+    end
+
+    context "destroy action" do
+      should "render" do
+        saved_search = FactoryGirl.create(:saved_search, user: @user)
+
+        delete :destroy, { id: saved_search.id }, { user_id: @user.id }
+        assert_redirected_to saved_searches_path
+      end
+    end
+  end
+end

--- a/test/functional/sources_controller_test.rb
+++ b/test/functional/sources_controller_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class SourcesControllerTest < ActionController::TestCase
+  context "The sources controller" do
+    context "show action" do
+      should "work" do
+        get :show, { url: "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=14901720", format: "json" }
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/tags_controller_test.rb
+++ b/test/functional/tags_controller_test.rb
@@ -26,7 +26,7 @@ class TagsControllerTest < ActionController::TestCase
 
     context "index action" do
       setup do
-        @tag = FactoryGirl.create(:tag, :name => "aaa")
+        @tag = FactoryGirl.create(:tag, name: "aaa", post_count: 1)
       end
 
       should "render" do
@@ -39,6 +39,15 @@ class TagsControllerTest < ActionController::TestCase
           get :index, {:search => {:name_matches => "aaa"}}
           assert_response :success
         end
+      end
+    end
+
+    context "autocomplete action" do
+      should "render" do
+        FactoryGirl.create(:tag, name: "touhou", post_count: 1)
+
+        get :autocomplete, { search: { name_matches: "t" }, format: :json }
+        assert_response :success
       end
     end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -13,28 +13,44 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     context "index action" do
-      setup do
-        FactoryGirl.create(:user, :name => "abc")
-      end
-
       should "list all users" do
         get :index
         assert_response :success
       end
 
+      should "list all users for /users?name=<name>" do
+        get :index, { name: @user.name }
+        assert_redirected_to(@user)
+      end
+
+      should "raise error for /users?name=<nonexistent>" do
+        get :index, { name: "nobody" }
+        assert_response :error
+      end
+
       should "list all users (with search)" do
-        get :index, {:search => {:name_matches => "abc"}}
+        get :index, {:search => {:name_matches => @user.name}}
         assert_response :success
       end
     end
 
     context "show action" do
       setup do
-        @user = FactoryGirl.create(:user)
+        # flesh out profile to get more test coverage of user presenter.
+        @user = FactoryGirl.create(:banned_user, can_approve_posts: true, is_super_voter: true)
+        FactoryGirl.create(:saved_search, user: @user)
+        FactoryGirl.create(:post, uploader: @user, tag_string: "fav:#{@user.name}")
       end
 
       should "render" do
         get :show, {:id => @user.id}
+        assert_response :success
+      end
+    end
+
+    context "new action" do
+      should "render" do
+        get :new
         assert_response :success
       end
     end

--- a/test/functional/wiki_page_versions_controller_test.rb
+++ b/test/functional/wiki_page_versions_controller_test.rb
@@ -6,6 +6,10 @@ class WikiPageVersionsControllerTest < ActionController::TestCase
       @user = FactoryGirl.create(:user)
       CurrentUser.user = @user
       CurrentUser.ip_addr = "127.0.0.1"
+
+      @wiki_page = FactoryGirl.create(:wiki_page)
+      @wiki_page.update_attributes(:body => "1 2")
+      @wiki_page.update_attributes(:body => "2 3")
     end
 
     teardown do
@@ -14,12 +18,6 @@ class WikiPageVersionsControllerTest < ActionController::TestCase
     end
 
     context "index action" do
-      setup do
-        @wiki_page = FactoryGirl.create(:wiki_page)
-        @wiki_page.update_attributes(:body => "1 2")
-        @wiki_page.update_attributes(:body => "2 3")
-      end
-
       should "list all versions" do
         get :index
         assert_response :success
@@ -30,6 +28,20 @@ class WikiPageVersionsControllerTest < ActionController::TestCase
         get :index, {:search => {:wiki_page_id => @wiki_page.id}}
         assert_response :success
         assert_not_nil(assigns(:wiki_page_versions))
+      end
+    end
+
+    context "show action" do
+      should "render" do
+        get :show, { id: @wiki_page.versions.first.id }
+        assert_response :success
+      end
+    end
+
+    context "diff action" do
+      should "render" do
+        get :diff, { thispage: @wiki_page.versions.first.id, otherpage: @wiki_page.versions.last.id }
+        assert_response :success
       end
     end
   end

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -40,9 +40,51 @@ class WikiPagesControllerTest < ActionController::TestCase
         assert_response :success
       end
 
+      should "render for a title" do
+        get :show, {:id => @wiki_page.title}
+        assert_response :success
+      end
+
+      should "redirect for a nonexistent title" do
+        get :show, {:id => "what"}
+        assert_redirected_to(show_or_new_wiki_pages_path(title: "what"))
+      end
+
       should "render for a negated tag" do
         @wiki_page.update_attribute(:title, "-aaa")
         get :show, {:id => @wiki_page.id}
+        assert_response :success
+      end
+    end
+
+    context "show_or_new action" do
+      setup do
+        @wiki_page = FactoryGirl.create(:wiki_page)
+      end
+
+      should "redirect when given a title" do
+        get :show_or_new, { title: @wiki_page.title }
+        assert_redirected_to(@wiki_page)
+      end
+
+      should "render when given a nonexistent title" do
+        get :show_or_new, { title: "what" }
+        assert_response :success
+      end
+    end
+
+    context "new action" do
+      should "render" do
+        get :new, {}, { user_id: @mod.id }
+        assert_response :success
+      end
+    end
+
+    context "edit action" do
+      should "render" do
+        wiki_page = FactoryGirl.create(:wiki_page)
+
+        get :edit, { id: wiki_page.id }, { user_id: @mod.id }
         assert_response :success
       end
     end

--- a/test/helpers/iqdb_test_helper.rb
+++ b/test/helpers/iqdb_test_helper.rb
@@ -16,5 +16,16 @@ module IqdbTestHelper
 
     service = mock_sqs_service.new
     Post.stubs(:iqdb_sqs_service).returns(service)
+
+    Danbooru.config.stubs(:iqdbs_auth_key).returns("hunter2")
+    Danbooru.config.stubs(:iqdbs_server).returns("http://localhost:3004")
+  end
+
+  def mock_iqdb_matches!(post_or_source, matches)
+    source = post_or_source.is_a?(Post) ? post_or_source.complete_preview_file_url : post_or_source
+    url = "http://localhost:3004/similar?key=hunter2&url=#{CGI.escape source}&ref"
+    body = matches.map { |post| { post_id: post.id } }.to_json
+
+    FakeWeb.register_uri(:get, url, body: body)
   end
 end

--- a/test/helpers/reportbooru_helper.rb
+++ b/test/helpers/reportbooru_helper.rb
@@ -1,0 +1,12 @@
+module ReportbooruHelper
+  def mock_popular_search_service!
+    Danbooru.config.stubs(:reportbooru_server).returns("http://localhost:3003")
+    FakeWeb.register_uri(:get, "http://localhost:3003/hits/month?date=#{Date.today}", body: "kantai_collection 1000.0\ntouhou 500.0")
+    FakeWeb.register_uri(:get, "http://localhost:3003/hits/day?date=#{Date.today}", body: "kantai_collection 1000.0\ntouhou 500.0")
+  end
+
+  def mock_missed_search_service!
+    Danbooru.config.stubs(:reportbooru_server).returns("http://localhost:3003")
+    FakeWeb.register_uri(:get, "http://localhost:3003/missed_searches", body: "kantai_collection 1000.0\ntouhou 500.0")
+  end
+end

--- a/test/helpers/saved_search_test_helper.rb
+++ b/test/helpers/saved_search_test_helper.rb
@@ -16,6 +16,7 @@ module SavedSearchTestHelper
 
     service = mock_sqs_service.new
     SavedSearch.stubs(:sqs_service).returns(service)
+    SavedSearch.stubs(:update_listbooru_on_create)
     Danbooru.config.stubs(:aws_sqs_saved_search_url).returns("http://localhost:3002")
     Danbooru.config.stubs(:listbooru_auth_key).returns("blahblahblah")
     Danbooru.config.stubs(:listbooru_server).returns("http://localhost:3001")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,3 +26,13 @@ end
 
 MEMCACHE = MemcacheMock.new
 Delayed::Worker.delay_jobs = false
+
+require "helpers/reportbooru_helper"
+class ActiveSupport::TestCase
+  include ReportbooruHelper
+
+  setup do
+    mock_popular_search_service!
+    mock_missed_search_service!
+  end
+end

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2039,7 +2039,7 @@ class PostTest < ActiveSupport::TestCase
 
     context "a post that has been updated" do
       setup do
-        @post = FactoryGirl.create(:post, :rating => "q", :tag_string => "aaa")
+        @post = FactoryGirl.create(:post, :rating => "q", :tag_string => "aaa", :source => nil)
         @post.stubs(:merge_version?).returns(false)
         @post.update_attributes(:tag_string => "aaa bbb ccc ddd")
         @post.update_attributes(:tag_string => "bbb xxx yyy", :source => "xyz")

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -208,4 +208,14 @@ class TagTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "A tag with a negative post count" do
+    should "be fixed" do
+      tag = FactoryGirl.create(:tag, name: "touhou", post_count: -10)
+      post = FactoryGirl.create(:post, tag_string: "touhou")
+
+      Tag.clean_up_negative_post_counts!
+      assert_equal(1, tag.reload.post_count)
+    end
+  end
 end


### PR DESCRIPTION
This adds a bunch of tests intended to increase controller test coverage. It's a lot of code, but most of the tests are fairly rote. Coverage is improved from ~58% to ~75%.

35b3398 also adds missing tests for metatag searches, so that the tag searching code should now have near full coverage.

The one functional change is that [/admin/dashboard](http://danbooru.donmai.us/admin/dashboard) is made public. That page doesn't have any sensitive info, it's just a combined listing of pending aliases/implications/BURs plus a forum listing.