### PR TITLE
Move hidden favorites when moving favs.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1279,9 +1279,9 @@ class Post < ActiveRecord::Base
     def give_favorites_to_parent
       return if parent.nil?
 
-      favorited_users.each do |user|
-        remove_favorite!(user)
-        parent.add_favorite!(user)
+      favorites.each do |fav|
+        remove_favorite!(fav.user)
+        parent.add_favorite!(fav.user)
       end
     end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1502,7 +1502,7 @@ class PostTest < ActiveSupport::TestCase
         @parent = FactoryGirl.create(:post)
         @child = FactoryGirl.create(:post, parent: @parent)
 
-        @user1 = FactoryGirl.create(:user)
+        @user1 = FactoryGirl.create(:user, enable_privacy_mode: true)
         @gold1 = FactoryGirl.create(:gold_user)
         @supervoter1 = FactoryGirl.create(:user, is_super_voter: true)
 


### PR DESCRIPTION
Bug: when moving favorites to a parent post, hidden favorites weren't moved. This is because `favorited_users` doesn't include favorites that are hidden from `CurrentUser`.

related: #2936.