### PR TITLE
Dmails: add indexes on is_read and is_deleted (fix #2886)

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -85,7 +85,7 @@
       <%= render "users/ban_notice" %>
     <% end %>
 
-    <% if CurrentUser.dmail_count.present? && CurrentUser.dmails.unread.present? && cookies[:hide_dmail_notice].to_i != CurrentUser.dmails.unread.first.id %>
+    <% if CurrentUser.has_mail? && CurrentUser.dmails.unread.first.present? && cookies[:hide_dmail_notice].to_i != CurrentUser.dmails.unread.first.id %>
       <%= render "users/dmail_notice" %>
     <% end %>
 

--- a/db/migrate/20170218104710_add_indexes_to_dmails.rb
+++ b/db/migrate/20170218104710_add_indexes_to_dmails.rb
@@ -1,0 +1,7 @@
+class AddIndexesToDmails < ActiveRecord::Migration
+  def change
+    execute "set statement_timeout = 0"
+    add_index :dmails, :is_read
+    add_index :dmails, :is_deleted
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -5085,6 +5085,20 @@ CREATE INDEX index_dmails_on_creator_ip_addr ON dmails USING btree (creator_ip_a
 
 
 --
+-- Name: index_dmails_on_is_deleted; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dmails_on_is_deleted ON dmails USING btree (is_deleted);
+
+
+--
+-- Name: index_dmails_on_is_read; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_dmails_on_is_read ON dmails USING btree (is_read);
+
+
+--
 -- Name: index_dmails_on_message_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7449,4 +7463,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170112021922');
 INSERT INTO schema_migrations (version) VALUES ('20170112060921');
 
 INSERT INTO schema_migrations (version) VALUES ('20170117233040');
+
+INSERT INTO schema_migrations (version) VALUES ('20170218104710');
 


### PR DESCRIPTION
Adds indexes on dmails and slightly optimizes the dmail notice logic (should shave off a couple sql queries).