### PR TITLE
Fix slow related tag calculations when searching single metatags.

### DIFF
--- a/app/logical/related_tag_calculator.rb
+++ b/app/logical/related_tag_calculator.rb
@@ -11,24 +11,15 @@ class RelatedTagCalculator
     convert_hash_to_array(calculate_from_sample(tags, Danbooru.config.post_sample_size, category_constraint))
   end
 
-  def self.calculate_from_post_set_to_array(post_set, category_constraint = nil)
-    convert_hash_to_array(calculate_from_post_set(post_set, category_constraint))
+  def self.calculate_from_posts_to_array(posts)
+    convert_hash_to_array(calculate_from_posts(posts))
   end
 
-  def self.calculate_from_post_set(post_set, category_constraint = nil)
+  def self.calculate_from_posts(posts)
     counts = Hash.new {|h, k| h[k] = 0}
 
-    post_set.posts.each do |post|
-      post.tag_array.each do |tag|
-        category = Tag.category_for(tag)
-        if category_constraint
-          if category == category_constraint
-            counts[tag] += 1
-          end
-        else
-          counts[tag] += 1
-        end
-      end
+    posts.flat_map(&:tag_array).each do |tag|
+      counts[tag] += 1
     end
 
     counts

--- a/app/presenters/post_set_presenters/post.rb
+++ b/app/presenters/post_set_presenters/post.rb
@@ -1,11 +1,14 @@
 module PostSetPresenters
   class Post < Base
-    attr_accessor :post_set, :tag_set_presenter
+    attr_accessor :post_set
     delegate :posts, :to => :post_set
 
     def initialize(post_set)
       @post_set = post_set
-      @tag_set_presenter = TagSetPresenter.new(related_tags)
+    end
+
+    def tag_set_presenter
+      @tag_set_presenter ||= TagSetPresenter.new(related_tags)
     end
 
     def related_tags
@@ -51,7 +54,7 @@ module PostSetPresenters
     end
 
     def calculate_related_tags_from_post_set
-      RelatedTagCalculator.calculate_from_post_set_to_array(post_set).map(&:first)
+      RelatedTagCalculator.calculate_from_posts_to_array(post_set.posts).map(&:first)
     end
 
     def saved_search_labels

--- a/test/unit/related_tag_calculator_test.rb
+++ b/test/unit/related_tag_calculator_test.rb
@@ -18,11 +18,11 @@ class RelatedTagCalculatorTest < ActiveSupport::TestCase
         FactoryGirl.create(:post, :tag_string => "aaa bbb ccc ddd")
         FactoryGirl.create(:post, :tag_string => "aaa bbb ccc")
         FactoryGirl.create(:post, :tag_string => "aaa bbb")
-        @post_set = PostSets::Post.new("aaa")
+        @posts = Post.tag_match("aaa")
       end
 
       should "calculate the related tags" do
-        assert_equal({"aaa"=>3, "bbb"=>3, "ccc"=>2, "ddd"=>1}, RelatedTagCalculator.calculate_from_post_set(@post_set))
+        assert_equal({"aaa"=>3, "bbb"=>3, "ccc"=>2, "ddd"=>1}, RelatedTagCalculator.calculate_from_posts(@posts))
       end
     end
 


### PR DESCRIPTION
Searching for single metatags such as `order:rank` or `user:evazion` or `fav:evazion` is somewhat slow. The culprit is the related tags sidebar. The related tags calculator calls `Tag.category_for` in its inner loop, which causes a memcache lookup on every iteration. At 100 posts per page and 20-30 tags per post, this led to 2000-3000 total memcache calls, which significantly slows the pageload.

This removes the `category_constraint` option from `RelatedTagCalculator.calculate_from_posts` entirely. As far as I can tell it isn't used anywhere.