### PR TITLE
Fix: Incorrect Relative Links for User Feedbacks #2887

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,9 +49,9 @@ module ApplicationHelper
     raw %{<a href="#{h(url)}" #{attributes}>#{text}</a>}
   end
 
-  def format_text(text, options = {})
-    if options[:ragel]
-      raw(DTextRagel.parse(text))
+  def format_text(text, ragel: true, **options)
+    if ragel
+      raw DTextRagel.parse(text, **options)
     else
       DText.parse(text)
     end

--- a/app/views/user_mailer/dmail_notice.html.erb
+++ b/app/views/user_mailer/dmail_notice.html.erb
@@ -1,10 +1,10 @@
 <!doctype html>
 <html>
 <body>
-<p><%= h @dmail.from.name %> said:</p>
+<p><%= @dmail.from.name %> said:</p>
 
-<div>
-  <%= DText.parse(@dmail.body) %>
+<div class="prose">
+  <%= format_text(@dmail.body, base_url: root_url) %>
 </div>
 
 <p><%= link_to "View message", dmail_url(@dmail, :host => Danbooru.config.hostname, :only_path => false) %> | <%= link_to "Unsubscribe", maintenance_user_email_notification_url(:user_id => @dmail.owner.id, :sig => email_sig(@dmail.owner), :host => Danbooru.config.hostname, :only_path => false) %></p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,12 @@ module Danbooru
     else
       config.x.git_hash = nil
     end
+
+    config.after_initialize do
+      Rails.application.routes.default_url_options = {
+        host: Danbooru.config.hostname,
+      }
+    end
   end
 
   I18n.enforce_available_locales = false

--- a/test/mailers/previews/user_mailer_preview.rb
+++ b/test/mailers/previews/user_mailer_preview.rb
@@ -1,0 +1,6 @@
+class UserMailerPreview < ActionMailer::Preview
+  def dmail_notice
+    dmail = User.admins.first.dmails.first
+    UserMailer.dmail_notice(dmail)
+  end
+end


### PR DESCRIPTION
Fixes #2887. Depends on https://github.com/r888888888/dtext_rb/pull/12. This makes the email notice you get when you receive a dmail use absolute urls instead of relative urls.

You can preview the mailer by going to `/rails/mailers` (you'll need to disable the `*other -> not_found` route for this to work).