### PR TITLE
Improve /bans listing

### DIFF
--- a/app/assets/stylesheets/common/000_vars.scss
+++ b/app/assets/stylesheets/common/000_vars.scss
@@ -27,6 +27,9 @@ $preview_flagged_color: #F00;
 $preview_sample_warning_color:  hsl(0,  100%, 90%); // light red
 $preview_quality_warning_color: hsl(50, 100%, 90%); // light yellow
 
+$error_color: hsl(0, 100%, 95%); // light red
+$success_color: hsl(120, 100%, 95%); // light green
+
 @mixin border-radius($val) {
   -moz-border-radius: $val;
   -webkit-border-radius: $val;

--- a/app/assets/stylesheets/common/tables.scss
+++ b/app/assets/stylesheets/common/tables.scss
@@ -40,6 +40,22 @@ table.striped {
   }
 }
 
+/*
+ * A table where one column expands to fill the screen, while the
+ * other columns shrink to fit their contents.
+ */
+table.autofit {
+  td, th, .col-fit {
+    white-space: nowrap;
+    padding-right: 2em;
+  }
+
+  .col-expand {
+    white-space: normal;
+    width: 100%;
+  }
+}
+
 table.search {
   tr {
     height: 2em;

--- a/app/assets/stylesheets/specific/bans.scss
+++ b/app/assets/stylesheets/specific/bans.scss
@@ -1,0 +1,19 @@
+@import "../common/000_vars.scss";
+
+#c-bans #a-index {
+  tr[data-expired="true"] {
+    background-color: $success_color !important;
+
+    &:hover {
+      background-color: darken($success_color, 5%) !important;
+    }
+  }
+
+  tr[data-expired="false"] {
+    background-color: $error_color !important;
+
+    &:hover {
+      background-color: darken($error_color, 5%) !important;
+    }
+  }
+}

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -11,8 +11,8 @@ class BansController < ApplicationController
   end
 
   def index
-    @search = Ban.search(params[:search]).order("id desc")
-    @bans = @search.paginate(params[:page], :limit => params[:limit])
+    @bans = Ban.search(params[:search])
+    @bans = @bans.paginate(params[:page], :limit => params[:limit])
     respond_with(@bans)
   end
 

--- a/app/controllers/bans_controller.rb
+++ b/app/controllers/bans_controller.rb
@@ -11,9 +11,10 @@ class BansController < ApplicationController
   end
 
   def index
-    @bans = Ban.search(params[:search])
-    @bans = @bans.paginate(params[:page], :limit => params[:limit])
-    respond_with(@bans)
+    @bans = Ban.search(params[:search]).paginate(params[:page], :limit => params[:limit])
+    respond_with(@bans) do |fmt|
+      fmt.html { @bans = @bans.includes(:user, :banner) }
+    end
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -81,6 +81,14 @@ module ApplicationHelper
     content_tag(:time, content || datetime, :datetime => datetime, :title => time.to_formatted_s)
   end
 
+  def humanized_duration(from, to)
+    duration = distance_of_time_in_words(from, to)
+    datetime = from.iso8601 + "/" + to.iso8601
+    title = "#{from.strftime("%Y-%m-%d %H:%M")} to #{to.strftime("%Y-%m-%d %H:%M")}"
+
+    raw content_tag(:time, duration, datetime: datetime, title: title)
+  end
+
   def time_ago_in_words_tagged(time)
     raw time_tag(time_ago_in_words(time) + " ago", time)
   end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -74,7 +74,7 @@ class UserFeedback < ActiveRecord::Base
   extend SearchMethods
 
   def initialize_creator
-    self.creator_id = CurrentUser.id
+    self.creator_id ||= CurrentUser.id
   end
 
   def user_name

--- a/app/views/bans/_search.html.erb
+++ b/app/views/bans/_search.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for(:search, method: :get, url: bans_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :user_name, label: "User", input_html: { value: params[:search][:user_name] } %>
+  <%= f.input :banner_name, label: "Banner", input_html: { value: params[:search][:banner_name] } %>
+  <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard", input_html: { value: params[:search][:reason_matches] } %>
+  <%= f.input :expired, label: "Expired?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:expired] %>
+  <%= f.input :order, include_blank: false, collection: [%w[Created id_desc], %w[Expiration expires_at_desc]], selected: params[:search][:order] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -16,8 +16,14 @@
       <tbody>
         <% @bans.each do |ban| %>
           <tr id="ban-<%= ban.id %>" data-expired="<%= ban.expired? %>">
-            <td><%= link_to_user(ban.user) %></td>
-            <td><%= link_to_user(ban.banner) %></td>
+            <td>
+              <%= link_to_user(ban.user) %>
+              <%= link_to "»", bans_path(search: params[:search].merge(user_name: ban.user.name)) %>
+            </td>
+            <td>
+              <%= link_to_user(ban.banner) %>
+              <%= link_to "»", bans_path(search: params[:search].merge(banner_name: ban.banner.name)) %>
+            </td>
             <td><%= time_ago_in_words_tagged(ban.created_at) %></td>
             <td><%= humanized_duration(ban.created_at, ban.expires_at) %></td>
             <td class="col-expand"><%= format_text ban.reason, :ragel => true %></td>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Bans</h1>
 
+    <%= render "search" %>
+
     <table class="striped autofit">
       <thead>
         <tr>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -6,6 +6,8 @@
       <thead>
         <tr>
           <th>User</th>
+          <th>Banner</th>
+          <th>Banned</th>
           <th>Expires</th>
           <th>Reason</th>
           <th></th>
@@ -15,6 +17,8 @@
         <% @bans.each do |ban| %>
           <tr id="ban-<%= ban.id %>" data-expired="<%= ban.expired? %>">
             <td><%= link_to_user(ban.user) %></td>
+            <td><%= link_to_user(ban.banner) %></td>
+            <td><%= time_ago_in_words_tagged(ban.created_at) %></td>
             <td><%= ban.expires_at %></td>
             <td class="col-expand"><%= format_text ban.reason, :ragel => true %></td>
             <td>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -2,7 +2,7 @@
   <div id="a-index">
     <h1>Bans</h1>
 
-    <table class="striped" width="100%">
+    <table class="striped autofit">
       <thead>
         <tr>
           <th>User</th>
@@ -16,7 +16,7 @@
           <tr id="ban-<%= ban.id %>" data-expired="<%= ban.expired? %>">
             <td><%= link_to_user(ban.user) %></td>
             <td><%= ban.expires_at %></td>
-            <td><%= format_text ban.reason, :ragel => true %></td>
+            <td class="col-expand"><%= format_text ban.reason, :ragel => true %></td>
             <td>
               <% if CurrentUser.is_moderator? %>
                 <%= link_to "Edit", edit_ban_path(ban) %>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -8,7 +8,7 @@
           <th>User</th>
           <th>Banner</th>
           <th>Banned</th>
-          <th>Expires</th>
+          <th>Duration</th>
           <th>Reason</th>
           <th></th>
         </tr>
@@ -19,7 +19,7 @@
             <td><%= link_to_user(ban.user) %></td>
             <td><%= link_to_user(ban.banner) %></td>
             <td><%= time_ago_in_words_tagged(ban.created_at) %></td>
-            <td><%= ban.expires_at %></td>
+            <td><%= humanized_duration(ban.created_at, ban.expires_at) %></td>
             <td class="col-expand"><%= format_text ban.reason, :ragel => true %></td>
             <td>
               <% if CurrentUser.is_moderator? %>

--- a/app/views/bans/index.html.erb
+++ b/app/views/bans/index.html.erb
@@ -1,5 +1,5 @@
-<div class="bans">
-  <div class="index">
+<div id="c-bans">
+  <div id="a-index">
     <h1>Bans</h1>
 
     <table class="striped" width="100%">
@@ -13,7 +13,7 @@
       </thead>
       <tbody>
         <% @bans.each do |ban| %>
-          <tr id="ban-<%= ban.id %>">
+          <tr id="ban-<%= ban.id %>" data-expired="<%= ban.expired? %>">
             <td><%= link_to_user(ban.user) %></td>
             <td><%= ban.expires_at %></td>
             <td><%= format_text ban.reason, :ragel => true %></td>

--- a/test/unit/ban_test.rb
+++ b/test/unit/ban_test.rb
@@ -165,6 +165,26 @@ class BanTest < ActiveSupport::TestCase
   end
 
   context "Searching for a ban" do
+    should "find a given ban" do
+      CurrentUser.user = FactoryGirl.create(:admin_user)
+      CurrentUser.ip_addr = "127.0.0.1"
+
+      user = FactoryGirl.create(:user)
+      ban = FactoryGirl.create(:ban, user: user)
+      params = {
+        user_name: user.name,
+        banner_name: ban.banner.name,
+        reason: ban.reason,
+        expired: false,
+        order: :id_desc
+      }
+
+      bans = Ban.search(params)
+
+      assert_equal(1, bans.length)
+      assert_equal(ban.id, bans.first.id)
+    end
+
     context "by user id" do
       setup do
         @admin = FactoryGirl.create(:admin_user)


### PR DESCRIPTION
This would add some improvements to the `/bans` page:

* adds a search form.
* adds columns for the banner, ban creation time, and ban duration.
* color code bans as expired or unexpired.

The result should be a lot more usable: [before](https://i.imgur.com/gTxeVMW.png), [after](https://i.imgur.com/E93Pamj.png).