### PR TITLE
Fix #2990: Wiki Autocomplete Misses On Certain Meta-wikis

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -437,7 +437,7 @@ class Artist < ActiveRecord::Base
       when "updated_at"
         q = q.order("artists.updated_at desc")
       when "post_count"
-        q = q.joins(:tag).order("tags.post_count desc")
+        q = q.includes(:tag).order("tags.post_count desc nulls last").references(:tags)
       else
         q = q.order("artists.id desc")
       end

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -87,7 +87,7 @@ class WikiPage < ActiveRecord::Base
       when "title"
         q = q.order("title")
       when "post_count"
-        q = q.joins(:tag).order("tags.post_count desc")
+        q = q.includes(:tag).order("tags.post_count desc nulls last").references(:tags)
       else
         q = q.order("updated_at desc")
       end

--- a/test/functional/wiki_pages_controller_test.rb
+++ b/test/functional/wiki_pages_controller_test.rb
@@ -28,6 +28,11 @@ class WikiPagesControllerTest < ActionController::TestCase
         get :index, {:search => {:title => "abc"}}
         assert_redirected_to(wiki_page_path(@wiki_page_abc))
       end
+
+      should "list wiki_pages without tags with order=post_count" do
+        get :index, {:search => {:title => "abc", :order => "post_count"}}
+        assert_redirected_to(wiki_page_path(@wiki_page_abc))
+      end
     end
 
     context "show action" do


### PR DESCRIPTION
Fixes #2990. `/wiki_pages?search[order]=post_count` didn't include wiki pages that didn't belong to a tag. This was due to doing an inner join on the tags table instead of a left outer join.