### PR TITLE
When merging artcomms, list source as html page url, not image url.

### DIFF
--- a/app/assets/javascripts/artist_commentaries.js
+++ b/app/assets/javascripts/artist_commentaries.js
@@ -115,10 +115,12 @@
   // If the new description conflicts with the current description, merge them
   // by appending the new description onto the old one.
   Danbooru.ArtistCommentary.merge_commentaries = function(description, commentary) {
+    var normalized_source = $("#image-container").data().normalizedSource;
+
     if ((commentary.original_description && description) &&
         (commentary.original_description != description)) {
       return description
-        + "\n\n[tn]\nSource: " + $("#post_source").val() + "\n[/tn]"
+        + "\n\n[tn]\nSource: " + normalized_source + "\n[/tn]"
         + "\n\nh6. " + (commentary.original_title || "Untitled")
         + "\n\n" + commentary.original_description
         + "\n\n[tn]\nSource: " + commentary.source + "\n[/tn]";

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -88,6 +88,8 @@ class PostPresenter < Presenter
       data-file-url="#{post.file_url}"
       data-large-file-url="#{post.large_file_url}"
       data-preview-file-url="#{post.preview_file_url}"
+      data-source="#{post.source}"
+      data-normalized-source="#{post.normalized_source}"
     }.html_safe
   end
 


### PR DESCRIPTION
Fixes this issue reported in https://danbooru.donmai.us/forum_topics/9127?page=164#forum_post_128360:

> When you use the fetch commentary feature to add commentary when there is existing commentary, Danbooru seems to fetch the URL listed as source. I.e.,
>
> Source: https://i1.pixiv.net/img-original/img/2017/01/18/00/56/32/60988872_p0.jpg
>
> I think this should be a link to the HTML page.