### PR TITLE
Fix #2950: Post Versions: "undefined method" error for specific edit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,4 +73,5 @@ group :test do
   gem "simplecov", :require => false
   gem "timecop"
   gem "fakeweb"
+  gem "test_after_commit" # XXX remove me after upgrading to rails 5.
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,6 +326,8 @@ GEM
       rest-client (~> 1.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -422,6 +424,7 @@ DEPENDENCIES
   streamio-ffmpeg
   stripe
   term-ansicolor
+  test_after_commit
   therubyracer
   timecop
   twitter
@@ -432,4 +435,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -17,9 +17,9 @@ class Pool < ActiveRecord::Base
   before_validation :initialize_creator, :on => :create
   before_validation :strip_name
   after_save :update_category_pseudo_tags_for_posts_async
-  after_save :create_version
   after_create :synchronize!
   before_destroy :create_mod_action_for_destroy
+  after_commit :create_version, :on => [:create, :update]
   attr_accessible :name, :description, :post_ids, :post_id_array, :post_count, :is_active, :category, :as => [:member, :gold, :platinum, :janitor, :moderator, :admin, :default]
   attr_accessible :is_deleted, :as => [:moderator, :admin]
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -23,13 +23,13 @@ class Post < ActiveRecord::Base
   before_save :set_tag_counts
   before_save :set_pool_category_pseudo_tags
   before_create :autoban
-  after_save :create_version
   after_save :update_parent_on_save
   after_save :apply_post_metatags
   after_save :expire_essential_tag_string_cache
   after_destroy :remove_iqdb_async
   after_destroy :delete_files
   after_destroy :delete_remote_files
+  after_commit :create_version, :on => [:create, :update]
   after_commit :update_iqdb_async, :on => :create
   after_commit :notify_pubsub
 
@@ -1414,7 +1414,7 @@ class Post < ActiveRecord::Base
 
   module VersionMethods
     def create_version(force = false)
-      if new_record? || rating_changed? || source_changed? || parent_id_changed? || tag_string_changed? || force
+      if force || new_record? || previous_changes.key?("rating") || previous_changes.key?("source") || previous_changes.key?("parent_id") || previous_changes.key?("tag_string")
         create_new_version
       end
     end

--- a/test/unit/pool_test.rb
+++ b/test/unit/pool_test.rb
@@ -238,6 +238,20 @@ class PoolTest < ActiveSupport::TestCase
       assert_equal(2, @pool.versions.size)
     end
 
+    should "not create a version if updating the pool fails" do
+      @pool.stubs(:synchronize!).raises(NotImplementedError)
+
+      assert_raise(NotImplementedError) { @pool.update(name: "blah") }
+      assert_equal(1, @pool.versions.size)
+    end
+
+    should "should create a version if the name changes" do
+      assert_difference("@pool.versions.size", 1) do
+        @pool.update(name: "blah")
+        assert_equal("blah", @pool.versions.last.name)
+      end
+    end
+
     should "know what its post ids were previously" do
       @pool.post_ids = "#{@p1.id}"
       assert_equal("", @pool.post_ids_was)


### PR DESCRIPTION
Should fix #2950. Sends post/pool versions in an `after_commit` hook so that they're sent only after the post is successfully saved to the db.

The offending post version will still need to be deleted.