### PR TITLE
Fix exception when searching for `search:adfijoioi`.

### DIFF
--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -21,6 +21,8 @@ class SavedSearch < ActiveRecord::Base
 
         Cache.get("ss-#{user_id}-#{Cache.hash(label)}", 60) do
           queries = SavedSearch.queries_for(user_id, label)
+          return [] if queries.empty?
+
           json = {
             "key" => Danbooru.config.listbooru_auth_key,
             "queries" => queries

--- a/test/unit/saved_search_test.rb
+++ b/test/unit/saved_search_test.rb
@@ -72,6 +72,17 @@ class SavedSearchTest < ActiveSupport::TestCase
         assert_equal([1,2,3,4], post_ids)
       end
     end
+
+    context "with a nonexistent label" do
+      setup do
+        SavedSearch.expects(:queries_for).with(1, "empty").returns([])
+      end
+
+      should "return an empty list of ids" do
+        post_ids = SavedSearch.post_ids(1, "empty")
+        assert_equal([], post_ids)
+      end
+    end
   end
 
   context "Creating a saved search" do


### PR DESCRIPTION
Fixes an exception when searching for a nonexistent saved search label (e.g. `search:aoijoiqwf`):

    NoMethodError exception raised

    undefined method `empty?' for nil:NilClass
    app/logical/post_query_builder.rb:113:in `block in add_saved_search_relation'
    app/logical/post_query_builder.rb:106:in `each'
    app/logical/post_query_builder.rb:106:in `add_saved_search_relation'
    app/logical/post_query_builder.rb:237:in `build'
    app/models/post.rb:1624:in `tag_match'
    app/models/post.rb:1172:in `block in fast_count_search'
    config/initializers/active_record_extensions.rb:16:in `with_timeout'
    app/models/post.rb:1171:in `fast_count_search'
    app/models/post.rb:1162:in `fast_count'
    app/logical/post_sets/post.rb:106:in `get_post_count'
    app/logical/post_sets/post.rb:122:in `posts'
    app/controllers/posts_controller.rb:15:in `index'

Caused by this failure in listbooru when you send it an empty array as the list of queries:

    Redis::CommandError - ERR wrong number of arguments for 'zunionstore' command:

    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis/client.rb:121:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:1932:in `block in zunionstore'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:58:in `block in synchronize'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/2.4.0/monitor.rb:214:in `mon_synchronize'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:58:in `synchronize'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/redis-3.3.3/lib/redis.rb:1931:in `zunionstore'
    web/listbooru.rb:85:in `aggregate_searches'
    web/listbooru.rb:104:in `block in <main>'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1611:in `block incompile!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (3 levels) in route!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:994:in `route_eval'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:975:in `block (2 levels) in route!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1015:in `block inprocess_route'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `catch'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1013:in `process_route'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:973:in `block in route!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `each'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:972:in `route!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1085:in `block indispatch!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block ininvoke'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1082:in `dispatch!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `block in call!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `block ininvoke'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `catch'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1067:in `invoke'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:907:in `call!'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:895:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/xss_header.rb:18:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/path_traversal.rb:16:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/json_csrf.rb:18:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/base.rb:49:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-protection-1.5.3/lib/rack/protection/frame_options.rb:31:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-1.6.5/lib/rack/logger.rb:15:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-1.6.5/lib/rack/commonlogger.rb:33:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:219:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:212:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-1.6.5/lib/rack/head.rb:13:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-1.6.5/lib/rack/methodoverride.rb:22:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/show_exceptions.rb:25:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:182:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:2013:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `block incall'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1787:in `synchronize'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/sinatra-1.4.8/lib/sinatra/base.rb:1487:in `call'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/rack-1.6.5/lib/rack/handler/webrick.rb:88:in `service'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/2.4.0/webrick/httpserver.rb:140:in `service'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/2.4.0/webrick/httpserver.rb:96:in `run'
    /home/admin/.rbenv/versions/2.4.1/lib/ruby/2.4.0/webrick/server.rb:290:in `block in start_thread'