### PR TITLE
Improve autocomplete on /artists, /wiki_pages, and /pools.

### DIFF
--- a/app/assets/javascripts/artists.js
+++ b/app/assets/javascripts/artists.js
@@ -53,8 +53,9 @@
         $.ajax({
           url: "/artists.json",
           data: {
-            "search[name]": "*" + req.term + "*",
+            "search[name]": req.term + "*",
             "search[is_active]": true,
+            "search[order]": "post_count",
             "limit": 10
           },
           method: "get",

--- a/app/assets/javascripts/artists.js
+++ b/app/assets/javascripts/artists.js
@@ -54,6 +54,7 @@
           url: "/artists.json",
           data: {
             "search[name]": "*" + req.term + "*",
+            "search[is_active]": true,
             "limit": 10
           },
           method: "get",

--- a/app/assets/javascripts/pools.js
+++ b/app/assets/javascripts/pools.js
@@ -27,7 +27,6 @@
         $.ajax({
           url: "/pools.json",
           data: {
-            "search[is_active]": "true",
             "search[name_matches]": req.term,
             "limit": 10
           },

--- a/app/assets/javascripts/wiki_pages.js
+++ b/app/assets/javascripts/wiki_pages.js
@@ -20,8 +20,9 @@
         $.ajax({
           url: "/wiki_pages.json",
           data: {
-            "search[title]": "*" + req.term + "*",
+            "search[title]": req.term + "*",
             "search[hide_deleted]": "Yes",
+            "search[order]": "post_count",
             "limit": 10
           },
           method: "get",

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -38,7 +38,7 @@ class ArtistsController < ApplicationController
 
   def index
     search_params = params[:search].present? ? params[:search] : params
-    @artists = Artist.includes(:urls).search(search_params).order("id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @artists = Artist.includes(:urls).search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@artists) do |format|
       format.xml do
         render :xml => @artists.to_xml(:include => [:urls], :root => "artists")

--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -38,7 +38,7 @@ class ArtistsController < ApplicationController
 
   def index
     search_params = params[:search].present? ? params[:search] : params
-    @artists = Artist.search(search_params).order("id desc").paginate(params[:page], :limit => params[:limit])
+    @artists = Artist.includes(:urls).search(search_params).order("id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@artists) do |format|
       format.xml do
         render :xml => @artists.to_xml(:include => [:urls], :root => "artists")

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -15,7 +15,7 @@ class WikiPagesController < ApplicationController
   end
 
   def index
-    @wiki_pages = WikiPage.search(params[:search]).order("updated_at desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @wiki_pages = WikiPage.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@wiki_pages) do |format|
       format.html do
         if params[:page].nil? || params[:page].to_i == 1

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -19,9 +19,9 @@ class WikiPagesController < ApplicationController
     respond_with(@wiki_pages) do |format|
       format.html do
         if params[:page].nil? || params[:page].to_i == 1
-          if @wiki_pages.count == 1
+          if @wiki_pages.length == 1
             redirect_to(wiki_page_path(@wiki_pages.first))
-          elsif @wiki_pages.count == 0 && params[:search][:title].present? && params[:search][:title] !~ /\*/
+          elsif @wiki_pages.length == 0 && params[:search][:title].present? && params[:search][:title] !~ /\*/
             redirect_to(wiki_pages_path(:search => {:title => "*#{params[:search][:title]}*"}))
           end
         end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -419,11 +419,13 @@ class Artist < ActiveRecord::Base
       params[:order] ||= params.delete(:sort)
       case params[:order]
       when "name"
-        q = q.reorder("artists.name")
+        q = q.order("artists.name")
       when "updated_at"
-        q = q.reorder("artists.updated_at desc")
+        q = q.order("artists.updated_at desc")
+      when "post_count"
+        q = q.joins(:tag).order("tags.post_count desc")
       else
-        q = q.reorder("artists.id desc")
+        q = q.order("artists.id desc")
       end
 
       if params[:is_active] == "true"

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -45,9 +45,9 @@ class Pool < ActiveRecord::Base
     end
 
     def name_matches(name)
-      name = name.tr(" ", "_")
+      name = normalize_name_for_search(name)
       name = "*#{name}*" unless name =~ /\*/
-      where("name ilike ? escape E'\\\\'", name.to_escaped_for_sql_like)
+      where("lower(name) like ? escape E'\\\\'", name.to_escaped_for_sql_like)
     end
 
     def search(params)
@@ -137,6 +137,10 @@ class Pool < ActiveRecord::Base
 
   def self.normalize_name(name)
     name.gsub(/\s+/, "_")
+  end
+
+  def self.normalize_name_for_search(name)
+    normalize_name(name).mb_chars.downcase
   end
 
   def self.normalize_post_ids(post_ids, unique)

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -79,10 +79,15 @@ class WikiPage < ActiveRecord::Base
       end
 
       params[:order] ||= params.delete(:sort)
-      if params[:order] == "time" || params[:order] == "Date"
+      case params[:order]
+      when "time"
         q = q.order("updated_at desc")
-      elsif params[:order] == "title" || params[:order] == "Name"
+      when "title"
         q = q.order("title")
+      when "post_count"
+        q = q.joins(:tag).order("tags.post_count desc")
+      else
+        q = q.order("updated_at desc")
       end
 
       q

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -15,7 +15,7 @@
         <th><label for="search_order">Order</label>
         <td>
           <div class="input">
-            <%= select "search", "order", [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"]], :selected => params[:search][:order] %>
+            <%= select "search", "order", [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]], :selected => params[:search][:order] %>
           </div>
         </td>
       </tr>

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -13,7 +13,7 @@
 
       <div class="input">
         <label for="search_order">Order</label>
-        <%= select "search", "order", ["Name", "Date"] %>
+        <%= select "search", "order", [%w[Name title], %w[Date time], %w[Posts post_count]] %>
       </div>
 
       <div class="input">

--- a/db/migrate/20170329185605_add_updated_at_index_on_wiki_pages.rb
+++ b/db/migrate/20170329185605_add_updated_at_index_on_wiki_pages.rb
@@ -1,0 +1,7 @@
+class AddUpdatedAtIndexOnWikiPages < ActiveRecord::Migration
+  def change
+    WikiPage.without_timeout do
+      add_index :wiki_pages, :updated_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7218,6 +7218,13 @@ CREATE INDEX index_wiki_pages_on_title_pattern ON wiki_pages USING btree (title 
 
 
 --
+-- Name: index_wiki_pages_on_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_wiki_pages_on_updated_at ON wiki_pages USING btree (updated_at);
+
+
+--
 -- Name: unique_schema_migrations; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7561,4 +7568,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170314235626');
 INSERT INTO schema_migrations (version) VALUES ('20170316224630');
 
 INSERT INTO schema_migrations (version) VALUES ('20170319000519');
+
+INSERT INTO schema_migrations (version) VALUES ('20170329185605');
 


### PR DESCRIPTION
This fixes various issues with the autocomplete on the artists, wikis, and pools pages:

* de7a8cf, 3852143: autocomplete for artists and wikis currently gives poor results. This makes artists and wikis perform autocomplete the same way that tag autocomplete is performed.
* fa908a6: filter deleted artists from autocomplete (cf #2945).
* 00d0d08: *don't* filter pools marked as inactive from autocomplete. For pools, `is_active = false` doesn't mean the pool is deleted, it means the series is "complete" (no more posts will be added).
* 24e3705: fix an ambiguous column exception when doing https://danbooru.donmai.us/artists?search[empty_only]=true&search[name]=hammer*.
* 85a39ca, bb2f0ff, 6740285: optimize some queries to make autocomplete faster.
* fcc5521: add an `updated_at` index for wiki pages (makes the sidebar render faster).