### PR TITLE
Add confirm dialog to sidebar approve/undelete links.

### DIFF
--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -31,7 +31,7 @@
 
     <% if CurrentUser.can_approve_posts? %>
       <% if post.is_deleted? %>
-        <li><%= link_to "Undelete", undelete_moderator_post_post_path(:post_id => post.id), :remote => true, :method => :post, :id => "undelete" %></li>
+        <li><%= link_to "Undelete", undelete_moderator_post_post_path(:post_id => post.id), :remote => true, :method => :post, :id => "undelete", :data => { :confirm => "Are you sure you want to undelete this post?" } %></li>
         <% if post.fav_count > 0 && post.parent_id %>
           <li><%= link_to "Move favorites", confirm_move_favorites_moderator_post_post_path(:post_id => post.id) %></li>
         <% end %>
@@ -40,7 +40,7 @@
       <% end %>
 
       <% if post.is_flagged? || post.is_pending? %>
-        <li><%= link_to "Approve", moderator_post_approval_path(:post_id => post.id), :remote => true, :method => :post, :id => "approve" %></li>
+        <li><%= link_to "Approve", moderator_post_approval_path(:post_id => post.id), :remote => true, :method => :post, :id => "approve", :data => { :confirm => "Are you sure you want to approve this post?" } %></li>
       <% else %>
         <li><%= link_to "Hide from queue", moderator_post_disapproval_path(:post_id => post.id), :remote => true, :method => :post, :id => "disapprove" %></li>
       <% end %>


### PR DESCRIPTION
This adds a confirmation dialog to the Approve/Undelete links in the post sidebar. This is to prevent accidental approvals.

From https://danbooru.donmai.us/forum_posts/129311:

> On a side note, I don't know how desired it would be, but I'd like if we could have an option to double-check if we want to approve a post that's either flagged/pending/deleted outside of the mod queue when clicking 'Approve' from the sidebar. This is because I accidentally click the approve option when I meant to click the delete option (they're right next to each other on the sidebar).