### PR TITLE
Fix [quote] stripping for comments, forum post replies.

### DIFF
--- a/app/assets/javascripts/comments.js
+++ b/app/assets/javascripts/comments.js
@@ -18,22 +18,6 @@
     }
   }
 
-  Danbooru.Comment.quote_message = function(data) {
-    var blocks = data["body"].match(/\[\/?quote\]|.|\n|\r/gm);
-    var n = 0;
-    var stripped_body = "";
-    $.each(blocks, function(i, block) {
-      if (block === "[quote]") {
-        n += 1;
-      } else if (block == "[/quote]") {
-        n -= 1;
-      } else if (n === 0) {
-        stripped_body += block;
-      }
-    });
-    return "[quote]\n" + data["creator_name"] + " said:\n\n" + stripped_body + "\n[/quote]\n\n";
-  }
-
   Danbooru.Comment.quote = function(e) {
     $.get(
       "/comments/" + $(e.target).data('comment-id') + ".json",
@@ -41,7 +25,7 @@
         var $link = $(e.target);
         var $div = $link.closest("div.comments-for-post").find(".new-comment");
         var $textarea = $div.find("textarea");
-        var msg = Danbooru.Comment.quote_message(data);
+        var msg = data["quoted_response"];
         if ($textarea.val().length > 0) {
           msg = $textarea.val() + "\n\n" + msg;
         }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -48,7 +48,7 @@ class CommentsController < ApplicationController
 
   def show
     @comment = Comment.find(params[:id])
-    respond_with(@comment)
+    respond_with(@comment, methods: [:quoted_response])
   end
 
   def destroy

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -12,6 +12,11 @@ class DText
     CGI.escapeHTML(string)
   end
 
+  def self.quote(message, creator_name)
+    stripped_body = DText.strip_blocks(message, "quote")
+    "[quote]\n#{creator_name} said:\n\n#{stripped_body}\n[/quote]\n\n"
+  end
+
   def self.strip_blocks(string, tag)
     n = 0
     stripped = ""

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -13,10 +13,16 @@ class DText
   end
 
   def self.strip_blocks(string, tag)
-    blocks = string.scan(/\[\/?#{tag}\]|.+?(?=\[\/?#{tag}\]|$)/m)
     n = 0
     stripped = ""
-    blocks.each do |block|
+    string = string.dup
+
+    string.gsub!(/\s*\[#{tag}\](?!\])\s*/m, "\n\n[#{tag}]\n\n")
+    string.gsub!(/\s*\[\/#{tag}\]\s*/m, "\n\n[/#{tag}]\n\n")
+    string.gsub!(/(?:\r?\n){3,}/, "\n\n")
+    string.strip!
+
+    string.split(/\n{2}/).each do |block|
       case block
       when "[#{tag}]"
         n += 1
@@ -26,7 +32,7 @@ class DText
 
       else
         if n == 0
-          stripped += block
+          stripped << "#{block}\n\n"
         end
       end
     end

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -22,8 +22,8 @@ class DText
     stripped = ""
     string = string.dup
 
-    string.gsub!(/\s*\[#{tag}\](?!\])\s*/m, "\n\n[#{tag}]\n\n")
-    string.gsub!(/\s*\[\/#{tag}\]\s*/m, "\n\n[/#{tag}]\n\n")
+    string.gsub!(/\s*\[#{tag}\](?!\])\s*/mi, "\n\n[#{tag}]\n\n")
+    string.gsub!(/\s*\[\/#{tag}\]\s*/mi, "\n\n[/#{tag}]\n\n")
     string.gsub!(/(?:\r?\n){3,}/, "\n\n")
     string.strip!
 

--- a/app/logical/mentionable.rb
+++ b/app/logical/mentionable.rb
@@ -16,31 +16,10 @@ module Mentionable
     end
   end
 
-  def strip_quote_blocks(str)
-    stripped = ""
-    str.gsub!(/\s*\[quote\](?!\])\s*/m, "\n\n[quote]\n\n")
-    str.gsub!(/\s*\[\/quote\]\s*/m, "\n\n[/quote]\n\n")
-    str.gsub!(/(?:\r?\n){3,}/, "\n\n")
-    str.strip!
-    nest = 0
-    str.split(/\n{2}/).each do |block|
-      if block == "[quote]"
-        nest += 1
-
-      elsif block == "[/quote]"
-        nest -= 1
-
-      elsif nest == 0
-        stripped << "#{block}\n"
-      end
-    end
-
-    stripped
-  end
-
   def queue_mention_messages
     from_id = read_attribute(self.class.mentionable_option(:user_field))
-    text = strip_quote_blocks(read_attribute(self.class.mentionable_option(:message_field)))
+    text = read_attribute(self.class.mentionable_option(:message_field))
+    text = DText.strip_blocks(text, "quote")
 
     names = text.scan(DText::MENTION_REGEXP).map do |mention|
       mention.gsub!(/(?:^\s*@)|(?:[:;,.!?\)\]<>]$)/, "")

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -249,6 +249,10 @@ class Comment < ActiveRecord::Base
   def undelete!
     update({ :is_deleted => false }, :as => CurrentUser.role)
   end
+
+  def quoted_response
+    DText.quote(body, creator_name)
+  end
 end
 
 Comment.connection.extend(PostgresExtensions)

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -234,8 +234,7 @@ class ForumPost < ActiveRecord::Base
   end
 
   def quoted_response
-    stripped_body = DText.strip_blocks(body, "quote")
-    "[quote]\n#{creator_name} said:\n\n#{stripped_body}\n[/quote]\n\n"
+    DText.quote(body, creator_name)
   end
 
   def forum_topic_page

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -243,6 +243,33 @@ class CommentTest < ActiveSupport::TestCase
           assert_equal([comment], post.comments.visible(user))
         end
       end
+
+      context "that is quoted" do
+        should "strip [quote] tags correctly" do
+          comment = FactoryGirl.create(:comment, body: <<-EOS.strip_heredoc)
+            paragraph one
+
+            [quote]
+            somebody said:
+
+            blah blah blah
+            [/QUOTE]
+
+            paragraph two
+          EOS
+
+          assert_equal(<<-EOS.strip_heredoc, comment.quoted_response)
+            [quote]
+            #{comment.creator_name} said:
+
+            paragraph one
+
+            paragraph two
+            [/quote]
+
+          EOS
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
From https://danbooru.donmai.us/forum_topics/9127?page=177#forum_post_130215:

> I found a weird bug on this [comment](https://danbooru.donmai.us/posts/2700454#comment-1682984). If you try to reply it, only the first paragraph appears on the comment box, while the other two are completely omitted.

There are two problems here:

* That comment has a `[quote][/QUOTE]` block, but the `[quote]` stripping code doesn't recognize uppercase `[/QUOTE]` tags.

* There are three separate `[quote]` stripping implementations (!): one for forum posts, one for \@mentions, and one for comments. The one for comments is in javascript.

This refactors things so that `DText.quote` is a single implementation that everything uses. There were slight differences between each version, but the one for \@mentions looked the best so I went with that.