### PR TITLE
Support mp4s of ftyp "avc1"

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -344,7 +344,7 @@ class Upload < ActiveRecord::Base
       when /^\x1a\x45\xdf\xa3/n
         "video/webm"
 
-      when /^....ftyp(?:isom|3gp5|mp42|MSNV)/
+      when /^....ftyp(?:isom|3gp5|mp42|MSNV|avc1)/
         "video/mp4"
 
       when /^PK\x03\x04/


### PR DESCRIPTION
This file can't be uploaded: https://img.pawoo.net/media_attachments/files/000/133/785/original/06d859c9db2b0060.mp4.

The problem is that filetype detection during upload rejects it. It's an mp4 with an `ftyp` of `avc1`, but this `ftyp` isn't on the whitelist.

According to http://www.ftyps.com/, there are a large number of valid `ftyp` designations. It might be better to use ffmpeg or something to detect the filetype.