### PR TITLE
Add /sources.xml endpoint; include backtraces in json

### DIFF
--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -1,15 +1,12 @@
 class SourcesController < ApplicationController
-  # before_filter :member_only
-  respond_to :json
+  respond_to :json, :xml
 
   def show
     @source = Sources::Site.new(params[:url], :referer_url => params[:ref])
     @source.get
 
-    respond_with(@source) do |format|
-      format.json do
-        render :json => @source.to_json
-      end
+    respond_with(@source.to_h) do |format|
+      format.xml { render xml: @source.to_h.to_xml(root: "source") }
     end
   end
 

--- a/app/controllers/sources_controller.rb
+++ b/app/controllers/sources_controller.rb
@@ -9,14 +9,4 @@ class SourcesController < ApplicationController
       format.xml { render xml: @source.to_h.to_xml(root: "source") }
     end
   end
-
-private
-
-  def rescue_exception(exception)
-    respond_with do |format|
-      format.json do
-        render :json => {:message => exception.to_s, :backtrace => exception.backtrace}, :status => :error
-      end
-    end
-  end
 end

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -56,7 +56,7 @@ module Sources
       WikiPage.other_names_match(untranslated_tags).map{|wiki_page| [wiki_page.title, wiki_page.category_name]}
     end
 
-    def to_json
+    def to_h
       return {
         :artist_name => artist_name,
         :profile_url => profile_url,
@@ -71,7 +71,7 @@ module Sources
           :title => artist_commentary_title,
           :description => artist_commentary_desc,
         }
-      }.to_json
+      }
     end
 
     def available?

--- a/app/views/static/error.json.erb
+++ b/app/views/static/error.json.erb
@@ -1,5 +1,9 @@
 <% if @error_message %>
 {"success": false, "message": <%= raw @error_message.encode("utf-8", {:invalid => :replace, :undef => :replace, :replace => "?"}).to_json %>}
 <% else %>
-{"success": false, "message": <%= raw @exception.to_s.encode("utf-8", {:invalid => :replace, :undef => :replace, :replace => "?"}).to_json %>}
+  {
+    "success": false,
+    "message": <%= raw @exception.to_s.encode("utf-8", {:invalid => :replace, :undef => :replace, :replace => "?"}).to_json %>,
+    "backtrace": <%= raw @exception.backtrace.to_json %>
+  }
 <% end %>


### PR DESCRIPTION
Does a couple very minor things in the sources controller:

* Adds /sources.xml support.
* Makes all json responses include a backtrace on error, not just those on /sources.json.