### PR TITLE
/moderator/dashboard: optimize sql queries

### DIFF
--- a/app/logical/moderator/dashboard/queries/artist.rb
+++ b/app/logical/moderator/dashboard/queries/artist.rb
@@ -1,28 +1,16 @@
 module Moderator
   module Dashboard
     module Queries
-      class Artist
-        attr_reader :user, :count
-
+      class Artist < ::Struct.new(:user, :count)
         def self.all(min_date, max_level)
-          sql = <<-EOS
-            SELECT artist_versions.updater_id AS updater_id, count(*)
-            FROM artist_versions
-            JOIN users ON users.id = artist_versions.updater_id
-            WHERE
-              artist_versions.created_at > ?
-              AND users.level <= ?
-            GROUP BY artist_versions.updater_id
-            ORDER BY count(*) DESC
-            LIMIT 10
-          EOS
-
-          ActiveRecord::Base.select_all_sql(sql, min_date, max_level).map {|x| new(x)}
-        end
-
-        def initialize(hash)
-          @user = ::User.find(hash["updater_id"])
-          @count = hash["count"]
+          ::ArtistVersion.joins(:updater)
+            .where("artist_versions.created_at > ?", min_date)
+            .where("users.level <= ?", max_level)
+            .group(:updater)
+            .order("count(*) desc")
+            .limit(10)
+            .count
+            .map { |user, count| new(user, count) }
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/mod_action.rb
+++ b/app/logical/moderator/dashboard/queries/mod_action.rb
@@ -3,7 +3,7 @@ module Moderator
     module Queries
       class ModAction
         def self.all
-          ::ModAction.order("id desc").limit(10)
+          ::ModAction.includes(:creator).order("id desc").limit(10)
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/note.rb
+++ b/app/logical/moderator/dashboard/queries/note.rb
@@ -1,28 +1,16 @@
 module Moderator
   module Dashboard
     module Queries
-      class Note
-        attr_reader :user, :count
-
+      class Note < ::Struct.new(:user, :count)
         def self.all(min_date, max_level)
-          sql = <<-EOS
-            SELECT note_versions.updater_id, count(*)
-            FROM note_versions
-            JOIN users ON users.id = note_versions.updater_id
-            WHERE
-              note_versions.created_at > ?
-              AND users.level <= ?
-            GROUP BY note_versions.updater_id
-            ORDER BY count(*) DESC
-            LIMIT 10
-          EOS
-
-          ActiveRecord::Base.select_all_sql(sql, min_date, max_level).map {|x| new(x)}
-        end
-
-        def initialize(hash)
-          @user = ::User.find(hash["updater_id"])
-          @count = hash["count"]
+          ::NoteVersion.joins(:updater)
+            .where("note_versions.created_at > ?", min_date)
+            .where("users.level <= ?", max_level)
+            .group(:updater)
+            .order("count(*) desc")
+            .limit(10)
+            .count
+            .map { |user, count| new(user, count) }
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/post_appeal.rb
+++ b/app/logical/moderator/dashboard/queries/post_appeal.rb
@@ -2,28 +2,13 @@ module Moderator
   module Dashboard
     module Queries
       class PostAppeal
-        attr_reader :post, :count
-
         def self.all(min_date)
-          sql = <<-EOS
-            SELECT post_appeals.post_id, count(*)
-            FROM post_appeals
-            JOIN posts ON posts.id = post_appeals.post_id
-            WHERE
-              post_appeals.created_at > ?
-              and posts.is_deleted = true
-              and posts.is_pending = false
-            GROUP BY post_appeals.post_id
-            ORDER BY count(*) DESC
-            LIMIT 10
-          EOS
-
-          ActiveRecord::Base.select_all_sql(sql, min_date).map {|x| new(x)}
-        end
-
-        def initialize(hash)
-          @post = ::Post.find(hash["post_id"])
-          @count = hash["count"]
+          ::Post.joins(:appeals).includes(:uploader, :flags, appeals: [:creator])
+            .deleted
+            .where("post_appeals.created_at > ?", min_date)
+            .group(:id)
+            .order("count(*) desc")
+            .limit(10)
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/tag.rb
+++ b/app/logical/moderator/dashboard/queries/tag.rb
@@ -1,9 +1,7 @@
 module Moderator
   module Dashboard
     module Queries
-      class Tag
-        attr_reader :user, :count
-
+      class Tag < ::Struct.new(:user, :count)
         def self.all(min_date, max_level)
           return [] unless PostArchive.enabled?
 
@@ -12,10 +10,6 @@ module Moderator
           end
 
           records.select { |rec| rec.user.level <= max_level }.sort_by(&:count).reverse.take(10)
-        end
-
-        def initialize(user, count)
-          @user, @count = user, count
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/upload.rb
+++ b/app/logical/moderator/dashboard/queries/upload.rb
@@ -1,28 +1,16 @@
 module Moderator
   module Dashboard
     module Queries
-      class Upload
-        attr_reader :user, :count
-
+      class Upload < ::Struct.new(:user, :count)
         def self.all(min_date, max_level)
-          sql = <<-EOS
-            select uploader_id, count(*)
-            from posts
-            join users on uploader_id = users.id
-            where
-              posts.created_at > ?
-              and level <= ?
-            group by posts.uploader_id
-            order by count(*) desc
-            limit 10
-          EOS
-
-          ActiveRecord::Base.select_all_sql(sql, min_date, max_level).map {|x| new(x)}
-        end
-
-        def initialize(hash)
-          @user = ::User.find(hash["uploader_id"])
-          @count = hash["count"]
+          ::Post.joins(:uploader)
+            .where("posts.created_at > ?", min_date)
+            .where("users.level <= ?", max_level)
+            .group(:uploader)
+            .order("count(*) desc")
+            .limit(10)
+            .count
+            .map { |user, count| new(user, count) }
         end
       end
     end

--- a/app/logical/moderator/dashboard/queries/user_feedback.rb
+++ b/app/logical/moderator/dashboard/queries/user_feedback.rb
@@ -3,7 +3,7 @@ module Moderator
     module Queries
       class UserFeedback
         def self.all
-          ::UserFeedback.order("id desc").limit(10)
+          ::UserFeedback.includes(:user).order("id desc").limit(10)
         end
       end
     end

--- a/app/views/moderator/dashboards/_activity_appeal.html.erb
+++ b/app/views/moderator/dashboards/_activity_appeal.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% @dashboard.appeals.each do |post| %>
       <tr>
-        <td><%= link_to image_tag(post.preview_file_url), post_path(post) %></td>
+        <td><%= PostPresenter.preview(post, show_deleted: true) %></td>
         <td><%= mod_link_to_user post.uploader, :negative %></td>
         <td><%= post_flag_reasons(post) %></td>
         <td><%= post_appeal_reasons(post) %></td>

--- a/app/views/moderator/dashboards/_activity_appeal.html.erb
+++ b/app/views/moderator/dashboards/_activity_appeal.html.erb
@@ -10,13 +10,13 @@
     </tr>
   </thead>
   <tbody>
-    <% @dashboard.appeals.each do |appeal| %>
+    <% @dashboard.appeals.each do |post| %>
       <tr>
-        <td><%= link_to image_tag(appeal.post.preview_file_url), post_path(appeal.post) %></td>
-        <td><%= mod_link_to_user appeal.post.uploader, :negative %></td>
-        <td><%= post_flag_reasons(appeal.post) %></td>
-        <td><%= post_appeal_reasons(appeal.post) %></td>
-        <td><%= appeal.post.score %></td>
+        <td><%= link_to image_tag(post.preview_file_url), post_path(post) %></td>
+        <td><%= mod_link_to_user post.uploader, :negative %></td>
+        <td><%= post_flag_reasons(post) %></td>
+        <td><%= post_appeal_reasons(post) %></td>
+        <td><%= post.score %></td>
       </tr>
     <% end %>
   </tbody>

--- a/db/migrate/20170319000519_add_created_at_index_to_versions.rb
+++ b/db/migrate/20170319000519_add_created_at_index_to_versions.rb
@@ -1,0 +1,10 @@
+class AddCreatedAtIndexToVersions < ActiveRecord::Migration
+  def change
+    ActiveRecord::Base.without_timeout do
+      add_index :note_versions, :created_at
+      add_index :artist_versions, :created_at
+      add_index :wiki_page_versions, :created_at
+      add_index :post_appeals, :created_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4978,6 +4978,13 @@ CREATE INDEX index_artist_versions_on_artist_id ON artist_versions USING btree (
 
 
 --
+-- Name: index_artist_versions_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_artist_versions_on_created_at ON artist_versions USING btree (created_at);
+
+
+--
 -- Name: index_artist_versions_on_name; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6707,6 +6714,13 @@ CREATE INDEX index_news_updates_on_created_at ON news_updates USING btree (creat
 
 
 --
+-- Name: index_note_versions_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_note_versions_on_created_at ON note_versions USING btree (created_at);
+
+
+--
 -- Name: index_note_versions_on_note_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6788,6 +6802,13 @@ CREATE INDEX index_pools_on_name ON pools USING btree (name);
 --
 
 CREATE INDEX index_pools_on_name_trgm ON pools USING gin (name gin_trgm_ops);
+
+
+--
+-- Name: index_post_appeals_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_appeals_on_created_at ON post_appeals USING btree (created_at);
 
 
 --
@@ -7145,6 +7166,13 @@ CREATE UNIQUE INDEX index_users_on_name ON users USING btree (lower((name)::text
 --
 
 CREATE INDEX index_users_on_name_trgm ON users USING gin (lower((name)::text) gin_trgm_ops);
+
+
+--
+-- Name: index_wiki_page_versions_on_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wiki_page_versions_on_created_at ON wiki_page_versions USING btree (created_at);
 
 
 --
@@ -7532,3 +7560,4 @@ INSERT INTO schema_migrations (version) VALUES ('20170314235626');
 
 INSERT INTO schema_migrations (version) VALUES ('20170316224630');
 
+INSERT INTO schema_migrations (version) VALUES ('20170319000519');


### PR DESCRIPTION
This optimizes the http://danbooru.donmai.us/moderator/dashboard page in two ways:

* Adds `created_at` indexes that were missing on a few version tables.
* Converts the queries to use active record instead of raw sql. This fixes some issues with users being loaded one-by-one in multiple places. Doing this cuts the number of sql queries executed by the page in half.