### PR TITLE
Fix exception when autotagging animated_gifs

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -173,7 +173,7 @@ class Post < ActiveRecord::Base
     end
 
     def is_animated_gif?
-      if file_ext =~ /gif/i
+      if file_ext =~ /gif/i && File.exists?(file_path)
         return Magick::Image.ping(file_path).length > 1
       else
         return false


### PR DESCRIPTION
Fixes an exception caused by the `animated_gif` autotagger trying to access the gif file, which fails if the file isn't present due to #2500.

This is the lazy fix. The real fix would be to do the autotagging at post creation instead of on post update. This would be a slight change in behavior though, since then it would be possible to remove the `animated_gif` tag, whereas now you can't.

```ruby
Magick::ImageMagickError exception raised

    unable to open image `/var/www/danbooru2/releases/20170322212609/public/data/f0e32c0e2d906c4932858866346f98b5.gif': No such file or directory @ error/blob.c/OpenBlob/2712
    app/models/post.rb:177:in `ping'
    app/models/post.rb:177:in `is_animated_gif?'
    app/models/post.rb:684:in `add_automatic_tags'
    app/models/post.rb:638:in `normalize_tags'
    app/controllers/posts_controller.rb:49:in `update'
```