### PR TITLE
Fix exception when moving favorites

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,5 +1,6 @@
 class Favorite < ActiveRecord::Base
   belongs_to :post
+  belongs_to :user
   scope :for_user, lambda {|user_id| where("user_id % 100 = #{user_id.to_i % 100} and user_id = #{user_id.to_i}")}
   attr_accessible :user_id, :post_id
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1282,9 +1282,11 @@ class Post < ActiveRecord::Base
     def give_favorites_to_parent
       return if parent.nil?
 
-      favorites.each do |fav|
-        remove_favorite!(fav.user)
-        parent.add_favorite!(fav.user)
+      transaction do
+        favorites.each do |fav|
+          remove_favorite!(fav.user)
+          parent.add_favorite!(fav.user)
+        end
       end
     end
 


### PR DESCRIPTION
Fixes an exception when moving favorites. Caused by me forgetting to include `belongs_to :user` in 7779375.

Also wraps fav movement in a transaction to ensure that if anything fails then the whole transfer is rolled back.

related: #2936
ref: https://danbooru.donmai.us/forum_topics/9127?page=171#forum_post_129261