### PR TITLE
Fix #2931: mention automated implications on *_(cosplay) wikis.

### DIFF
--- a/app/helpers/artists_helper.rb
+++ b/app/helpers/artists_helper.rb
@@ -1,11 +1,6 @@
 module ArtistsHelper
   def artist_alias_and_implication_list(artist)
-    consequent_tag_aliases = TagAlias.where("status in ('active', 'processing') and consequent_name = ?", artist.name)
-    antecedent_tag_alias = TagAlias.where("status in ('active', 'processing') and antecedent_name = ?", artist.name).first
-    consequent_tag_implications = TagImplication.where("status in ('active', 'processing') and consequent_name = ?", artist.name)
-    antecedent_tag_implications = TagImplication.where("status in ('active', 'processing') and antecedent_name = ?", artist.name)
-
-    alias_and_implication_list(antecedent_tag_alias, consequent_tag_aliases, antecedent_tag_implications, consequent_tag_implications)
+    alias_and_implication_list(artist.tag)
   end
 
   def link_to_artist(name)

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,28 +1,30 @@
 module TagsHelper
-  def alias_and_implication_list(antecedent_alias, consequent_aliases, antecedent_implications, consequent_implications)
+  def alias_and_implication_list(tag)
+    return "" if tag.nil?
+
     html = ""
 
-    if antecedent_alias
+    if tag.antecedent_alias
       html << "<p class='hint'>This tag has been aliased to "
-      html << link_to(antecedent_alias.consequent_name, show_or_new_wiki_pages_path(:title => antecedent_alias.consequent_name))
+      html << link_to(tag.antecedent_alias.consequent_name, show_or_new_wiki_pages_path(:title => tag.antecedent_alias.consequent_name))
       html << ".</p>"
     end
 
-    if consequent_aliases.any?
+    if tag.consequent_aliases.any?
       html << "<p class='hint'>The following tags are aliased to this tag: "
-      html << raw(consequent_aliases.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
+      html << raw(tag.consequent_aliases.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
       html << ".</p>"
     end
 
-    if antecedent_implications.any?
+    if tag.antecedent_implications.any?
       html << "<p class='hint'>This tag implicates "
-      html << raw(antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))
+      html << raw(tag.antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))
       html << ".</p>"
     end
 
-    if consequent_implications.any?
+    if tag.consequent_implications.any?
       html << "<p class='hint'>The following tags implicate this tag: "
-      html << raw(consequent_implications.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
+      html << raw(tag.consequent_implications.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
       html << ".</p>"
     end
 

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -16,6 +16,13 @@ module TagsHelper
       html << ".</p>"
     end
 
+    automatic_tags = TagImplication.automatic_tags_for([tag.name])
+    if automatic_tags.any?
+      html << "<p class='hint'>This tag automatically adds "
+      html << raw(automatic_tags.map {|x| link_to(x, show_or_new_wiki_pages_path(:title => x))}.join(", "))
+      html << ".</p>"
+    end
+
     if tag.antecedent_implications.any?
       html << "<p class='hint'>This tag implicates "
       html << raw(tag.antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -7,32 +7,32 @@ module TagsHelper
     if tag.antecedent_alias
       html << "<p class='hint'>This tag has been aliased to "
       html << link_to(tag.antecedent_alias.consequent_name, show_or_new_wiki_pages_path(:title => tag.antecedent_alias.consequent_name))
-      html << ".</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_aliases")}).</p>"
     end
 
     if tag.consequent_aliases.any?
       html << "<p class='hint'>The following tags are aliased to this tag: "
       html << raw(tag.consequent_aliases.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
-      html << ".</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_aliases")}).</p>"
     end
 
     automatic_tags = TagImplication.automatic_tags_for([tag.name])
     if automatic_tags.any?
       html << "<p class='hint'>This tag automatically adds "
       html << raw(automatic_tags.map {|x| link_to(x, show_or_new_wiki_pages_path(:title => x))}.join(", "))
-      html << ".</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "help:autotags")}).</p>"
     end
 
     if tag.antecedent_implications.any?
       html << "<p class='hint'>This tag implicates "
       html << raw(tag.antecedent_implications.map {|x| link_to(x.consequent_name, show_or_new_wiki_pages_path(:title => x.consequent_name))}.join(", "))
-      html << ".</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_implications")}).</p>"
     end
 
     if tag.consequent_implications.any?
       html << "<p class='hint'>The following tags implicate this tag: "
       html << raw(tag.consequent_implications.map {|x| link_to(x.antecedent_name, show_or_new_wiki_pages_path(:title => x.antecedent_name))}.join(", "))
-      html << ".</p>"
+      html << " (#{link_to "learn more", wiki_pages_path(title: "help:tag_implications")}).</p>"
     end
 
     html.html_safe

--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -1,11 +1,6 @@
 module WikiPagesHelper
   def wiki_page_alias_and_implication_list(wiki_page)
-    antecedent_alias = wiki_page.presenter.antecedent_tag_alias
-    consequent_aliases = wiki_page.presenter.consequent_tag_aliases
-    antecedent_implications = wiki_page.presenter.antecedent_tag_implications
-    consequent_implications = wiki_page.presenter.consequent_tag_implications
-
-    alias_and_implication_list(antecedent_alias, consequent_aliases, antecedent_implications, consequent_implications)
+    alias_and_implication_list(wiki_page.tag)
   end
 
   def wiki_page_post_previews(wiki_page)

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -37,6 +37,11 @@ module PostSets
       end
     end
 
+    def tag
+      return nil if !is_single_tag?
+      @tag ||= Tag.find_by(name: Tag.normalize_name(tag_string))
+    end
+
     def has_artist?
       is_single_tag? && artist.present? && artist.visible?
     end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -636,6 +636,7 @@ class Post < ActiveRecord::Base
       normalized_tags = %w(tagme) if normalized_tags.empty?
       normalized_tags = TagAlias.to_aliased(normalized_tags)
       normalized_tags = add_automatic_tags(normalized_tags)
+      normalized_tags = normalized_tags + TagImplication.automatic_tags_for(normalized_tags)
       normalized_tags = TagImplication.with_descendants(normalized_tags)
       normalized_tags = normalized_tags.compact
       normalized_tags.sort!
@@ -704,10 +705,6 @@ class Post < ActiveRecord::Base
       if is_ugoira?
         tags << "ugoira"
       end
-
-      characters = tags.grep(/\A(.+)_\(cosplay\)\Z/) { $1 }
-      tags += characters
-      tags << "cosplay" if characters.present?
 
       return tags
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -5,6 +5,10 @@ class Tag < ActiveRecord::Base
   attr_accessible :category, :as => [:moderator, :janitor, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
   attr_accessible :is_locked, :as => [:moderator, :admin]
   has_one :wiki_page, :foreign_key => "title", :primary_key => "name"
+  has_one :antecedent_alias, lambda {active}, :class_name => "TagAlias", :foreign_key => "antecedent_name", :primary_key => "name"
+  has_many :consequent_aliases, lambda {active}, :class_name => "TagAlias", :foreign_key => "consequent_name", :primary_key => "name"
+  has_many :antecedent_implications, lambda {active}, :class_name => "TagImplication", :foreign_key => "antecedent_name", :primary_key => "name"
+  has_many :consequent_implications, lambda {active}, :class_name => "TagImplication", :foreign_key => "consequent_name", :primary_key => "name"
 
   validates :name, uniqueness: true, tag_name: true, on: :create
 

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -32,6 +32,12 @@ class TagImplication < ActiveRecord::Base
       def with_descendants(names)
         (names + where("antecedent_name in (?) and status in (?)", names, ["active", "processing"]).map(&:descendant_names_array)).flatten.uniq
       end
+
+      def automatic_tags_for(names)
+        tags = names.grep(/\A(.+)_\(cosplay\)\Z/) { $1 }
+        tags << "cosplay" if tags.present?
+        tags.uniq
+      end
     end
 
     def descendants

--- a/app/presenters/wiki_page_presenter.rb
+++ b/app/presenters/wiki_page_presenter.rb
@@ -13,22 +13,6 @@ class WikiPagePresenter
     DText.strip(excerpt.to_s)
   end
 
-  def consequent_tag_aliases
-    @consequent_tag_aliases ||= TagAlias.where("status in ('active', 'processing') and consequent_name = ?", wiki_page.title)
-  end
-
-  def antecedent_tag_alias
-    @antecedent_tag_alias ||= TagAlias.where("status in ('active', 'processing') and antecedent_name = ?", wiki_page.title).first
-  end
-
-  def consequent_tag_implications
-    @consequent_tag_implications ||= TagImplication.where("status in ('active', 'processing') and consequent_name = ?", wiki_page.title)
-  end
-
-  def antecedent_tag_implications
-    @antecedent_tag_implications ||= TagImplication.where("status in ('active', 'processing') and antecedent_name = ?", wiki_page.title)
-  end
-
   # Produce a formatted page that shows the difference between two versions of a page.
   def diff(other_version)
     pattern = Regexp.new('(?:<.+?>)|(?:[0-9_A-Za-z\x80-\xff]+[\x09\x20]?)|(?:[ \t]+)|(?:\r?\n)|(?:.+?)')

--- a/app/views/posts/partials/index/_excerpt.html.erb
+++ b/app/views/posts/partials/index/_excerpt.html.erb
@@ -82,6 +82,8 @@
   <% else %>
     <% if post_set.tag_string.present? %>
       <p>There is currently no wiki page for the tag "<%= post_set.tag_string %>". You can <%= link_to "create one", new_wiki_page_path(:wiki_page => {:title => post_set.tag_string}) %>.</p>
+
+      <%= alias_and_implication_list(post_set.tag) %>
     <% end %>
   <% end %>
 </div>


### PR DESCRIPTION
Fixes #2931. In addition:

* adds `(learn more)` links next to the alias / implication lists in wiki excerpts.
* shows alias / implication lists even for tags that don't have a wiki entry.