### PR TITLE
Add dtext preview to flags and appeals

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
   end
 
   def dtext_field(object, name, options = {})
-    options[:name] ||= "Body"
+    options[:name] ||= name.capitalize
     options[:input_id] ||= "#{object}_#{name}"
     options[:input_name] ||= "#{object}[#{name}]"
     options[:value] ||= instance_variable_get("@#{object}").try(name)

--- a/app/views/post_appeals/_new.html.erb
+++ b/app/views/post_appeals/_new.html.erb
@@ -1,6 +1,9 @@
 <%= format_text(WikiPage.titled(Danbooru.config.appeal_notice_wiki_page).first.try(&:body), :ragel => true) %>
 
-<%= form_tag(post_appeals_path(:format => :js), :remote => true) do %>
-  <%= hidden_field_tag "post_appeal[post_id]", @post_appeal.post_id %>
-  <%= text_area :post_appeal, :reason, :size => "40x5" %>
+<!-- XXX dtext_field expects there to be a `post_appeal` instance variable. -->
+<% @post_appeal = post_appeal %>
+<%= simple_form_for(@post_appeal, format: :js, remote: true) do |f| %>
+  <%= f.hidden_field :post_id %>
+  <%= dtext_field "post_appeal", "reason", preview_id: "dtext-preview-for-post-appeal" %>
+  <%= dtext_preview_button "post_appeal", "reason", preview_id: "dtext-preview-for-post-appeal" %>
 <% end %>

--- a/app/views/post_flags/_new.html.erb
+++ b/app/views/post_flags/_new.html.erb
@@ -1,8 +1,9 @@
 <%= format_text(WikiPage.titled(Danbooru.config.flag_notice_wiki_page).first.try(&:body), :ragel => true) %>
 
-<p>Enter a reason:</p>
-
-<%= form_tag(post_flags_path(:format => :js), :remote => true) do %>
-  <%= hidden_field :post_flag, :post_id %>
-  <%= text_area :post_flag, :reason, :size => "40x5" %>
+<!-- XXX dtext_field expects there to be a `post_flag` instance variable. -->
+<% @post_flag = post_flag %>
+<%= simple_form_for(@post_flag, format: :js, remote: true) do |f| %>
+  <%= f.hidden_field :post_id %>
+  <%= dtext_field "post_flag", "reason", preview_id: "dtext-preview-for-post-flag" %>
+  <%= dtext_preview_button "post_flag", "reason", preview_id: "dtext-preview-for-post-flag" %>
 <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -119,11 +119,11 @@
   </div>
 
   <div id="flag-dialog" class="prose" title="Flag post" style="display: none;">
-    <%= render "post_flags/new" %>
+    <%= render "post_flags/new", post_flag: @post.flags.new %>
   </div>
 
   <div id="appeal-dialog" class="prose" title="Appeal post" style="display: none;">
-    <%= render "post_appeals/new" %>
+    <%= render "post_appeals/new", post_appeal: @post.appeals.new %>
   </div>
 
   <div id="add-to-pool-dialog" title="Add to pool" style="display: none;">


### PR DESCRIPTION
This adds dtext preview to the flag and appeal dialog boxes.

A caveat: this makes the `<textarea>` box for the reason bigger, too big in fact. The font size is bigger as well. The `textarea` CSS ought to be fixed so that textareas are styled consistently sitewide. I avoided that for now because it's a bigger change.

ref: https://danbooru.donmai.us/forum_topics/13927