### PR TITLE
Add noter:<any|none>, commenter:<any|none> metatags

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -245,7 +245,13 @@ class PostQueryBuilder
 
     if q[:noter_ids]
       q[:noter_ids].each do |noter_id|
-        relation = relation.where("posts.id IN (?)", Note.unscoped.where("creator_id = ?", noter_id).select("post_id").uniq)
+        if noter_id == "any"
+          relation = relation.where("posts.last_noted_at is not null")
+        elsif noter_id == "none"
+          relation = relation.where("posts.last_noted_at is null")
+        else
+          relation = relation.where("posts.id": Note.unscoped.where(creator_id: noter_id).select("post_id").distinct)
+        end
       end
       has_constraints!
     end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -238,7 +238,13 @@ class PostQueryBuilder
 
     if q[:commenter_ids]
       q[:commenter_ids].each do |commenter_id|
-        relation = relation.where("posts.id IN (?)", Comment.unscoped.where("creator_id = ?", commenter_id).select("post_id").uniq)
+        if commenter_id == "any"
+          relation = relation.where("posts.last_commented_at is not null")
+        elsif commenter_id == "none"
+          relation = relation.where("posts.last_commented_at is null")
+        else
+          relation = relation.where("posts.id":  Comment.unscoped.where(creator_id: commenter_id).select(:post_id).distinct)
+        end
       end
       has_constraints!
     end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -14,8 +14,8 @@ class Comment < ActiveRecord::Base
   after_update(:if => lambda {|rec| CurrentUser.id != rec.creator_id}) do |rec|
     ModAction.log("comment ##{rec.id} updated by #{CurrentUser.name}")
   end
-  after_update :update_last_commented_at_on_destroy, :if => lambda {|rec| rec.is_deleted? && rec.is_deleted_changed?}
-  after_update(:if => lambda {|rec| rec.is_deleted? && rec.is_deleted_changed? && CurrentUser.id != rec.creator_id}) do |rec|
+  after_save :update_last_commented_at_on_destroy, :if => lambda {|rec| rec.is_deleted? && rec.is_deleted_changed?}
+  after_save(:if => lambda {|rec| rec.is_deleted? && rec.is_deleted_changed? && CurrentUser.id != rec.creator_id}) do |rec|
     ModAction.log("comment ##{rec.id} deleted by #{CurrentUser.name}")
   end
   attr_accessible :body, :post_id, :do_not_bump_post, :is_deleted, :as => [:member, :gold, :platinum, :builder, :janitor, :moderator, :admin]
@@ -171,13 +171,13 @@ class Comment < ActiveRecord::Base
   include VoteMethods
 
   def initialize_creator
-    self.creator_id = CurrentUser.user.id
-    self.ip_addr = CurrentUser.ip_addr
+    self.creator_id ||= CurrentUser.user.id
+    self.ip_addr ||= CurrentUser.ip_addr
   end
 
   def initialize_updater
-    self.updater_id = CurrentUser.user.id
-    self.updater_ip_addr = CurrentUser.ip_addr
+    self.updater_id ||= CurrentUser.user.id
+    self.updater_ip_addr ||= CurrentUser.ip_addr
   end
 
   def creator_name

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -443,8 +443,15 @@ class Tag < ActiveRecord::Base
 
           when "commenter", "comm"
             q[:commenter_ids] ||= []
-            user_id = User.name_to_id($2)
-            q[:commenter_ids] << user_id unless user_id.blank?
+
+            if $2 == "none"
+              q[:commenter_ids] << "none"
+            elsif $2 == "any"
+              q[:commenter_ids] << "any"
+            else
+              user_id = User.name_to_id($2)
+              q[:commenter_ids] << user_id unless user_id.blank?
+            end
 
           when "noter"
             q[:noter_ids] ||= []

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -448,8 +448,15 @@ class Tag < ActiveRecord::Base
 
           when "noter"
             q[:noter_ids] ||= []
-            user_id = User.name_to_id($2)
-            q[:noter_ids] << user_id unless user_id.blank?
+
+            if $2 == "none"
+              q[:noter_ids] << "none"
+            elsif $2 == "any"
+              q[:noter_ids] << "any"
+            else
+              user_id = User.name_to_id($2)
+              q[:noter_ids] << user_id unless user_id.blank?
+            end
 
           when "noteupdater"
             q[:note_updater_ids] ||= []

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1788,6 +1788,24 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match([posts[2]], "approver:none")
     end
 
+    should "return posts for the commenter:<name> metatag" do
+      users = FactoryGirl.create_list(:user, 2, created_at: 2.weeks.ago)
+      posts = FactoryGirl.create_list(:post, 2)
+      comms = users.zip(posts).map { |u, p| FactoryGirl.create(:comment, creator: u, post: p) }
+
+      assert_tag_match([posts[0]], "commenter:#{users[0].name}")
+      assert_tag_match([posts[1]], "commenter:#{users[1].name}")
+    end
+
+    should "return posts for the commenter:<any|none> metatag" do
+      posts = FactoryGirl.create_list(:post, 2)
+      FactoryGirl.create(:comment, post: posts[0], is_deleted: false)
+      FactoryGirl.create(:comment, post: posts[1], is_deleted: true)
+
+      assert_tag_match([posts[0]], "commenter:any")
+      assert_tag_match([posts[1]], "commenter:none")
+    end
+
     should "return posts for the noter:<name> metatag" do
       users = FactoryGirl.create_list(:user, 2)
       posts = FactoryGirl.create_list(:post, 2)
@@ -1795,6 +1813,15 @@ class PostTest < ActiveSupport::TestCase
 
       assert_tag_match([posts[0]], "noter:#{users[0].name}")
       assert_tag_match([posts[1]], "noter:#{users[1].name}")
+    end
+
+    should "return posts for the noter:<any|none> metatag" do
+      posts = FactoryGirl.create_list(:post, 2)
+      FactoryGirl.create(:note, post: posts[0], is_active: true)
+      FactoryGirl.create(:note, post: posts[1], is_active: false)
+
+      assert_tag_match([posts[0]], "noter:any")
+      assert_tag_match([posts[1]], "noter:none")
     end
 
     should "return posts for the artcomm:<name> metatag" do


### PR DESCRIPTION
Adds these metatags:

* `noter:any` - all posts with notes.
* `noter:none` - all posts without notes.
* `commenter:any` - all posts with comments.
* `commenter:none` - all posts without comments.

These tags are similar in purpose to `order:note` and `order:comment`, but without forcing an ordering. Saying `noter:any` to mean "posts that have notes" is kind of unintuitive, but it's chosen to be consistent with `approver:any`.