### PR TITLE
Allow <ruby> tags for marking up furigana in notes.

### DIFF
--- a/app/assets/stylesheets/specific/notes.scss
+++ b/app/assets/stylesheets/specific/notes.scss
@@ -34,6 +34,12 @@ div#note-container {
       font-size: 0.8em;
     }
 
+    ruby {
+      rt {
+        font-size: 0.8em;
+      }
+    }
+
     ul {
       margin-left: 1em;
       margin-bottom: 1em;

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -363,7 +363,7 @@ class DText
 
     Sanitize.clean(
       text,
-      :elements => %w(code center tn h1 h2 h3 h4 h5 h6 a span div blockquote br p ul li ol em strong small big b i font u s pre),
+      :elements => %w(code center tn h1 h2 h3 h4 h5 h6 a span div blockquote br p ul li ol em strong small big b i font u s pre ruby rb rt rp),
       :attributes => {
         "a" => %w(href title style),
         "span" => %w(class style),


### PR DESCRIPTION
This would allow the `<ruby>`, `<rb>`, `<rp>`, and `<rt>` HTML tags to be used in notes. This is so that translators can mark up furigana without resorting to CSS hacks.

Discussion:

* https://danbooru.donmai.us/posts/2697885
* https://danbooru.donmai.us/forum_topics/13353?page=1#forum_post_130038

References:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ruby
* https://www.w3.org/TR/css-ruby-1/
* https://jsfiddle.net/3L4zszzs/2/