### PR TITLE
Add API support to /iqdb_queries

### DIFF
--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -1,6 +1,7 @@
 # todo: move this to iqdbs
 class IqdbQueriesController < ApplicationController
   before_filter :member_only
+  respond_to :html, :json, :xml
 
   def index
     if !Danbooru.config.iqdbs_server
@@ -24,7 +25,9 @@ protected
     @download = Iqdb::Download.new(params[:url])
     @download.find_similar
     @results = @download.matches
-    render :layout => false, :action => "create_by_url"
+    respond_with(@results) do |fmt|
+      fmt.html { render :layout => false, :action => "create_by_url" }
+    end
   end
 
   def create_by_post
@@ -32,6 +35,8 @@ protected
     @download = Iqdb::Download.new(@post.complete_preview_file_url)
     @download.find_similar
     @results = @download.matches
-    render :layout => false, :action => "create_by_post"
+    respond_with(@results) do |fmt|
+      fmt.js { render :layout => false, :action => "create_by_post" }
+    end
   end
 end

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -2,7 +2,7 @@
 class IqdbQueriesController < ApplicationController
   before_filter :member_only
 
-  def create
+  def index
     if !Danbooru.config.iqdbs_server
       raise NotImplementedError.new("the IQDBs service isn't configured. Similarity searches are not available.")
     end
@@ -15,6 +15,9 @@ class IqdbQueriesController < ApplicationController
       render :nothing => true, :status => 422
     end
   end
+
+  # Support both POST /iqdb_queries and GET /iqdb_queries.
+  alias_method :create, :index
 
 protected
   def create_by_url

--- a/app/logical/iqdb/download.rb
+++ b/app/logical/iqdb/download.rb
@@ -33,7 +33,13 @@ module Iqdb
           if resp.is_a?(Net::HTTPSuccess)
             json = JSON.parse(resp.body)
             if json.is_a?(Array)
-              @matches = json
+              post_ids = json.map { |match| match["post_id"] }
+              posts = Post.find(post_ids)
+
+              @matches = json.map do |match|
+                post = posts.find { |post| post.id == match["post_id"] }
+                match.with_indifferent_access.merge({ post: post })
+              end
             else
               @matches = []
             end

--- a/app/views/iqdb_queries/create_by_post.js.erb
+++ b/app/views/iqdb_queries/create_by_post.js.erb
@@ -1,7 +1,7 @@
 var html = '';
 <% if @results.any? %>
   <% @results.each do |match| %>
-    html += '<%= j PostPresenter.preview(Post.find(match["post_id"]), :tags => "status:any") %>';
+    html += '<%= j PostPresenter.preview(match[:post], :tags => "status:any") %>';
   <% end %>
 <% else %>
   html += '<p>No matches found</p>';

--- a/app/views/iqdb_queries/create_by_url.html.erb
+++ b/app/views/iqdb_queries/create_by_url.html.erb
@@ -1,7 +1,7 @@
 <% if @results.any? %>
   <h3>Similar</h3>
   <% @results.each do |match| %>
-    <%= PostPresenter.preview(Post.find(match["post_id"]), :tags => "status:any", :size => true) %>
+    <%= PostPresenter.preview(match[:post], :tags => "status:any", :size => true) %>
   <% end %>
 <% else %>
   <h3>Similar</h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -147,7 +147,7 @@ Rails.application.routes.draw do
     resource :visit, :controller => "forum_topic_visits"
   end
   resources :ip_bans
-  resources :iqdb_queries, :only => [:create]
+  resources :iqdb_queries, :only => [:create, :index]
   resources :janitor_trials do
     collection do
       get :test
@@ -206,6 +206,7 @@ Rails.application.routes.draw do
       get :show_seq
       put :mark_as_translated
     end
+    get :similar, :to => "iqdb_queries#index"
   end
   resources :post_appeals
   resources :post_flags

--- a/test/functional/iqdb_queries_controller_test.rb
+++ b/test/functional/iqdb_queries_controller_test.rb
@@ -28,6 +28,13 @@ class IqdbQueriesControllerTest < ActionController::TestCase
 
         assert_response :success
       end
+
+      should "render for a json response" do
+        mock_iqdb_matches!(@posts[0].source, @posts)
+        get :index, { url: @posts[0].source, format: "json" }, { user_id: @user.id }
+
+        assert_response :success
+      end
     end
   end
 end


### PR DESCRIPTION
This adds json/xml api endpoints to `/iqdb_queries`, plus an `/posts/1234/similar.json` endpoint. This also makes `/iqdb_queries` accessible via GET. Currently `/iqdb_queries` is POST only, which is inconvenient for userscripts because of cross-origin restrictions.

Available endpoints:

* `GET /posts/1234/similar.json`
* `GET /iqdb_queries.json?post_id=1234`
* `GET /iqdb_queries.json?url=<url>`