### PR TITLE
Improve /post_flags, /post_appeals pages

### DIFF
--- a/app/controllers/post_appeals_controller.rb
+++ b/app/controllers/post_appeals_controller.rb
@@ -8,8 +8,8 @@ class PostAppealsController < ApplicationController
   end
 
   def index
-    @query = PostAppeal.order("post_appeals.id desc").includes(:post).search(params[:search])
-    @post_appeals = @query.paginate(params[:page], :limit => params[:limit])
+    @post_appeals = PostAppeal.includes(:creator).search(params[:search]).includes(post: [:appeals, :uploader, :approver])
+    @post_appeals = @post_appeals.paginate(params[:page], limit: params[:limit])
     respond_with(@post_appeals) do |format|
       format.xml do
         render :xml => @post_appeals.to_xml(:root => "post-appeals")

--- a/app/controllers/post_flags_controller.rb
+++ b/app/controllers/post_flags_controller.rb
@@ -8,8 +8,8 @@ class PostFlagsController < ApplicationController
   end
 
   def index
-    @query = PostFlag.order("id desc").search(params[:search])
-    @post_flags = @query.paginate(params[:page], :limit => params[:limit])
+    @post_flags = PostFlag.search(params[:search]).includes(:creator, post: [:flags, :uploader, :approver])
+    @post_flags = @post_flags.paginate(params[:page], limit: params[:limit])
     respond_with(@post_flags) do |format|
       format.xml do
         render :xml => @post_flags.to_xml(:root => "post-flags")

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -37,7 +37,7 @@ class PostAppeal < ActiveRecord::Base
     end
 
     def search(params)
-      q = where("true")
+      q = order("post_appeals.id desc")
       return q if params.blank?
 
       if params[:reason_matches].present?

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -16,6 +16,10 @@ class PostAppeal < ActiveRecord::Base
       where("reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
     end
 
+    def post_tags_match(query)
+      PostQueryBuilder.new(query).build(self.joins(:post))
+    end
+
     def resolved
       joins(:post).where("posts.is_deleted = false and posts.is_flagged = false")
     end
@@ -54,6 +58,10 @@ class PostAppeal < ActiveRecord::Base
 
       if params[:post_id].present?
         q = q.where("post_id = ?", params[:post_id].to_i)
+      end
+
+      if params[:post_tags_match].present?
+        q = q.post_tags_match(params[:post_tags_match])
       end
 
       if params[:is_resolved] == "true"

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -24,6 +24,10 @@ class PostFlag < ActiveRecord::Base
       where("reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
     end
 
+    def post_tags_match(query)
+      PostQueryBuilder.new(query).build(self.joins(:post))
+    end
+
     def resolved
       where("is_resolved = ?", true)
     end
@@ -62,6 +66,10 @@ class PostFlag < ActiveRecord::Base
 
       if params[:post_id].present?
         q = q.where("post_id = ?", params[:post_id].to_i)
+      end
+
+      if params[:post_tags_match].present?
+        q = q.post_tags_match(params[:post_tags_match])
       end
 
       if params[:is_resolved] == "true"

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -45,7 +45,7 @@ class PostFlag < ActiveRecord::Base
     end
 
     def search(params)
-      q = where("true")
+      q = order("post_flags.id desc")
       return q if params.blank?
 
       if params[:reason_matches].present?

--- a/app/views/post_appeals/_search.html.erb
+++ b/app/views/post_appeals/_search.html.erb
@@ -1,45 +1,7 @@
-<table class="search">
-  <tbody>
-    <%= form_tag(post_appeals_path, :method => :get, :class => "simple_form") do %>
-      <tr>
-        <th><label for="search_reason_matches">Reason</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "reason_matches", :label => "Reason", :value => params[:search][:reason_matches] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_post_id">Post ID</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "post_id", :value => params[:search][:post_id] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_creator_name">Creator</th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "creator_name", :value => params[:search][:creator_name] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_is_resolved">Resolved</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "is_resolved", ["true", "false"], :selected => params[:search][:is_resolved], :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <td><%= submit_tag "Search" %><td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= simple_form_for(:search, url: post_appeals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
+  <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
+  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], selected: params[:search][:is_resolved] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/post_appeals/_search.html.erb
+++ b/app/views/post_appeals/_search.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for(:search, url: post_appeals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], selected: params[:search][:is_resolved] %>

--- a/app/views/post_appeals/index.html.erb
+++ b/app/views/post_appeals/index.html.erb
@@ -7,20 +7,44 @@
       <thead>
         <tr>
           <th width="1%">Post</th>
-          <th width="10%">Creator</th>
           <th>Reason</th>
-          <th width="15%">Date</th>
+          <th width="1%">Appeals</th>
           <th width="5%">Resolved?</th>
+          <th width="15%">Uploaded</th>
+          <th width="15%">Appealed</th>
+          <th width="15%">Approver</th>
         </tr>
       </thead>
       <tbody>
         <% @post_appeals.each do |post_appeal| %>
           <tr>
             <td><%= PostPresenter.preview(post_appeal.post, :tags => "status:any") %></td>
-            <td><%= link_to_user post_appeal.creator %></td>
             <td><%= format_text post_appeal.reason, :ragel => true %></td>
-            <td><%= compact_time post_appeal.updated_at %></td>
-            <td><%= post_appeal.resolved? %></td>
+            <td>
+              <%= link_to post_appeal.post.appeals.size, post_appeals_path(search: { post_id: post_appeal.post_id }) %>
+            </td>
+            <td>
+              <%= link_to post_appeal.is_resolved.to_s, post_appeals_path(search: params[:search].merge(is_resolved: post_appeal.is_resolved)) %>
+            </td>
+            <td>
+              <%= compact_time post_appeal.post.created_at %>
+              <br> by <%= link_to_user post_appeal.post.uploader %>
+            <%= link_to "»", post_appeals_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} user:#{post_appeal.post.uploader.name}".strip)) %>
+            </td>
+            <td>
+              <%= compact_time post_appeal.created_at %>
+              <br> by <%= link_to_user post_appeal.creator %>
+              <%= link_to "»", post_appeals_path(search: params[:search].merge(creator_name: post_appeal.creator.name)) %>
+            </td>
+            <td>
+              <% if post_appeal.post.approver %>
+                <%= link_to_user post_appeal.post.approver %>
+                <%= link_to "»", post_appeals_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:#{post_appeal.post.approver.name}".strip)) %>
+              <% else %>
+                <em>none</em>
+                <%= link_to "»", post_appeals_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:none".strip)) %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for(:search, url: post_flags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <% if CurrentUser.is_moderator? %>
     <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,56 +1,10 @@
-<table class="search">
-  <tbody>
-    <%= form_tag(post_flags_path, :method => :get, :class => "simple_form") do %>
-      <tr>
-        <th><label for="search_reason_matches">Reason</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "reason_matches", :label => "Reason", :value => params[:search][:reason_matches] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_post_id">Post ID</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "post_id", :value => params[:search][:post_id] %>
-          </div>
-        </td>
-      </tr>
-
-      <% if CurrentUser.user.is_moderator? %>
-        <tr>
-          <th><label for="search_creator_name">Creator</th>
-          <td>
-            <div class="input">
-              <%= text_field "search", "creator_name", :value => params[:search][:creator_name] %>
-            </div>
-          </td>
-        </tr>
-      <% end %>
-
-      <tr>
-        <th><label for="search_is_resolved">Resolved</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "is_resolved", ["true", "false"], :selected => params[:search][:is_resolved], :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_category">Category</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "category", ["normal", "unapproved", "banned"], :selected => params[:search][:category], :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <td><%= submit_tag "Search" %><td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= simple_form_for(:search, url: post_flags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
+  <% if CurrentUser.is_moderator? %>
+    <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
+  <% end %>
+  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_resolved] %>
+  <%= f.input :category, label: "Category", collection: ["normal", "unapproved", "rejected", "deleted", "banned"], include_blank: true, selected: params[:search][:category] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -6,25 +6,53 @@
     <table width="100%" class="striped">
       <thead>
         <tr>
-          <th width="1%"></th>
-          <% if CurrentUser.user.is_moderator? %>
-            <th width="10%">Creator</th>
-          <% end %>
+          <th width="1%">Post</th>
           <th>Reason</th>
-          <th width="15%">Date</th>
+          <th width="1%">Flags</th>
+          <th width="1%">Category</th>
+          <th width="1%">Resolved?</th>
+          <th width="15%">Uploaded</th>
+          <th width="15%">Flagged</th>
+          <th width="15%">Approver</th>
         </tr>
       </thead>
       <tbody>
         <% @post_flags.each do |post_flag| %>
           <tr class="resolved-<%= post_flag.is_resolved? %>">
             <td><%= PostPresenter.preview(post_flag.post, :tags => "status:any") %></td>
-            <% if CurrentUser.user.is_moderator? %>
-              <td>
-                <%= link_to_user post_flag.creator %>
-              </td>
-            <% end %>
-            <td><%= format_text post_flag.reason, :ragel => true %></td>
-            <td><%= compact_time post_flag.updated_at %></td>
+            <td>
+              <%= format_text post_flag.reason, :ragel => true %>
+            </td>
+            <td>
+              <%= link_to post_flag.post.flags.size, post_flags_path(search: { post_id: post_flag.post_id }) %>
+            </td>
+            <td>
+              <%= link_to post_flag.category.to_s, post_flags_path(search: params[:search].merge(category: post_flag.category)) %>
+            </td>
+            <td>
+              <%= link_to post_flag.is_resolved?.to_s, post_flags_path(search: params[:search].merge(is_resolved: post_flag.is_resolved?)) %>
+            </td>
+            <td>
+              <%= compact_time post_flag.post.created_at %>
+              <br> by <%= link_to_user post_flag.post.uploader %>
+              <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} user:#{post_flag.post.uploader.name}".strip)) %>
+            </td>
+            <td>
+              <%= compact_time post_flag.created_at %>
+              <% if CurrentUser.user.is_moderator? %>
+                <br> by <%= link_to_user post_flag.creator %>
+                <%= link_to "»", post_flags_path(search: params[:search].merge(creator_name: post_flag.creator.name)) %>
+              <% end %>
+            </td>
+            <td>
+              <% if post_flag.post.approver %>
+                <%= link_to_user post_flag.post.approver %>
+                <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:#{post_flag.post.approver.name}".strip)) %>
+              <% else %>
+                <em>none</em>
+                <%= link_to "»", post_flags_path(search: params[:search].merge(post_tags_match: "#{params[:search][:post_tags_match]} approver:none".strip)) %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>


### PR DESCRIPTION
This does a few things to improve usability of the flags and appeals pages:

* adds a tag search field for filtering by tags.
* adds uploader, approver, and flagger/appealer columns.
* adds `»` links that let you narrow your search to flags for a given uploader/approver/flagger.
* adds a flag/appeal count so you can see when a post has by flagged/appealed multiple times.

Screenshots:

* https://i.imgur.com/oMjadDh.png
* https://i.imgur.com/3YPuhMB.png