### PR TITLE
Modqueue: highlight uploads containing "bad" tags.

### DIFF
--- a/app/assets/javascripts/mod_queue.js
+++ b/app/assets/javascripts/mod_queue.js
@@ -48,9 +48,6 @@
       if ($post.data("has-children")) {
         $post.addClass("post-has-children");
       }
-      if ($post.data("has-dup")) {
-        $post.addClass("post-has-dup");
-      }
     });
   }
 

--- a/app/assets/stylesheets/common/000_vars.scss
+++ b/app/assets/stylesheets/common/000_vars.scss
@@ -24,6 +24,8 @@ $preview_has_parent_color: #CC0;
 $preview_deleted_color: #000;
 $preview_pending_color: #00F;
 $preview_flagged_color: #F00;
+$preview_sample_warning_color:  hsl(0,  100%, 90%); // light red
+$preview_quality_warning_color: hsl(50, 100%, 90%); // light yellow
 
 @mixin border-radius($val) {
   -moz-border-radius: $val;

--- a/app/assets/stylesheets/specific/mod_queue.scss
+++ b/app/assets/stylesheets/specific/mod_queue.scss
@@ -9,10 +9,6 @@ div#c-moderator-post-queues {
       background: rgb(230, 255, 230);
     }
 
-    &.post-has-dup {
-      background: rgb(255, 255, 100);
-    }
-
     &.post-neg-score {
       background: rgb(255, 230, 230);
     }
@@ -27,6 +23,23 @@ div#c-moderator-post-queues {
     section {
       float: left;
       width: 800px;
+    }
+
+    &[data-tags~="hard_translated"],
+    &[data-tags~="self_upload"],
+    &[data-tags~="nude_filter"],
+    &[data-tags~="photoshop"],
+    &[data-tags~="screencap"] {
+      background-color: $preview_quality_warning_color;
+    }
+
+    &[data-tags~="duplicate"],
+    &[data-tags~="image_sample"],
+    &[data-tags~="md5_mismatch"],
+    &[data-tags~="resized"],
+    &[data-tags~="upscaled"],
+    &[data-tags~="downscaled"] {
+      background-color: $preview_sample_warning_color;
     }
 
     &[data-tags~=animated], &[data-file-ext=swf], &[data-file-ext=webm], &[data-file-ext=zip], &[data-file-ext=mp4] {

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -831,10 +831,6 @@ class Post < ActiveRecord::Base
       set_tag_string((tag_array - Array(tag)).join(" "))
     end
 
-    def has_dup_tag?
-      has_tag?("duplicate")
-    end
-
     def tag_categories
       @tag_categories ||= Tag.categories_for(tag_array)
     end

--- a/app/views/moderator/post/queues/random.html.erb
+++ b/app/views/moderator/post/queues/random.html.erb
@@ -13,7 +13,7 @@
       </div>
 
       <% @posts.each do |post| %>
-        <div id="post-<%= post.id %>" class="post mod-queue-preview <%= PostPresenter.preview_class(post) %>" <%= PostPresenter.data_attributes(post) %> data-has-dup="<%= post.has_dup_tag? %>">
+        <div id="post-<%= post.id %>" class="post mod-queue-preview <%= PostPresenter.preview_class(post) %>" <%= PostPresenter.data_attributes(post) %>>
           <aside>
             <%= link_to(image_tag(post.preview_file_url), post_path(post), :target => "_blank") %>
           </aside>

--- a/app/views/moderator/post/queues/show.html.erb
+++ b/app/views/moderator/post/queues/show.html.erb
@@ -24,7 +24,7 @@
       </div>
 
       <% @posts.each do |post| %>
-        <div id="post-<%= post.id %>" class="post mod-queue-preview <%= PostPresenter.preview_class(post) %>" <%= PostPresenter.data_attributes(post) %> data-has-dup="<%= post.has_dup_tag? %>">
+        <div id="post-<%= post.id %>" class="post mod-queue-preview <%= PostPresenter.preview_class(post) %>" <%= PostPresenter.data_attributes(post) %>>
           <aside>
             <%= link_to(image_tag(post.preview_file_url), post_path(post), :target => "_blank") %>
           </aside>


### PR DESCRIPTION
ref: http://danbooru.donmai.us/forum_topics/13646?page=7#forum_post_127569

This would highlight posts in the modqueue that contain certain "bad" tags:

highlighted red: `duplicate`, `md5_mistmatch`, `resized`, `upscaled`, `downscaled`.
highlighted yellow: `hard_translated`, `self_upload`, `nude_filter`, `photoshop`, `screencap`.