### PR TITLE
Fix #2974: Wiki Pages Being Updated Erroneously on Artist Edits

### DIFF
--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -1,23 +1,25 @@
 class WikiPage < ActiveRecord::Base
   class RevertError < Exception ; end
 
-  before_save :normalize_title
-  before_save :normalize_other_names
   before_validation :initialize_creator, :on => :create
   before_validation :initialize_updater
-  after_save :create_version
-  belongs_to :creator, :class_name => "User"
-  belongs_to :updater, :class_name => "User"
   validates_uniqueness_of :title, :case_sensitive => false
   validates_presence_of :title
   validate :validate_rename
   validate :validate_locker_is_builder
   validate :validate_not_locked
-  attr_accessor :skip_secondary_validations
-  attr_accessible :title, :body, :is_locked, :is_deleted, :other_names, :skip_secondary_validations
+  before_save :normalize_title
+  before_save :normalize_other_names
+  after_save :create_version
+
+  belongs_to :creator, :class_name => "User"
+  belongs_to :updater, :class_name => "User"
   has_one :tag, :foreign_key => "name", :primary_key => "title"
   has_one :artist, lambda {where(:is_active => true)}, :foreign_key => "name", :primary_key => "title"
   has_many :versions, lambda {order("wiki_page_versions.id ASC")}, :class_name => "WikiPageVersion", :dependent => :destroy
+
+  attr_accessor :skip_secondary_validations
+  attr_accessible :title, :body, :is_locked, :is_deleted, :other_names, :skip_secondary_validations
 
   module SearchMethods
     def titled(title)

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -115,6 +115,18 @@ class ArtistTest < ActiveSupport::TestCase
       assert_equal("kokoko", artist.wiki_page.body)
     end
 
+    should "not bump the wiki page when notes are unchanged" do
+      artist = FactoryGirl.create(:artist, name: "bkub", notes: "honk honk")
+      updater_name_was = artist.wiki_page.updater_name
+      updated_at_was = artist.wiki_page.updated_at
+
+      updater = FactoryGirl.create(:user)
+      CurrentUser.scoped(updater) { artist.update(notes: "honk honk") }
+
+      assert_equal(updater_name_was, artist.wiki_page.updater_name)
+      assert_equal(updated_at_was, artist.wiki_page.updated_at)
+    end
+
     should "normalize its name" do
       artist = FactoryGirl.create(:artist, :name => "  AAA BBB  ")
       assert_equal("aaa_bbb", artist.name)

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -67,6 +67,21 @@ class WikiPageTest < ActiveSupport::TestCase
         assert_equal("hot_potato", matches.first.title)
       end
 
+      should "change the updater if the wiki changed" do
+        updater = FactoryGirl.create(:user)
+        CurrentUser.scoped(updater) { @wiki_page.update(title: "honk honk") }
+
+        assert_equal(updater.id, @wiki_page.updater_id)
+      end
+
+      should "not change the updater if the wiki didn't change" do
+        updater = FactoryGirl.create(:user)
+
+        assert_no_difference("@wiki_page.updater_id") do
+          CurrentUser.scoped(updater) { @wiki_page.update(title: "HOT POTATO") }
+        end
+      end
+
       should "create versions" do
         assert_difference("WikiPageVersion.count") do
           @wiki_page = FactoryGirl.create(:wiki_page, :title => "xxx")


### PR DESCRIPTION
Fixes #2974. Sets the `updater_id` only when the wiki page has actually been changed.