### PR TITLE
dmails: don't default IP addr to 127.0.0.1 in database (fixes #2908).

### DIFF
--- a/db/migrate/20170302014435_remove_default_ip_addr_from_dmails.rb
+++ b/db/migrate/20170302014435_remove_default_ip_addr_from_dmails.rb
@@ -1,0 +1,9 @@
+class RemoveDefaultIpAddrFromDmails < ActiveRecord::Migration
+  def up
+    change_column_default(:dmails, :creator_ip_addr, nil)
+  end
+
+  def down
+    change_column_default(:dmails, :creator_ip_addr, "127.0.0.1")
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1007,7 +1007,7 @@ CREATE TABLE dmails (
     is_deleted boolean DEFAULT false NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    creator_ip_addr inet DEFAULT '127.0.0.1'::inet NOT NULL
+    creator_ip_addr inet NOT NULL
 );
 
 
@@ -7465,4 +7465,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170112060921');
 INSERT INTO schema_migrations (version) VALUES ('20170117233040');
 
 INSERT INTO schema_migrations (version) VALUES ('20170218104710');
+
+INSERT INTO schema_migrations (version) VALUES ('20170302014435');
 

--- a/test/unit/dmail_test.rb
+++ b/test/unit/dmail_test.rb
@@ -6,7 +6,7 @@ class DmailTest < ActiveSupport::TestCase
       MEMCACHE.flush_all
       @user = FactoryGirl.create(:user)
       CurrentUser.user = @user
-      CurrentUser.ip_addr = "127.0.0.1"
+      CurrentUser.ip_addr = "1.2.3.4"
       ActionMailer::Base.delivery_method = :test
       ActionMailer::Base.perform_deliveries = true
       ActionMailer::Base.deliveries = []
@@ -110,6 +110,11 @@ class DmailTest < ActiveSupport::TestCase
       assert_difference("Dmail.count", 2) do
         Dmail.create_split(:to_id => @new_user.id, :title => "foo", :body => "foo")
       end
+    end
+
+    should "record the creator's ip addr" do
+      dmail = FactoryGirl.create(:dmail, owner: @user)
+      assert_equal(CurrentUser.ip_addr, dmail.creator_ip_addr.to_s)
     end
 
     should "send an email if the user wants it" do


### PR DESCRIPTION
Bug introduced in 1400f64; that commit changed dmails so that `creator_ip_addr` defaulted to `CurrentUser.ip_addr` like this:

```ruby
    after_initialize :initialize_attributes, if: :new_record?

    def initialize_attributes
      self.from_id ||= CurrentUser.id
      self.creator_ip_addr ||= CurrentUser.ip_addr
    end
```

...but `creator_ip_addr` already defaulted to 127.0.0.1 from the database, so the ||= assignment didn't work. Remove the database default so we always default to `CurrentUser.ip_addr` instead.