### PR TITLE
modqueue: link tags, optimize sql, use dtext in disapproval reasons.

### DIFF
--- a/app/controllers/moderator/post/queues_controller.rb
+++ b/app/controllers/moderator/post/queues_controller.rb
@@ -15,7 +15,7 @@ module Moderator
         end
 
         ::Post.without_timeout do
-          @posts = ::Post.order("posts.id asc").pending_or_flagged.available_for_moderation(params[:hidden]).tag_match(params[:query]).paginate(params[:page], :limit => per_page)
+          @posts = ::Post.includes(:disapprovals, :uploader).order("posts.id asc").pending_or_flagged.available_for_moderation(params[:hidden]).tag_match(params[:query]).paginate(params[:page], :limit => per_page)
           @posts.each # hack to force rails to eager load
         end
         respond_with(@posts)
@@ -25,7 +25,7 @@ module Moderator
         cookies.permanent[:moderated] = Time.now.to_i
 
         ::Post.without_timeout do
-          @posts = ::Post.order("posts.id asc").pending_or_flagged.available_for_moderation(false).reorder("random()").limit(RANDOM_COUNT)
+          @posts = ::Post.includes(:disapprovals, :uploader).order("posts.id asc").pending_or_flagged.available_for_moderation(false).reorder("random()").limit(RANDOM_COUNT)
           @posts.each # hack to force rails to eager load
 
           if @posts.empty?

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -95,6 +95,10 @@ class PostPresenter < Presenter
     @post = post
   end
 
+  def tag_set_presenter
+    @tag_set_presenter ||= TagSetPresenter.new(@post.tag_array)
+  end
+
   def preview_html
     PostPresenter.preview(@post)
   end
@@ -170,13 +174,15 @@ class PostPresenter < Presenter
   end
 
   def tag_list_html(template, options = {})
-    @tag_set_presenter ||= TagSetPresenter.new(@post.tag_array)
-    @tag_set_presenter.tag_list_html(template, options.merge(:show_extra_links => CurrentUser.user.is_gold?))
+    tag_set_presenter.tag_list_html(template, options.merge(:show_extra_links => CurrentUser.user.is_gold?))
   end
 
   def split_tag_list_html(template, options = {})
-    @tag_set_presenter ||= TagSetPresenter.new(@post.tag_array)
-    @tag_set_presenter.split_tag_list_html(template, options.merge(:show_extra_links => CurrentUser.user.is_gold?))
+    tag_set_presenter.split_tag_list_html(template, options.merge(:show_extra_links => CurrentUser.user.is_gold?))
+  end
+
+  def inline_tag_list_html(template)
+    tag_set_presenter.inline_tag_list(template)
   end
 
   def has_nav_links?(template)

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -64,6 +64,17 @@ class TagSetPresenter < Presenter
     html.html_safe
   end
 
+  # compact (horizontal) list, as seen in the /comments index.
+  def inline_tag_list(template)
+    @tags.map do |tag_name|
+      <<-EOS
+        <span class="category-#{Tag.category_for(tag_name)}">
+          #{template.link_to(tag_name.tr("_", " "), template.posts_path(tags: tag_name))}
+        </span>
+      EOS
+    end.join.html_safe
+  end
+
 private
   def general_tags
     @general_tags ||= categories.select {|k, v| v == Tag.categories.general}

--- a/app/views/comments/partials/index/_header.html.erb
+++ b/app/views/comments/partials/index/_header.html.erb
@@ -24,11 +24,7 @@
   </div>
   <div class="row list-of-tags">
     <strong>Tags</strong>
-    <% post.tag_array.each do |tag_name| %>
-      <span class="category-<%= Tag.category_for(tag_name) %>">
-        <%= link_to(tag_name.tr("_", " "), posts_path(:tags => tag_name)) %>
-      </span>
-    <% end %>
+    <%= post.presenter.inline_tag_list_html(self) %>
   </div>
 </div>
 

--- a/app/views/moderator/post/queues/show.html.erb
+++ b/app/views/moderator/post/queues/show.html.erb
@@ -60,7 +60,7 @@
                 <strong>Hidden</strong>: <%= render "post_disapprovals/compact_counts", :disapprovals => post.disapprovals, :post => post %>
               </li>
               <li><strong>Source</strong>: <%= post.source %></li>
-              <li><strong>Tags</strong>: <%= post.tag_string %></li>
+              <li><strong>Tags</strong>: <%= post.presenter.inline_tag_list_html(self) %></li>
             </ul>
           </section>
         </div>

--- a/app/views/post_disapprovals/_compact_counts.html.erb
+++ b/app/views/post_disapprovals/_compact_counts.html.erb
@@ -1,17 +1,17 @@
-<% if disapprovals.count > 0 && (CurrentUser.can_approve_posts? || post.created_at < 3.days.ago) %>
-  <% if disapprovals.breaks_rules.count > 0 %>
-    (breaks rules: <%= disapprovals.breaks_rules.count %>)
+<% if CurrentUser.can_approve_posts? || post.created_at < 3.days.ago %>
+  <% if disapprovals.map(&:reason).grep("breaks_rules").count > 0 %>
+    (breaks rules: <%= disapprovals.map(&:reason).grep("breaks_rules").count %>)
   <% end %>
 
-  <% if disapprovals.poor_quality.count > 0 %>
-    (poor quality: <%= disapprovals.poor_quality.count %>)
+  <% if disapprovals.map(&:reason).grep("poor_quality").count > 0 %>
+    (poor quality: <%= disapprovals.map(&:reason).grep("poor_quality").count %>)
   <% end %>
 
-  <% if disapprovals.disinterest.count > 0 %>
-    (no interest: <%= disapprovals.disinterest.count %>)
+  <% if disapprovals.map(&:reason).grep(/disinterest|legacy/).count > 0 %>
+    (no interest: <%= disapprovals.map(&:reason).grep(/disinterest|legacy/).count %>)
   <% end %>
 
-  <% if disapprovals.with_message.any? %>
+  <% if disapprovals.map(&:message).any?(&:present?) %>
     (messages: <%= disapprovals.map(&:message).select(&:present?).map { |msg| format_text(msg, ragel: true, inline: true) }.to_sentence.html_safe %>)
   <% end %>
 <% end %>

--- a/app/views/post_disapprovals/_compact_counts.html.erb
+++ b/app/views/post_disapprovals/_compact_counts.html.erb
@@ -12,6 +12,6 @@
   <% end %>
 
   <% if disapprovals.with_message.any? %>
-    (messages: <%= disapprovals.disinterest.with_message.map(&:message).to_sentence %>)
+    (messages: <%= disapprovals.map(&:message).select(&:present?).map { |msg| format_text(msg, ragel: true, inline: true) }.to_sentence.html_safe %>)
   <% end %>
 <% end %>

--- a/app/views/post_disapprovals/_counts.html.erb
+++ b/app/views/post_disapprovals/_counts.html.erb
@@ -1,20 +1,20 @@
-<% if disapprovals.count > 0 && (CurrentUser.can_approve_posts? || post.created_at < 3.days.ago) %>
+<% if CurrentUser.can_approve_posts? || post.created_at < 3.days.ago %>
   <p>
-    It has been reviewed by <%= pluralize disapprovals.count, "moderator" %>. 
+    It has been reviewed by <%= pluralize disapprovals.length, "moderator" %>. 
 
-    <% if disapprovals.breaks_rules.count > 0 %>
-      <%= disapprovals.breaks_rules.count %> believe it breaks the rules.
+    <% if disapprovals.map(&:reason).grep("breaks_rules").count > 0 %>
+      <%= disapprovals.map(&:reason).grep("breaks_rules").count %> believe it breaks the rules.
     <% end %>
 
-    <% if disapprovals.poor_quality.count > 0 %>
-      <%= disapprovals.poor_quality.count %> believe it has poor quality.
+    <% if disapprovals.map(&:reason).grep("poor_quality").count > 0 %>
+      <%= disapprovals.map(&:reason).grep("poor_quality").count %> believe it has poor quality.
     <% end %>
 
-    <% if disapprovals.disinterest.count > 0 %>
-      <%= disapprovals.disinterest.count %> did not like the post enough to approve it.
+    <% if disapprovals.map(&:reason).grep(/disinterest|legacy/).count > 0 %>
+      <%= disapprovals.map(&:reason).grep(/disinterest|legacy/).count %> did not like the post enough to approve it.
     <% end %>
 
-    <% if disapprovals.with_message.any? %>
+    <% if disapprovals.map(&:message).any?(&:present?) %>
       Messages: <%= disapprovals.map(&:message).select(&:present?).map { |msg| format_text(msg, ragel: true, inline: true) }.to_sentence.html_safe %>.
     <% end %>
   </p>

--- a/app/views/post_disapprovals/_counts.html.erb
+++ b/app/views/post_disapprovals/_counts.html.erb
@@ -15,7 +15,7 @@
     <% end %>
 
     <% if disapprovals.with_message.any? %>
-      Messages: <%= disapprovals.with_message.map(&:message).to_sentence %>
+      Messages: <%= disapprovals.map(&:message).select(&:present?).map { |msg| format_text(msg, ragel: true, inline: true) }.to_sentence.html_safe %>.
     <% end %>
   </p>
 <% end %>


### PR DESCRIPTION
This does several things:

* formats detailed disapproval messages using dtext on the `/posts/NNN` page and in the modqueue.
* in the modqueue, shows detailed disapproval messages for all disapproval types (disinterest/breaks rules/poor quality). Currently only distinterest messages are shown for some reason?
* fixes a minor N+1 queries problem on the modqueue page. Reduces the total number of sql queries on that page from 47 to 13.
* formats tag lists as colorized links, like in the `/comments` index.