### PR TITLE
Fix broken tag subscription migrations.

### DIFF
--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -112,6 +112,11 @@ class SavedSearch < ActiveRecord::Base
   end
 
   def label_string=(val)
-    self.labels = val.to_s.scan(/\S+/).map {|x| SavedSearch.normalize_label(x)}
+    self.labels = val.to_s.split(/[[:space:]]+/)
+  end
+
+  def labels=(labels)
+    labels = labels.map { |label| SavedSearch.normalize_label(label) }
+    super(labels)
   end
 end

--- a/app/models/tag_subscription.rb
+++ b/app/models/tag_subscription.rb
@@ -11,13 +11,8 @@ class TagSubscription < ActiveRecord::Base
 
   def migrate_to_saved_searches
     tag_query.split(/\r\n|\r|\n/).each do |query|
-      creator.saved_searches.create(
-        :tag_query => query,
-        :category => name
-      )
+      creator.saved_searches.create({query: query, labels: [name]}, without_protection: true)
     end
-    
-    destroy
   end
 
   def normalize_name

--- a/test/unit/saved_search_test.rb
+++ b/test/unit/saved_search_test.rb
@@ -95,6 +95,14 @@ class SavedSearchTest < ActiveSupport::TestCase
     should "normalize whitespace" do
       assert_equal("xxx", @saved_search.query)
     end
+
+    should "normalize the label string" do
+      @saved_search.label_string = "Foo Bar"
+      assert_equal(%w[foo bar], @saved_search.labels)
+
+      @saved_search.labels = ["Artist 1", "Artist 2"]
+      assert_equal(%w[artist_1 artist_2], @saved_search.labels)
+    end
   end
 
   context "Destroying a saved search" do

--- a/test/unit/tag_subscription_test.rb
+++ b/test/unit/tag_subscription_test.rb
@@ -72,6 +72,16 @@ class TagSubscriptionTest < ActiveSupport::TestCase
         assert_equal([posts[1].id], TagSubscription.find_posts(user.id, "yyy").map(&:id))
       end
     end
+
+    should "migrate to saved searches" do
+      sub = FactoryGirl.create(:tag_subscription, tag_query: "foo bar\r\nbar\nbaz", :name => "Artist 1")
+      sub.migrate_to_saved_searches
+
+      assert_equal(1, CurrentUser.user.subscriptions.size)
+      assert_equal(3, CurrentUser.user.saved_searches.size)
+      assert_equal(["bar foo", "bar", "baz"], CurrentUser.user.saved_searches.pluck(:query))
+      assert_equal([%w[artist_1]]*3, CurrentUser.user.saved_searches.pluck(:labels))
+    end
   end
 
   context "A tag subscription manager" do


### PR DESCRIPTION
Migrating tag subscriptions to saved searches is broken. The problem is that the migration code still uses the `tag_query` / `category` params instead of `query` / `labels`. Consequently migrating a subscription deletes it without creating any saved searches.

This fixes the bug. It also skips deleting the subscription after it is migrated. This is so the user can verify it was moved properly before deleting it themselves.