### PR TITLE
/post_appeals: add blank option to Resolved dropdown.

### DIFF
--- a/app/views/post_appeals/_search.html.erb
+++ b/app/views/post_appeals/_search.html.erb
@@ -3,6 +3,6 @@
   <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
   <%= f.input :post_id, label: "Post ID", input_html: { value: params[:search][:post_id] } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
-  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], selected: params[:search][:is_resolved] %>
+  <%= f.input :is_resolved, label: "Resolved?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_resolved] %>
   <%= f.submit "Search" %>
 <% end %>


### PR DESCRIPTION
The [/post_appeals](http://danbooru.donmai.us/post_appeals) search form is missing a blank option for the Resolved dropdown.