### PR TITLE
/posts: add notice when posts are hidden.

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -77,6 +77,18 @@ module PostSets
       posts.any? {|x| x.rating == "e"}
     end
 
+    def hidden_posts
+      posts.select { |p| !p.visible? }
+    end
+
+    def banned_posts
+      posts.select(&:is_banned?)
+    end
+
+    def censored_posts
+      hidden_posts - banned_posts
+    end
+
     def use_sequential_paginator?
       unknown_post_count? && !CurrentUser.is_gold?
     end

--- a/app/views/posts/partials/index/_posts.html.erb
+++ b/app/views/posts/partials/index/_posts.html.erb
@@ -9,6 +9,18 @@
     </div>
   <% end %>
 
+  <% if post_set.hidden_posts.present? %>
+    <div class="tn hidden-posts-notice">
+      <% if post_set.banned_posts.present? %>
+        <%= post_set.banned_posts.size %> post(s) were removed from this page at the artist's request (<%= link_to "learn more", wiki_pages_path(title: "banned_artist") %>).
+      <% end %>
+
+      <% if post_set.censored_posts.present? %>
+        <%= post_set.censored_posts.size %> post(s) on this page require a <%= link_to "Gold account", new_user_upgrade_path %> to view (<%= link_to "learn more", wiki_pages_path(title: "help:censored_tags") %>).
+      <% end %>
+    </div>
+  <% end %>
+
   <% unless @random.present? %>
     <%= numbered_paginator(post_set.posts) %>
   <% end %>


### PR DESCRIPTION
As discussed in https://danbooru.donmai.us/forum_topics/13828, this would add a notice to /posts when results are removed due to being banned or censored. The purpose is so that when a member searches for a banned artist or for loli, they get some explanation of why the results are empty.

Demo:

http://devbooru.evazion.ml/posts?tags=banned_artist
http://devbooru.evazion.ml/posts?tags=loli