### PR TITLE
Send @mention dmails from DanbooruBot

### DIFF
--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -381,5 +381,12 @@ class DText
       })
     )
   end
+
+  # extract the first paragraph `needle` occurs in.
+  def self.excerpt(dtext, needle)
+    dtext = dtext.gsub(/\r\n|\r|\n/, "\n")
+    excerpt = ActionController::Base.helpers.excerpt(dtext, needle, separator: "\n\n", radius: 1, omission: "")
+    excerpt
+  end
 end
 

--- a/app/logical/mentionable.rb
+++ b/app/logical/mentionable.rb
@@ -39,17 +39,17 @@ module Mentionable
   end
 
   def queue_mention_messages
-    title = self.class.mentionable_option(:title)
     from_id = read_attribute(self.class.mentionable_option(:user_field))
     text = strip_quote_blocks(read_attribute(self.class.mentionable_option(:message_field)))
-    bodies = {}
 
-    text.scan(DText::MENTION_REGEXP).each do |mention|
+    names = text.scan(DText::MENTION_REGEXP).map do |mention|
       mention.gsub!(/(?:^\s*@)|(?:[:;,.!?\)\]<>]$)/, "")
-      bodies[mention] = self.class.mentionable_option(:body).call(self, mention)
     end
 
-    bodies.each do |name, text|
+    names.uniq.each do |name|
+      body  = self.instance_exec(name, &self.class.mentionable_option(:body))
+      title = self.instance_exec(name, &self.class.mentionable_option(:title))
+
       Dmail.create_automated(to_name: name, title: title, body: body)
     end
   end

--- a/app/logical/mentionable.rb
+++ b/app/logical/mentionable.rb
@@ -50,18 +50,7 @@ module Mentionable
     end
 
     bodies.each do |name, text|
-      user = User.find_by_name(name)
-
-      if user
-        dmail = Dmail.new(
-          from_id: from_id,
-          to_id: user.id,
-          title: title,
-          body: text
-        )
-        dmail.owner_id = user.id
-        dmail.save
-      end
+      Dmail.create_automated(to_name: name, title: title, body: body)
     end
   end
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -23,9 +23,9 @@ class Comment < ActiveRecord::Base
   mentionable(
     :message_field => :body, 
     :user_field => :creator_id, 
-    :title => "You were mentioned in a comment",
-    :body => lambda {|rec, user_name| "You were mentioned in a \"comment\":/posts/#{rec.post_id}#comment-#{rec.id}\n\n---\n\n[i]#{rec.creator.name} said:[/i]\n\n#{ActionController::Base.helpers.excerpt(rec.body, user_name)}"}
-    )
+    :title => lambda {|user_name| "#{creator_name} mentioned you in a comment on post ##{post_id}"},
+    :body => lambda {|user_name| "@#{creator_name} mentioned you in a \"comment\":/posts/#{post_id}#comment-#{id} on post ##{post_id}:\n\n[quote]\n#{DText.excerpt(body, "@"+user_name)}\n[/quote]\n"},
+  )
 
   module SearchMethods
     def recent

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -61,7 +61,10 @@ class Dmail < ActiveRecord::Base
       end
 
       def create_automated(params)
-        create_split(from: Danbooru.config.system_user, **params)
+        dmail = Dmail.new(from: Danbooru.config.system_user, **params)
+        dmail.owner = dmail.to
+        dmail.save
+        dmail
       end
     end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -28,8 +28,8 @@ class ForumPost < ActiveRecord::Base
   mentionable(
     :message_field => :body, 
     :user_field => :creator_id, 
-    :title => "You were mentioned in a forum topic",
-    :body => lambda {|rec, user_name| "You were mentioned in the forum topic \"#{rec.topic.title}\":/forum_topics/#{rec.topic_id}?page=#{rec.forum_topic_page}\n\n---\n\n[i]#{rec.creator.name} said:[/i]\n\n#{ActionController::Base.helpers.excerpt(rec.body, user_name)}"}
+    :title => lambda {|user_name| %{#{creator_name} mentioned you in topic ##{topic_id} (#{topic.title})}},
+    :body => lambda {|user_name| %{@#{creator_name} mentioned you in topic ##{topic_id} ("#{topic.title}":[/forum_topics/#{topic_id}?page=#{forum_topic_page}]):\n\n[quote]\n#{DText.excerpt(body, "@"+user_name)}\n[/quote]\n}},
   )
 
   module SearchMethods

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -57,7 +57,13 @@ class CommentTest < ActiveSupport::TestCase
           end
 
           dmail = Dmail.last
-          assert_equal("You were mentioned in a \"comment\":/posts/#{@comment.post_id}#comment-#{@comment.id}\n\n---\n\n[i]#{CurrentUser.name} said:[/i]\n\nHey @#{@user2.name} check this out!", dmail.body)
+          assert_equal(<<-EOS.strip_heredoc, dmail.body)
+            @#{CurrentUser.name} mentioned you in a \"comment\":/posts/#{@comment.post_id}#comment-#{@comment.id} on post ##{@comment.post_id}:
+
+            [quote]
+            Hey @#{@user2.name} check this out!
+            [/quote]
+          EOS
         end
       end
     end

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -51,7 +51,13 @@ class ForumPostTest < ActiveSupport::TestCase
           end
 
           dmail = Dmail.last
-          assert_equal("You were mentioned in the forum topic \"#{@topic.title}\":/forum_topics/#{@topic.id}?page=1\n\n---\n\n[i]#{@user.name} said:[/i]\n\nHey @#{@user2.name} check this out!", dmail.body)
+          assert_equal(<<-EOS.strip_heredoc, dmail.body)
+            @#{CurrentUser.name} mentioned you in topic ##{@topic.id} (\"#{@topic.title}\":[/forum_topics/#{@topic.id}?page=1]):
+
+            [quote]
+            Hey @#{@user2.name} check this out!
+            [/quote]
+          EOS
         end
       end
     end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -31,12 +31,11 @@ class UserTest < ActiveSupport::TestCase
         bot = FactoryGirl.create(:user)
         Danbooru.config.stubs(:system_user).returns(bot)
 
-        assert_difference("Dmail.count", 2) do
+        assert_difference("Dmail.count", 1) do
           @user.promote_to!(User::Levels::GOLD)
         end
 
         assert(@user.dmails.exists?(from: bot, to: @user, title: "You have been promoted"))
-        assert(bot.dmails.exists?(from: bot, to: @user, title: "You have been promoted"))
       end
     end
 


### PR DESCRIPTION
Continuing on http://danbooru.donmai.us/forum_topics/13760:

6994231: send \@mention dmails from DanbooruBot instead of the mentioner.
6e3ddb6: don't save copies of dmails sent by DanbooruBot in DanbooruBot's outbox.
46280f2: include the mentioner in the subject line of the dmail. The template is this:

```
Subject:

    #{creator_name} mentioned you in a comment on post ##{post_id}

Body:

    @#{creator_name} mentioned you in a \"comment\":/posts/#{post_id}#comment-#{id} on post ##{post_id}:

    [quote]
    #{DText.excerpt(body, "@"+user_name)}
    [/quote]
```

Also changes the excerpt to be the paragraph containing the \@mention, plus the preceding and following paragraphs for context. Currently the excerpt is the 100 characters surrounding the mention, but this tends to mangle dtext by cutting things off in the middle of a dtext tag.