### PR TITLE
Fix upload tags report (closes #2863)

### DIFF
--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -21,6 +21,6 @@ class ReportsController < ApplicationController
 
   def upload_tags
     @user = User.find(params[:user_id])
-    @upload_reports = Reports::UploadTags.for_user(params[:user_id]).order("id desc").paginate(params[:page], :limit => params[:limit])
+    @upload_reports = Reports::UploadTags.includes(versions: [:post]).for_user(params[:user_id]).order("id desc").paginate(params[:page], :limit => params[:limit])
   end
 end

--- a/app/logical/reports/upload_tags.rb
+++ b/app/logical/reports/upload_tags.rb
@@ -29,9 +29,9 @@ module Reports
 
     def uploader_tags_array
       @uploader_tags ||= begin
-        added_tags = []
-        PostArchive.where(post_id: id, updater_id: uploader_id).each do |version|
-          added_tags += version.changes[:added_tags]
+        uploader_versions = versions.select { |p| p.updater_id == uploader_id }
+        added_tags = uploader_versions.flat_map do |version|
+          version.changes[:added_tags]
         end
         added_tags.uniq.sort
       end

--- a/app/views/reports/upload_tags.html.erb
+++ b/app/views/reports/upload_tags.html.erb
@@ -12,7 +12,7 @@
       <tbody>
         <% @upload_reports.each do |upload_report| %>
           <tr>
-            <td><%= link_to(upload_report.id, post_path(:id => upload_report.id ))%></td>
+            <td><%= PostPresenter.preview(upload_report, show_deleted: true, tags: "user:#{upload_report.uploader_name}") %></td>
             <td>
               <% upload_report.uploader_tags_array.each do |tag_name| %>
                 <span class="category-<%= Tag.category_for(tag_name) %>">

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -36,7 +36,12 @@
 
       <tr>
         <th>Uploads</th>
-        <td><%= presenter.upload_count(self) %></td>
+        <td>
+          <%= presenter.upload_count(self) %>
+          <% if presenter.has_uploads? %>
+            (<%= link_to "tag changes report", reports_upload_tags_path(user_id: user.id) %>)
+          <% end %>
+        </td>
       </tr>
 
       <tr>


### PR DESCRIPTION
Should close out #2863:

* Links to upload tag report in user profiles
* Shows thumbnails instead of post ids.
* Fixes a couple N+1 queries issues.