### PR TITLE
Fix failing Pixiv tests

### DIFF
--- a/app/views/post_appeals/new.html.erb
+++ b/app/views/post_appeals/new.html.erb
@@ -1,5 +1,5 @@
 <div id="c-post-appeals">
   <div id="a-new">
-    <%= render "post_appeals/new" %>
+    <%= render "post_appeals/new", post_appeal: @post_appeal %>
   </div>
 </div>

--- a/app/views/post_flags/new.html.erb
+++ b/app/views/post_flags/new.html.erb
@@ -1,5 +1,5 @@
 <div id="c-post-flags">
   <div id="a-new">
-    <%= render "post_flags/new" %>
+    <%= render "post_flags/new", post_flag: @post_flag %>
   </div>
 </div>

--- a/test/functional/tag_subscriptions_controller_test.rb
+++ b/test/functional/tag_subscriptions_controller_test.rb
@@ -54,8 +54,8 @@ class TagSubscriptionsControllerTest < ActionController::TestCase
     end
 
     context "create action" do
-      should "create a new tag subscription" do
-        assert_difference("TagSubscription.count", 1) do
+      should "not create a new tag subscription" do
+        assert_no_difference("TagSubscription.count") do
           post :create, {:tag_subscription => {:name => "aaa", :tag_query => "bbb"}}, {:user_id => @user.id}
         end
       end

--- a/test/unit/downloads/pixiv_test.rb
+++ b/test/unit/downloads/pixiv_test.rb
@@ -75,7 +75,7 @@ module Downloads
         setup do
           @medium_page = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=62247350"
           @medium_thumbnail = "https://i.pximg.net/c/600x600/img-master/img/2017/04/04/08/54/15/62247350_p0_master1200.jpg"
-          @full_size_image  = "http://i3.pixiv.net/img-original/img/2017/04/04/08/54/15/62247350_p0.png"
+          @full_size_image  = "https://i.pximg.net/img-original/img/2017/04/04/08/54/15/62247350_p0.png"
           @file_size = 16275
         end
 
@@ -101,12 +101,12 @@ module Downloads
           @manga_page  = "http://www.pixiv.net/member_illust.php?mode=manga&illust_id=46304614"
           @manga_big_p1_page = "http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=46304614&page=1"
 
-          @p0_large_thumbnail = "http://i1.pixiv.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p0_master1200.jpg"
-          @p1_large_thumbnail = "http://i1.pixiv.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p1_master1200.jpg"
-          @p0_full_size_image = "http://i1.pixiv.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
-          @p0_full_size_image_3 = "http://i3.pixiv.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
-          @p1_full_size_image = "http://i1.pixiv.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
-          @p1_full_size_image_3 = "http://i3.pixiv.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
+          @p0_large_thumbnail = "https://i.pximg.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p0_master1200.jpg"
+          @p1_large_thumbnail = "https://i.pximg.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p1_master1200.jpg"
+          @p0_full_size_image = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
+          @p0_full_size_image_3 = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
+          @p1_full_size_image = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
+          @p1_full_size_image_3 = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
 
           @p0_file_size = 61_131
           @p1_file_size = 46_818

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -17,7 +17,7 @@ module Sources
         end
 
         should "get all the image urls" do
-          assert_equal(["http://i2.pixiv.net/img-original/img/2016/09/26/21/30/41/59182257_p0.jpg"], @image_urls)
+          assert_equal(["https://i.pximg.net/img-original/img/2016/09/26/21/30/41/59182257_p0.jpg"], @image_urls)
         end
       end
 
@@ -28,7 +28,7 @@ module Sources
         end
 
         should "get all the image urls" do
-          assert_equal("http://i4.pixiv.net/img-original/img/2016/10/29/17/13/23/59687915_p0.png", @image_urls)
+          assert_equal("https://i.pximg.net/img-original/img/2016/10/29/17/13/23/59687915_p0.png", @image_urls)
         end
       end
 
@@ -40,7 +40,7 @@ module Sources
         end
 
         should "get all the image urls" do
-          assert_equal(["http://i3.pixiv.net/img-original/img/2015/03/14/17/53/32/49270482_p0.jpg", "http://i3.pixiv.net/img-original/img/2015/03/14/17/53/32/49270482_p1.jpg"], @image_urls)
+          assert_equal(["https://i.pximg.net/img-original/img/2015/03/14/17/53/32/49270482_p0.jpg", "https://i.pximg.net/img-original/img/2015/03/14/17/53/32/49270482_p1.jpg"], @image_urls)
         end
       end
 
@@ -73,7 +73,7 @@ module Sources
         end
 
         should "get the full size image url" do
-          assert_equal("http://i3.pixiv.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif", @site.image_url)
+          assert_equal("https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif", @site.image_url)
         end
 
         should "get the page count" do
@@ -110,7 +110,7 @@ module Sources
         end
 
         should "get the full size image url" do
-          assert_equal("http://i4.pixiv.net/img-original/img/2014/10/29/09/27/19/46785915_p0.jpg", @site.image_url)
+          assert_equal("https://i.pximg.net/img-original/img/2014/10/29/09/27/19/46785915_p0.jpg", @site.image_url)
         end
       end
     end


### PR DESCRIPTION
Fix some Pixiv tests that fail due to the switch to https://i.pximg.net. Also fixes a tag subscription test, and an exception on the `/post_flags/new` and `/post_appeals/new` pages.