### PR TITLE
Fix broken tag autocomplete on multiple pages

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -87,18 +87,8 @@
   }
 
   Danbooru.Autocomplete.initialize_tag_autocomplete = function() {
-    var $fields_multiple = $(
-      "#tags,#post_tag_string,#upload_tag_string,#tag-script-field,#c-moderator-post-queues #query," +
-      "#user_blacklisted_tags,#user_favorite_tags,#search_post_tags_match"
-    );
-    var $fields_single = $(
-      "#c-tags #search_name_matches,#c-tag-aliases #query,#c-tag-implications #query," +
-      "#wiki_page_title," +
-      "#tag_alias_request_antecedent_name,#tag_alias_request_consequent_name," +
-      "#tag_implication_request_antecedent_name,#tag_implication_request_consequent_name," +
-      "#tag_alias_antecedent_name,#tag_alias_consequent_name," +
-      "#tag_implication_antecedent_name,#tag_implication_consequent_name"
-    );
+    var $fields_multiple = $('[data-autocomplete="tag-query"], [data-autocomplete="tag-edit"]');
+    var $fields_single = $('[data-autocomplete="tag"]');
 
     var prefixes = "-|~|general:|gen:|artist:|art:|copyright:|copy:|co:|character:|char:|ch:";
     var metatags = "order|-status|status|-rating|rating|-locked|locked|child|filetype|-filetype|" +

--- a/app/views/artist_commentaries/search.html.erb
+++ b/app/views/artist_commentaries/search.html.erb
@@ -1,21 +1,13 @@
 <div id="c-artist-commentaries">
   <div id="a-search">
     <h1>Search Artist Commentary</h1>
-    <%= form_tag(artist_commentaries_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "text_matches", :label => "Text" %>
-      <%= search_field "post_tags_match", :label => "Tags" %>
 
-      <div class="input">
-        <label for="search_original_present">Original present?</label>
-        <%= select "search", "original_present", ["yes", "no"], :include_blank => true %>
-      </div>
-
-      <div class="input">
-        <label for="search_translated_present">Translation present?</label>
-        <%= select "search", "translated_present", ["yes", "no"], :include_blank => true %>
-      </div>
-
-      <%= submit_tag "Search" %>
+    <%= simple_form_for(:search, url: artist_commentaries_path, method: :get, defaults: { required: false }) do |f| %>
+      <%= f.input :text_matches, label: "Text" %>
+      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.input :original_present, label: "Original present?", collection: ["yes", "no"], include_blank: true %>
+      <%= f.input :translated_present, label: "Translation present?", collection: ["yes", "no"], include_blank: true %>
+      <%= f.submit "Search" %>
     <% end %>
   </div>
 </div>

--- a/app/views/artist_commentaries/search.html.erb
+++ b/app/views/artist_commentaries/search.html.erb
@@ -4,7 +4,7 @@
 
     <%= simple_form_for(:search, url: artist_commentaries_path, method: :get, defaults: { required: false }) do |f| %>
       <%= f.input :text_matches, label: "Text" %>
-      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
       <%= f.input :original_present, label: "Original present?", collection: ["yes", "no"], include_blank: true %>
       <%= f.input :translated_present, label: "Translation present?", collection: ["yes", "no"], include_blank: true %>
       <%= f.submit "Search" %>

--- a/app/views/comments/search.html.erb
+++ b/app/views/comments/search.html.erb
@@ -6,7 +6,7 @@
       <%= hidden_field_tag "group_by", "comment", :id => "group_by_full" %>
       <%= f.input :creator_name, label: "Commenter" %>
       <%= f.input :body_matches, label: "Body" %>
-      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
       <%= f.input :is_deleted, label: "Deleted?", collection: [["Yes", true], ["No", false]] %>
       <%= f.input :is_sticky, label: "Sticky?", collection: [["Yes", true], ["No", false]] %>
       <%= f.input :do_not_bump_post, label: "Bumping?", collection: [["Yes", false], ["No", true]] %>

--- a/app/views/meta_searches/tags.html.erb
+++ b/app/views/meta_searches/tags.html.erb
@@ -4,7 +4,7 @@
 
     <section>
       <%= form_tag(meta_searches_tags_path, :method => :get) do %>
-        <%= text_field_tag "name", params[:name] %>
+        <%= text_field_tag "name", params[:name], :data => { :autocomplete => "tag" } %>
         <%= submit_tag "Go" %>
       <% end %>
     </section>

--- a/app/views/moderator/bulk_reverts/new.html.erb
+++ b/app/views/moderator/bulk_reverts/new.html.erb
@@ -22,13 +22,13 @@
 
       <div class="input" id="added-tags-input">
         <label>Added Tags</label>
-        <%= text_field :constraints, :added_tags, :value => @constraints[:added_tags] %>
+        <%= text_field :constraints, :added_tags, :value => @constraints[:added_tags], :data => { :autocomplete => "tag" } %>
         <p class="hint">You must specify a user to add tags</p>
       </div>
 
       <div class="input" id="removed-tags-input">
         <label>Removed Tags</label>
-        <%= text_field :constraints, :removed_tags, :value => @constraints[:removed_tags] %>
+        <%= text_field :constraints, :removed_tags, :value => @constraints[:removed_tags], :data => { :autocomplete => "tag" } %>
         <p class="hint">You must specify a user to add tags</p>
       </div>
 

--- a/app/views/moderator/post/queues/show.html.erb
+++ b/app/views/moderator/post/queues/show.html.erb
@@ -5,7 +5,7 @@
 
       <div id="search">
         <%= form_tag(moderator_post_queue_path, :method => :get) do %>
-          <%= text_field_tag "query", params[:query], :size => 40 %>
+          <%= text_field_tag "query", params[:query], :size => 40, :data => { :autocomplete => "tag-query" } %>
           <%= select_tag "per_page", options_for_select(%w(25 50 100 200), cookies["mq_per_page"])%>
           <%= submit_tag "Search" %>
         <% end %>

--- a/app/views/moderator/tags/edit.html.erb
+++ b/app/views/moderator/tags/edit.html.erb
@@ -5,12 +5,12 @@
     <%= form_tag(moderator_tag_path, :method => :put, :class => "simple_form") do %>
       <div class="input">
         <label>Antecedent</label>
-        <%= text_field :tag, :antecedent, :value => params[:antecedent] %>
+        <%= text_field :tag, :antecedent, :value => params[:antecedent], :data => { :autocomplete => "tag-query" } %>
       </div>
 
       <div class="input">
         <label>Consequent</label>
-        <%= text_field :tag, :consequent, :value => params[:consequent] %>
+        <%= text_field :tag, :consequent, :value => params[:consequent], :data => { :autocomplete => "tag-edit" } %>
       </div>
 
       <div class="input">

--- a/app/views/notes/search.html.erb
+++ b/app/views/notes/search.html.erb
@@ -7,7 +7,7 @@
 
       <%= f.input :body_matches, label: "Body" %>
       <%= f.input :creator_name, label: "Author" %>
-      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
       <%= f.submit "Search" %>
     <% end %>
   </div>

--- a/app/views/notes/search.html.erb
+++ b/app/views/notes/search.html.erb
@@ -2,13 +2,13 @@
   <div id="a-search">
     <h1>Search Notes</h1>
 
-    <%= form_tag(notes_path, :method => :get, :class => "simple_form") do %>
-      <%= hidden_field_tag "group_by", "note" %>
+    <%= simple_form_for(:search, url: notes_path, method: :get, defaults: { required: false }) do |f| %>
+      <%= f.hidden_field :group_by, value: "note" %>
 
-      <%= search_field "body_matches", :label => "Body" %>
-      <%= search_field "creator_name", :label => "Author" %>
-      <%= search_field "post_tags_match", :label => "Tags" %>
-      <%= submit_tag "Search" %>
+      <%= f.input :body_matches, label: "Body" %>
+      <%= f.input :creator_name, label: "Author" %>
+      <%= f.input :post_tags_match, label: "Tags" %>
+      <%= f.submit "Search" %>
     <% end %>
   </div>
 </div>

--- a/app/views/post_appeals/_search.html.erb
+++ b/app/views/post_appeals/_search.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for(:search, url: post_appeals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params[:search][:reason_matches] } %>
-  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
   <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], selected: params[:search][:is_resolved] %>

--- a/app/views/post_flags/_search.html.erb
+++ b/app/views/post_flags/_search.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for(:search, url: post_flags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :reason_matches, label: "Reason", hint: "Use * for wildcard searches", input_html: { value: params[:search][:reason_matches] } %>
-  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
+  <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <% if CurrentUser.is_moderator? %>
     <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>

--- a/app/views/posts/partials/common/_search.html.erb
+++ b/app/views/posts/partials/common/_search.html.erb
@@ -6,7 +6,7 @@
 <section id="search-box">
   <h1>Search</h1>
   <%= form_tag(path, :method => "get") do %>
-    <%= text_field_tag("tags", tags, :size => 20, :id => tags_dom_id) %>
+    <%= text_field_tag("tags", tags, :size => 20, :id => tags_dom_id, :data => { :autocomplete => "tag-query" }) %>
     <% if params[:raw] %>
       <%= hidden_field_tag :raw, params[:raw] %>
     <% end %>

--- a/app/views/posts/partials/index/_edit.html.erb
+++ b/app/views/posts/partials/index/_edit.html.erb
@@ -3,7 +3,7 @@
 
   <%= form_tag("/posts", :class => "simple_form", :method => :put, :id => "quick-edit-form") do %>
     <div class="input">
-      <%= text_area_tag "post[tag_string]", "" %>
+      <%= text_area_tag "post[tag_string]", "", :data => { :autocomplete => "tag-edit" } %>
       <%= submit_tag "Submit", :data => { :disable_with => "Submitting..." } %>
       <%= submit_tag "Cancel" %>
     </div>

--- a/app/views/posts/partials/index/_mode_menu.html.erb
+++ b/app/views/posts/partials/index/_mode_menu.html.erb
@@ -25,6 +25,6 @@
         <% end %>
       </select>
     </form>
-    <input id="tag-script-field" placeholder="Enter tag script" style="display: none; margin-top: 0.5em;"></input>
+    <input id="tag-script-field" data-autocomplete="tag-edit" placeholder="Enter tag script" style="display: none; margin-top: 0.5em;"></input>
   </section>
 <% end %>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -79,7 +79,7 @@
   <div class="input">
     <div>
       <%= f.label :tag_string, "Tags" %>
-      <%= f.text_area :tag_string, :size => "50x5", :value => post.presenter.categorized_tag_string + " " %>
+      <%= f.text_area :tag_string, :size => "50x5", :value => post.presenter.categorized_tag_string + " ", :data => { :autocomplete => "tag-edit" } %>
       <span id="open-edit-dialog" class="ui-icon ui-icon-arrow-1-ne" title="detach" style="display: none;"/>
     </div>
 

--- a/app/views/related_tags/show.html.erb
+++ b/app/views/related_tags/show.html.erb
@@ -2,7 +2,7 @@
   <h1>Related tags</h1>
   <section>
     <%= form_tag(related_tag_path, :method => :get) do %>
-      <%= text_field_tag "query", params[:query] %>
+      <%= text_field_tag "query", params[:query], :data => { :autocomplete => "tag" } %>
       <%= select_tag "category", options_for_select([""] + Danbooru.config.canonical_tag_category_mapping.map{|x| [x.first, x.first.downcase]}, params[:category]) %>
       <%= submit_tag "Show"%>
     <% end %>

--- a/app/views/tag_alias_requests/new.html.erb
+++ b/app/views/tag_alias_requests/new.html.erb
@@ -9,12 +9,12 @@
     <%= form_tag(tag_alias_request_path, :class => "simple_form") do %>
       <div class="input">
         <label>From</label>
-        <%= text_field "tag_alias_request", "antecedent_name" %>
+        <%= text_field "tag_alias_request", "antecedent_name", :data => { :autocomplete => "tag" } %>
       </div>
 
       <div class="input">
         <label>To</label>
-        <%= text_field "tag_alias_request", "consequent_name" %>
+        <%= text_field "tag_alias_request", "consequent_name", :data => { :autocomplete => "tag" } %>
       </div>
 
       <div class="input">

--- a/app/views/tag_aliases/index.html.erb
+++ b/app/views/tag_aliases/index.html.erb
@@ -1,11 +1,9 @@
 <div id="c-tag-aliases">
   <div id="a-index">
-    <div class="search">
-      <%= form_tag(tag_aliases_path, :method => :get) do %>
-        <%= text_field :search, :name_matches, :value => params[:search][:name_matches] %>
-        <%= submit_tag "Search" %>
-      <% end %>
-    </div>
+    <%= simple_form_for(:search, method: :get, url: tag_aliases_path, defaults: { required: false }) do |f| %>
+      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches] } %>
+      <%= f.submit "Search" %>
+    <% end %>
 
     <%= render "listing", :tag_aliases => @tag_aliases %>
 

--- a/app/views/tag_aliases/index.html.erb
+++ b/app/views/tag_aliases/index.html.erb
@@ -1,7 +1,7 @@
 <div id="c-tag-aliases">
   <div id="a-index">
     <%= simple_form_for(:search, method: :get, url: tag_aliases_path, defaults: { required: false }) do |f| %>
-      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches] } %>
+      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/tag_implication_requests/new.html.erb
+++ b/app/views/tag_implication_requests/new.html.erb
@@ -9,12 +9,12 @@
     <%= form_tag(tag_implication_request_path, :class => "simple_form") do %>
       <div class="input">
         <label>From</label>
-        <%= text_field "tag_implication_request", "antecedent_name" %>
+        <%= text_field "tag_implication_request", "antecedent_name", :data => { :autocomplete => "tag" } %>
       </div>
 
       <div class="input">
         <label>To</label>
-        <%= text_field "tag_implication_request", "consequent_name" %>
+        <%= text_field "tag_implication_request", "consequent_name", :data => { :autocomplete => "tag" } %>
       </div>
 
       <div class="input">

--- a/app/views/tag_implications/index.html.erb
+++ b/app/views/tag_implications/index.html.erb
@@ -1,7 +1,7 @@
 <div id="c-tag-implications">
   <div id="a-index">
     <%= simple_form_for(:search, method: :get, url: tag_implications_path, defaults: { required: false }) do |f| %>
-      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches] } %>
+      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/tag_implications/index.html.erb
+++ b/app/views/tag_implications/index.html.erb
@@ -1,11 +1,9 @@
 <div id="c-tag-implications">
   <div id="a-index">
-    <div class="search">
-      <%= form_tag(tag_implications_path, :method => :get) do %>
-        <%= text_field :search, :name_matches, :value => params[:search][:name_matches] %>
-        <%= submit_tag "Search" %>
-      <% end %>
-    </div>
+    <%= simple_form_for(:search, method: :get, url: tag_implications_path, defaults: { required: false }) do |f| %>
+      <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches] } %>
+      <%= f.submit "Search" %>
+    <% end %>
 
     <%= render "listing", :tag_implications => @tag_implications %>
 

--- a/app/views/tags/_quick_search.html.erb
+++ b/app/views/tags/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(tags_path, :method => :get) do %>
-  <%= text_field "search", "name_matches", :id => "quick_search_name_matches", :placeholder => "Search tags" %>
+  <%= text_field "search", "name_matches", :id => "quick_search_name_matches", :placeholder => "Search tags", :data => { :autocomplete => "tag" } %>
 <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -1,64 +1,9 @@
-<table class="search">
-  <tbody>
-    <%= form_tag(tags_path, :method => :get, :class => "simple_form") do %>
-      <tr>
-        <th><label for="search_name_matches">Name</label></th>
-        <td>
-          <div class="input">
-            <%= text_field "search", "name_matches", :value => params[:search][:name_matches] %>
-            <span class="hint">Use * for wildcard</span>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_category">Category</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "category", [""] + Danbooru.config.canonical_tag_category_mapping.to_a, :selected => params[:search][:category] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_order">Order</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "order", %w(count date name), :selected => params[:search][:order] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_hide_empty">Hide Empty</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "hide_empty", ["yes", "no"], :selected => params[:search][:hide_empty] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_has_wiki">Has a Wiki Page</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "has_wiki", ["yes", "no"], :selected => params[:search][:has_wiki], :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_has_artist">Has an Artist Entry</label></th>
-        <td>
-          <div class="input">
-            <%= select "search", "has_artist", ["yes", "no"], :selected => params[:search][:has_artist], :include_blank => true %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <td><%= submit_tag "Search" %><td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= simple_form_for(:search, url: tags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name_matches] } %>
+  <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true,selected: params[:search][:category] %>
+  <%= f.input :order, collection: [%w[Newest date], %w[Count count], %w[Name name]], include_blank: false, selected: params[:search][:order] %>
+  <%= f.input :hide_empty, label: "Hide empty?", collection: %w[yes no], selected: params[:search][:hide_empty] %>
+  <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true, selected: params[:search][:has_wiki] %>
+  <%= f.input :has_artist, label: "Has artist?", collection: %w[yes no], include_blank: true, selected: params[:search][:has_artist] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(:search, url: tags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name_matches] } %>
+  <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
   <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true,selected: params[:search][:category] %>
   <%= f.input :order, collection: [%w[Newest date], %w[Count count], %w[Name name]], include_blank: false, selected: params[:search][:order] %>
   <%= f.input :hide_empty, label: "Hide empty?", collection: %w[yes no], selected: params[:search][:hide_empty] %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -101,7 +101,7 @@
         <div class="input">
           <div>
             <%= f.label :tag_string, "Tags" %>
-            <%= f.text_area :tag_string, :size => "60x5" %>
+            <%= f.text_area :tag_string, :size => "60x5", :data => { :autocomplete => "tag-edit" } %>
             <span id="open-edit-dialog" class="ui-icon ui-icon-arrow-1-ne" title="detach" style="display: none;"/>
           </div>
 

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -48,7 +48,7 @@
           <%= f.input :per_page, :label => "Posts per page", :as => :select, :collection => (1..100), :include_blank => false %>
         <% end %>
         
-        <%= f.input :blacklisted_tags, :hint => "Put any tag combinations you never want to see here. Each combination should go on a separate line. <a href='/wiki_pages/help:blacklists'>View help.</a>".html_safe, :input_html => {:size => "40x5"} %>
+        <%= f.input :blacklisted_tags, :hint => "Put any tag combinations you never want to see here. Each combination should go on a separate line. <a href='/wiki_pages/help:blacklists'>View help.</a>".html_safe, :input_html => {:size => "40x5", :data => {:autocomplete => "tag-query"}} %>
       </fieldset>
       
       <fieldset id="advanced-settings-section">
@@ -76,7 +76,7 @@
 
         <%= f.input :enable_recent_searches, :as => :select, :collection => [["No", "false"], ["Yes", "true"]], :include_blank => false %>
 
-        <%= f.input :favorite_tags, :label => "Frequent tags", :hint => "A list of tags that you use often. They will appear when using the list of Related Tags.", :input_html => { :rows => 5 } %>
+        <%= f.input :favorite_tags, :label => "Frequent tags", :hint => "A list of tags that you use often. They will appear when using the list of Related Tags.", :input_html => { :rows => 5, :data => { :autocomplete => "tag-query" } } %>
 
         <div class="input text optional field_with_hint">
           <label class="text optional" for="user_dmail_filter_attributes_words">Dmail filter</label>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -3,9 +3,9 @@
 
   <%= simple_form_for(@wiki_page) do |f| %>
     <% if @wiki_page.new_record? %>
-      <%= f.input :title, error: false %>
+      <%= f.input :title, error: false, input_html: { data: { autocomplete: "tag" } } %>
     <% else %>
-      <%= f.input :title, error: false, hint: "Change to rename this wiki page. Move the tag and update any wikis linking to this page first." %>
+      <%= f.input :title, error: false, input_html: { data: { autocomplete: "tag" } }, hint: "Change to rename this wiki page. Move the tag and update any wikis linking to this page first." %>
     <% end %>
 
     <%= f.input :other_names, :as => :text, :label => "Other names (<a href='/wiki_pages/help:translated_tags'>view help</a>)".html_safe, :hint => "Names used for this tag on other sites such as Pixiv. Separate with spaces." %>


### PR DESCRIPTION
Tag autocomplete doesn't work in the `/posts` search box in the responsive layout. It also doesn't work in a few other places, namely the tag aliases and implications pages, the moderator mass edit page, and the bulk revert page.

This fixes it by marking all inputs that should be autocompleted with a  `data-autocomplete` attribute. This should be less fragile than the current method of hardcoding a big list of html ids in the javascript.

In doing this I converted some search forms over to simple form. This wasn't entirely necessary, but it's generally shorter and it helps ensure that forms are formatted consistently across the site.