### PR TITLE
Fix post version reference on /moderator/dashboard

### DIFF
--- a/app/logical/moderator/dashboard/report.rb
+++ b/app/logical/moderator/dashboard/report.rb
@@ -45,9 +45,7 @@ module Moderator
       end
 
       def tags
-        PostArchive.without_timeout do
-          Queries::Tag.all(min_date, max_level)
-        end
+        Queries::Tag.all(min_date, max_level)
       end
 
       def posts

--- a/app/logical/moderator/dashboard/report.rb
+++ b/app/logical/moderator/dashboard/report.rb
@@ -45,7 +45,7 @@ module Moderator
       end
 
       def tags
-        ActiveRecord::Base.without_timeout do
+        PostArchive.without_timeout do
           Queries::Tag.all(min_date, max_level)
         end
       end


### PR DESCRIPTION
http://danbooru.donmai.us/moderator/dashboard is broken due to a reference to the post versions table. 

The problem is the tag updates section is supposed to show the list of top post updaters filtered by a given user level, but doing that requires joining on users, which isn't possible any more. So this just does the filtering in ruby.