### PR TITLE
Upvote correctly when moving favorites (partial fix for #2936)

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -943,7 +943,7 @@ class Post < ActiveRecord::Base
 
     def add_favorite!(user)
       Favorite.add(self, user)
-      vote!("up", user) if user.is_gold?
+      vote!("up", user) if user.is_voter?
     rescue PostVote::Error
     end
 
@@ -953,7 +953,7 @@ class Post < ActiveRecord::Base
 
     def remove_favorite!(user)
       Favorite.remove(self, user)
-      unvote!(user) if user.is_gold?
+      unvote!(user) if user.is_voter?
     rescue PostVote::Error
     end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1063,7 +1063,7 @@ class Post < ActiveRecord::Base
       !PostVote.exists?(:user_id => user.id, :post_id => id)
     end
 
-    def vote!(score, voter = CurrentUser.user)
+    def vote!(vote, voter = CurrentUser.user)
       unless voter.is_voter?
         raise PostVote::Error.new("You do not have permission to vote")
       end
@@ -1072,7 +1072,7 @@ class Post < ActiveRecord::Base
         raise PostVote::Error.new("You have already voted for this post")
       end
 
-      votes.create!(user: voter, score: vote)
+      votes.create!(user: voter, vote: vote)
       reload # PostVote.create modifies our score. Reload to get the new score.
     end
 

--- a/app/models/post_vote.rb
+++ b/app/models/post_vote.rb
@@ -2,10 +2,14 @@ class PostVote < ActiveRecord::Base
   class Error < Exception ; end
 
   belongs_to :post
-  before_validation :initialize_user, :on => :create
+  belongs_to :user
+  attr_accessor :vote
+  attr_accessible :post, :post_id, :user, :user_id, :score, :vote
+
+  after_initialize :initialize_attributes, if: :new_record?
   validates_presence_of :post_id, :user_id, :score
   validates_inclusion_of :score, :in => [SuperVoter::MAGNITUDE, 1, -1, -SuperVoter::MAGNITUDE]
-  attr_accessible :post_id, :user_id, :score
+  after_create :update_post_on_create
   after_destroy :update_post_on_destroy
 
   def self.prune!
@@ -24,18 +28,22 @@ class PostVote < ActiveRecord::Base
     select_values_sql("select post_id from post_votes where score > 0 and user_id = ?", user_id)
   end
 
-  def score=(x)
-    if x == "up"
-      Post.where(:id => post_id).update_all("score = score + #{magnitude}, up_score = up_score + #{magnitude}")
-      write_attribute(:score, magnitude)
-    elsif x == "down"
-      Post.where(:id => post_id).update_all("score = score - #{magnitude}, down_score = down_score - #{magnitude}")
-      write_attribute(:score, -magnitude)
+  def initialize_attributes
+    self.user_id ||= CurrentUser.user.id
+
+    if vote == "up"
+      self.score = magnitude
+    elsif vote == "down"
+      self.score = -magnitude
     end
   end
 
-  def initialize_user
-    self.user_id ||= CurrentUser.user.id
+  def update_post_on_create
+    if score > 0
+      Post.where(:id => post_id).update_all("score = score + #{score}, up_score = up_score + #{score}")
+    else
+      Post.where(:id => post_id).update_all("score = score + #{score}, down_score = down_score + #{score}")
+    end
   end
 
   def update_post_on_destroy
@@ -47,7 +55,7 @@ class PostVote < ActiveRecord::Base
   end
 
   def magnitude
-    if CurrentUser.is_super_voter?
+    if user.is_super_voter?
       SuperVoter::MAGNITUDE
     else
       1

--- a/app/models/post_vote.rb
+++ b/app/models/post_vote.rb
@@ -35,7 +35,7 @@ class PostVote < ActiveRecord::Base
   end
 
   def initialize_user
-    self.user_id = CurrentUser.user.id
+    self.user_id ||= CurrentUser.user.id
   end
 
   def update_post_on_destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,6 +77,7 @@ class User < ActiveRecord::Base
   #after_create :notify_sock_puppets
   has_many :feedback, :class_name => "UserFeedback", :dependent => :destroy
   has_many :posts, :foreign_key => "uploader_id"
+  has_many :post_votes
   has_many :bans, lambda {order("bans.id desc")}
   has_one :recent_ban, lambda {order("bans.id desc")}, :class_name => "Ban"
   has_one :api_key

--- a/app/presenters/presenter.rb
+++ b/app/presenters/presenter.rb
@@ -1,6 +1,6 @@
 class Presenter
   def self.h(s)
-    CGI.escapeHTML(s)
+    CGI.escapeHTML(s.to_s)
   end
 
   def self.u(s)

--- a/test/unit/post_vote_test.rb
+++ b/test/unit/post_vote_test.rb
@@ -4,8 +4,9 @@ class PostVoteTest < ActiveSupport::TestCase
   def setup
     super
     
-    user = FactoryGirl.create(:user)
-    CurrentUser.user = user
+    @supervoter = FactoryGirl.create(:user, is_super_voter: true)
+    @user = FactoryGirl.create(:user)
+    CurrentUser.user = @user
     CurrentUser.ip_addr = "127.0.0.1"
     MEMCACHE.flush_all
 
@@ -23,9 +24,38 @@ class PostVoteTest < ActiveSupport::TestCase
       assert_equal(-1, vote.score)
     end
 
+    should "interpret up as +3 score for a supervoter" do
+      vote = PostVote.create(:user_id => @supervoter.id, :post_id => @post.id, :vote => "up")
+      assert_equal(3, vote.score)
+    end
+
     should "not accept any other scores" do
       vote = PostVote.create(:post_id => @post.id, :vote => "xxx")
       assert(vote.errors.any?)
+    end
+
+    should "increase the score of the post" do
+      @post.votes.create(vote: "up")
+      @post.reload
+
+      assert_equal(1, @post.score)
+      assert_equal(1, @post.up_score)
+    end
+
+    should "decrease the score of the post when removed" do
+      @post.votes.create(vote: "up").destroy
+      @post.reload
+
+      assert_equal(0, @post.score)
+      assert_equal(0, @post.up_score)
+    end
+
+    should "upvote by 3 points if the voter is a supervoter" do
+      @post.votes.create(user: @supervoter, vote: "up")
+      @post.reload
+
+      assert_equal(3, @post.score)
+      assert_equal(3, @post.up_score)
     end
   end
 end

--- a/test/unit/post_vote_test.rb
+++ b/test/unit/post_vote_test.rb
@@ -14,17 +14,17 @@ class PostVoteTest < ActiveSupport::TestCase
 
   context "Voting for a post" do
     should "interpret up as +1 score" do
-      vote = PostVote.create(:post_id => @post.id, :score => "up")
+      vote = PostVote.create(:post_id => @post.id, :vote => "up")
       assert_equal(1, vote.score)
     end
 
     should "interpret down as -1 score" do
-      vote = PostVote.create(:post_id => @post.id, :score => "down")
+      vote = PostVote.create(:post_id => @post.id, :vote => "down")
       assert_equal(-1, vote.score)
     end
 
     should "not accept any other scores" do
-      vote = PostVote.create(:post_id => @post.id, :score => "xxx")
+      vote = PostVote.create(:post_id => @post.id, :vote => "xxx")
       assert(vote.errors.any?)
     end
   end


### PR DESCRIPTION
Fixes three favorite moving bugs:

* Upvotes on the parent post were performed by the favorite mover, rather than the user that favorited the post.
* Favorites by supervoters didn't give the parent a supervote (a consequence of the above bug).
* Non-gold supervoters didn't upvote the post when favoriting.