### PR TITLE
Add full text search for flag/appeal reasons

### DIFF
--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -12,8 +12,11 @@ class PostAppeal < ActiveRecord::Base
 
   module SearchMethods
     def reason_matches(query)
-      query = "*#{query}*" unless query =~ /\*/
-      where("reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
+      if query =~ /\*/
+        where("post_appeals.reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
+      else
+        where("to_tsvector('english', post_appeals.reason) @@ plainto_tsquery(?)", query.to_escaped_for_tsquery)
+      end
     end
 
     def post_tags_match(query)

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -20,8 +20,11 @@ class PostFlag < ActiveRecord::Base
 
   module SearchMethods
     def reason_matches(query)
-      query = "*#{query}*" unless query =~ /\*/
-      where("reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
+      if query =~ /\*/
+        where("post_flags.reason ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
+      else
+        where("to_tsvector('english', post_flags.reason) @@ plainto_tsquery(?)", query.to_escaped_for_tsquery)
+      end
     end
 
     def post_tags_match(query)

--- a/app/views/post_appeals/_search.html.erb
+++ b/app/views/post_appeals/_search.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(:search, url: post_appeals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params[:search][:reason_matches] } %>
   <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(:search, url: post_flags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :reason_matches, label: "Reason", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params[:search][:reason_matches] } %>
   <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <% if CurrentUser.is_moderator? %>

--- a/db/migrate/20170416224142_add_reason_ts_vector_index_to_post_flags_and_appeals.rb
+++ b/db/migrate/20170416224142_add_reason_ts_vector_index_to_post_flags_and_appeals.rb
@@ -1,0 +1,13 @@
+class AddReasonTsVectorIndexToPostFlagsAndAppeals < ActiveRecord::Migration
+  def up
+    execute "SET statement_timeout = 0"
+    execute "CREATE INDEX index_post_flags_on_reason_tsvector ON post_flags USING gin (to_tsvector('pg_catalog.english', reason))"
+    execute "CREATE INDEX index_post_appeals_on_reason_tsvector ON post_appeals USING gin (to_tsvector('pg_catalog.english', reason))"
+  end
+
+  def down
+    execute "SET statement_timeout = 0"
+    remove_index :post_flags, name: "index_post_flags_on_reason_tsvector"
+    remove_index :post_appeals, name: "index_post_appeals_on_reason_tsvector"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6805,7 +6805,7 @@ CREATE INDEX index_pools_on_name ON pools USING btree (name);
 -- Name: index_pools_on_name_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_pools_on_name_trgm ON pools USING gin (name gin_trgm_ops);
+CREATE INDEX index_pools_on_name_trgm ON pools USING gin (lower((name)::text) gin_trgm_ops);
 
 
 --
@@ -7580,4 +7580,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170330230231');
 INSERT INTO schema_migrations (version) VALUES ('20170413000209');
 
 INSERT INTO schema_migrations (version) VALUES ('20170414005856');
+
+INSERT INTO schema_migrations (version) VALUES ('20170414233426');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6837,6 +6837,13 @@ CREATE INDEX index_post_appeals_on_post_id ON post_appeals USING btree (post_id)
 
 
 --
+-- Name: index_post_appeals_on_reason_tsvector; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_appeals_on_reason_tsvector ON post_appeals USING gin (to_tsvector('english'::regconfig, reason));
+
+
+--
 -- Name: index_post_approvals_on_post_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -6883,6 +6890,13 @@ CREATE INDEX index_post_flags_on_creator_ip_addr ON post_flags USING btree (crea
 --
 
 CREATE INDEX index_post_flags_on_post_id ON post_flags USING btree (post_id);
+
+
+--
+-- Name: index_post_flags_on_reason_tsvector; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_post_flags_on_reason_tsvector ON post_flags USING gin (to_tsvector('english'::regconfig, reason));
 
 
 --
@@ -7582,4 +7596,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170413000209');
 INSERT INTO schema_migrations (version) VALUES ('20170414005856');
 
 INSERT INTO schema_migrations (version) VALUES ('20170414233426');
+
+INSERT INTO schema_migrations (version) VALUES ('20170416224142');
 


### PR DESCRIPTION
This would add full text search for flag and appeal reasons. This is so that searches like `quality check` will match variations like `rechecking quality`.

Note that the index here is defined as an expression index: `USING gin (to_tsvector('english', reason))`. This way avoids the need to have a separate index column with a trigger function that updates that column, as is done is most other places using a gin index.