### PR TITLE
Fix #2994: More options for artist search page

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -430,6 +430,26 @@ class Artist < ActiveRecord::Base
         q = q.any_name_matches(params[:name])
       end
 
+      if params[:name_matches].present?
+        q = q.name_matches(params[:name_matches])
+      end
+
+      if params[:other_names_match].present?
+        q = q.other_names_match(params[:other_names_match])
+      end
+
+      if params[:group_name_matches].present?
+        q = q.group_name_matches(params[:group_name_matches])
+      end
+
+      if params[:any_name_matches].present?
+        q = q.any_name_matches(params[:any_name_matches])
+      end
+
+      if params[:url_matches].present?
+        q = q.url_matches(params[:url_matches])
+      end
+
       params[:order] ||= params.delete(:sort)
       case params[:order]
       when "name"
@@ -466,8 +486,15 @@ class Artist < ActiveRecord::Base
         q = q.where("creator_id = ?", params[:creator_id].to_i)
       end
 
+      # XXX deprecated, remove at some point.
       if params[:empty_only] == "true"
-        q = q.joins(:tag).where("tags.post_count = 0")
+        params[:has_tag] = "false"
+      end
+
+      if params[:has_tag] == "true"
+        q = q.joins(:tag).where("tags.post_count > 0")
+      elsif params[:has_tag] == "false"
+        q = q.includes(:tag).where("tags.name IS NULL OR tags.post_count <= 0").references(:tags)
       end
 
       q

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -1,5 +1,10 @@
 <%= simple_form_for(:search, url: artists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :name, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name] } %>
+  <%= f.input :url_matches, label: "URL", as: "string", input_html: { value: params[:search][:url_matches] } %>
+  <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
+  <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_active] %>
+  <%= f.input :is_banned, label: "Banned?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_banned] %>
+  <%= f.input :has_tag, label: "Has tag?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:has_tag] %>
   <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]], selected: params[:search][:order] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -1,28 +1,5 @@
-<table class="search">
-  <tbody>
-    <%= form_tag(artists_path, :method => :get, :class => "simple_form") do %>
-      <tr>
-        <th><label for="search_name">Name</label>
-        <td>
-          <div class="input">
-            <%= text_field "search", "name", :value => params[:search][:name] %>
-            <span class="hint">You can search on any name or URL</span>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <th><label for="search_order">Order</label>
-        <td>
-          <div class="input">
-            <%= select "search", "order", [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]], :selected => params[:search][:order] %>
-          </div>
-        </td>
-      </tr>
-
-      <tr>
-        <td><%= submit_tag "Search" %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<%= simple_form_for(:search, url: artists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :name, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name] } %>
+  <%= f.input :order, collection: [["Recently created", "created_at"], ["Last updated", "updated_at"], ["Name", "name"], ["Post count", "post_count"]], selected: params[:search][:order] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -291,6 +291,8 @@ class ArtistTest < ActiveSupport::TestCase
     should "search on its name should return results" do
       artist = FactoryGirl.create(:artist, :name => "artist")
       assert_not_nil(Artist.search(:name => "artist").first)
+      assert_not_nil(Artist.search(:name_matches => "artist").first)
+      assert_not_nil(Artist.search(:any_name_matches => "artist").first)
     end
 
     should "search on other names should return matches" do
@@ -300,6 +302,9 @@ class ArtistTest < ActiveSupport::TestCase
       assert_not_nil(Artist.other_names_match("ccc_ddd").first)
       assert_not_nil(Artist.search(:name => "other:aaa").first)
       assert_not_nil(Artist.search(:name => "aaa").first)
+
+      assert_not_nil(Artist.search(:other_names_match => "aaa").first)
+      assert_not_nil(Artist.search(:any_name_matches => "aaa").first)
     end
 
     should "search on group name and return matches" do
@@ -308,6 +313,18 @@ class ArtistTest < ActiveSupport::TestCase
       cat_or_fish.reload
       assert_equal("yuu", cat_or_fish.member_names)
       assert_not_nil(Artist.search(:name => "group:cat_or_fish").first)
+
+      assert_not_nil(Artist.search(:group_name_matches => "cat_or_fish").first)
+      assert_not_nil(Artist.search(:any_name_matches => "cat_or_fish").first)
+    end
+
+    should "search on has_tag and return matches" do
+      post = FactoryGirl.create(:post, tag_string: "bkub")
+      bkub = FactoryGirl.create(:artist, name: "bkub")
+      none = FactoryGirl.create(:artist, name: "none")
+
+      assert_equal(bkub.id, Artist.search(has_tag: "true").first.id)
+      assert_equal(none.id, Artist.search(has_tag: "false").first.id)
     end
 
     should "revert to prior versions" do


### PR DESCRIPTION
Fixes #2994. Adds these fields to the /artists search form:

* URL
* Creator
* Active?
* Banned?
* Has Tag?

And adds these params to the API:

* `search[name_matches]`
* `search[other_names_match]`
* `search[group_name_matches]`
* `search[any_name_matches]`
* `search[url_matches]`
* `search[has_tag]`

`has_tag=true` means the artist has a nonempty tag. `has_tag=false` means the artist entry doesn't have a tag or the tag is empty. `has_tag=false` is equivalent to `empty_only=true`.