### PR TITLE
Fix exceptions on /posts/:id/events, /moderator/dashboard; fix XSS in data-source.

### DIFF
--- a/app/logical/moderator/dashboard/queries/tag.rb
+++ b/app/logical/moderator/dashboard/queries/tag.rb
@@ -5,7 +5,7 @@ module Moderator
         attr_reader :user, :count
 
         def self.all(min_date, max_level)
-          return unless PostArchive.enabled?
+          return [] unless PostArchive.enabled?
 
           records = PostArchive.where("updated_at > ?", min_date).group(:updater).count.map do |user, count|
             new(user, count)

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -4,7 +4,7 @@ class PostEvent
   include ActiveModel::Serializers::Xml
 
   attr_accessor :event
-  delegate :creator_id, :reason, :is_resolved, :created_at, to: :event
+  delegate :creator, :creator_id, :reason, :is_resolved, :created_at, to: :event
 
   def self.find_for_post(post_id)
     post = Post.find(post_id)

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -88,8 +88,8 @@ class PostPresenter < Presenter
       data-file-url="#{post.file_url}"
       data-large-file-url="#{post.large_file_url}"
       data-preview-file-url="#{post.preview_file_url}"
-      data-source="#{post.source}"
-      data-normalized-source="#{post.normalized_source}"
+      data-source="#{h(post.source}"
+      data-normalized-source="#{h(post.normalized_source)}"
     }.html_safe
   end
 

--- a/test/functional/post_events_controller_test.rb
+++ b/test/functional/post_events_controller_test.rb
@@ -25,6 +25,11 @@ class PostEventsControllerTest < ActionController::TestCase
       get :index, {:post_id => @post.id}, {:user_id => CurrentUser.user.id}
       assert_response :ok      
     end
+
+    should "render for mods" do
+      get :index, {:post_id => @post.id}, {:user_id => FactoryGirl.create(:moderator_user).id }
+      assert_response :success
+    end
   end
 
   context "GET /posts/:post_id/events.xml" do


### PR DESCRIPTION
Fixes a few bugs in the last round of pull requests I sent:

47ecf03 - /posts/:id/events - fixes an exception when page is viewed by a mod.
2aa3f9c - /moderator/dashboard: fix exception when PostArchive isn't enabled (see http://testbooru.donmai.us/moderator/dashboard).
d1debec - Fix XSS in post thumbnail data attributes (I added a `data-source` attribute but I forgot to escape it).