### PR TITLE
Make commenter/flagger/appealer IPs visible to mods

### DIFF
--- a/app/helpers/post_appeals_helper.rb
+++ b/app/helpers/post_appeals_helper.rb
@@ -4,7 +4,12 @@ module PostAppealsHelper
     html << '<ul>'
 
     post.appeals.each do |appeal|
-      html << '<li>' + DText.parse_inline(appeal.reason).html_safe + ' - ' + link_to_user(appeal.creator) + ' ' + time_ago_in_words_tagged(appeal.created_at) + '</li>'
+      reason = DText.parse_inline(appeal.reason).html_safe
+      user = link_to_user(appeal.creator)
+      ip = link_to_ip(appeal.creator_ip_addr)
+      time = time_ago_in_words_tagged(appeal.created_at)
+
+      html << "<li>#{reason} - #{user} (#{ip}) #{time}</li>"
     end
 
     html << '</ul>'

--- a/app/helpers/post_appeals_helper.rb
+++ b/app/helpers/post_appeals_helper.rb
@@ -6,10 +6,14 @@ module PostAppealsHelper
     post.appeals.each do |appeal|
       reason = DText.parse_inline(appeal.reason).html_safe
       user = link_to_user(appeal.creator)
-      ip = link_to_ip(appeal.creator_ip_addr)
+      if CurrentUser.is_moderator?
+        ip = "(#{link_to_ip(appeal.creator_ip_addr)})"
+      else
+        ip = ""
+      end
       time = time_ago_in_words_tagged(appeal.created_at)
 
-      html << "<li>#{reason} - #{user} (#{ip}) #{time}</li>"
+      html << "<li>#{reason} - #{user} #{ip} #{time}</li>"
     end
 
     html << '</ul>'

--- a/app/helpers/post_flags_helper.rb
+++ b/app/helpers/post_flags_helper.rb
@@ -8,7 +8,7 @@ module PostFlagsHelper
       html << DText.parse_inline(flag.reason).html_safe
 
       if CurrentUser.is_moderator?
-        html << ' - ' + link_to_user(flag.creator)
+        html << " - #{link_to_user(flag.creator)} (#{link_to_ip(flag.creator_ip_addr)})"
       end
 
       html << ' - ' + time_ago_in_words_tagged(flag.created_at)

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -36,6 +36,13 @@
             <li id="comment-vote-up-link-for-<%= comment.id %>"><%= link_to "Vote up", comment_votes_path(:comment_id => comment.id, :score => "up"), :method => :post, :remote => true %></li>
             <li id="comment-vote-down-link-for-<%= comment.id %>"><%= link_to "Vote down", comment_votes_path(:comment_id => comment.id, :score => "down"), :method => :post, :remote => true %></li>
             <li id="comment-unvote-link-for-<%= comment.id %>" class="unvote-comment-link"><%= link_to "Unvote", comment_votes_path(:comment_id => comment.id), :method => :delete, :remote => true %></li>
+            <% if CurrentUser.is_moderator? %>
+              <li>|</li>
+              <li>
+                <strong>IP</strong>
+                <span><%= link_to_ip comment.ip_addr %></span>
+              </li>
+            <% end %>
           <% end %>
         </menu>
         <% if comment.editable_by?(CurrentUser.user) %>


### PR DESCRIPTION
There was an accusation on the forum about certain flags being from a sockpuppet. This would make flagger and appealer IPs visible next to the flag reason so that mods can detect such cases more easily.

This would also make commenter IPs visible in the comments. There's a certain regular commenter who I suspect of sockpuppeting.