### PR TITLE
Fix exception in `h(post.source)` when source is nil (fixes #2940).

### DIFF
--- a/app/presenters/presenter.rb
+++ b/app/presenters/presenter.rb
@@ -1,6 +1,6 @@
 class Presenter
   def self.h(s)
-    CGI.escapeHTML(s)
+    CGI.escapeHTML(s.to_s)
   end
 
   def self.u(s)


### PR DESCRIPTION
Fixes this exception that happens when a post has a NULL source:

    TypeError exception raised

    no implicit conversion of nil into String
    app/presenters/presenter.rb:3:in `escapeHTML'
    app/presenters/presenter.rb:3:in `h'
    app/presenters/post_presenter.rb:91:in `data_attributes'
    app/presenters/post_presenter.rb:24:in `preview'
    app/presenters/post_set_presenters/base.rb:15:in `block in post_previews_html'
    app/presenters/post_set_presenters/base.rb:14:in `post_previews_html'
    app/views/posts/partials/index/_posts.html.erb:3:in `_app_views_posts_partials_index__posts_html_erb___2716396856929289512_70158315986180'
    app/views/posts/index.html.erb:39:in `_app_views_posts_index_html_erb__1345252938355811220_70158296799280'
    app/controllers/posts_controller.rb:16:in `index'