### PR TITLE
Fix tag list for responsive layout.

### DIFF
--- a/app/assets/stylesheets/common/responsive.scss
+++ b/app/assets/stylesheets/common/responsive.scss
@@ -13,8 +13,21 @@
     display: none;
   }
 
-  aside {
-    font-size: 18pt;
+  div#page {
+    > div /* div#c-$controller */ {
+      > div /* div#a-$action */ {
+        display: flex;
+        flex-direction: column;
+
+        /* Move #sidebar below #content. */
+        > aside#sidebar {
+          font-size: 1.5em;
+          float: none;
+          width: auto;
+          order: 2;
+        }
+      }
+    }
   }
 
   #maintoggle {

--- a/app/assets/stylesheets/common/responsive.scss
+++ b/app/assets/stylesheets/common/responsive.scss
@@ -122,13 +122,6 @@
     }
   }
 
-  section#responsive-tag-list {
-    display: block;
-    h1 {
-      font-size: 1em;
-    }
-  }
-
   div#page {
     div.comments-for-post div.list-of-comments article.comment div.content {
       clear: both;
@@ -179,10 +172,6 @@
 }
 
 @media screen and (max-width: 440px) {
-  #responsive-tag-list {
-    display: block;
-  }
-
   input#expand-search {
     display: none;
   }

--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -299,12 +299,6 @@ div#c-posts {
     font-size: $h4_size;
   }
 
-  aside#sidebar > section#pool-sidebar {
-    span.ui-icon {
-      color: #666;
-    }
-  }
-
   aside#sidebar > section > ul {
     margin-bottom: 1em;
   }


### PR DESCRIPTION
From https://danbooru.donmai.us/forum_topics/9127?page=178#forum_post_130472:

> There is a problem with the translation notes: on the mobile site the picture is under the taglist, but the notes are above said taglist and not on the pic.

> The notes bug I can reproduce on [post #2706242](https://danbooru.donmai.us/posts/2706242) when the browser width is between 410px and 660px.

The problem is the responsive tag list was replaced by the regular sidebar in b7f207180c52a43bed9f477c660580bd0055d2eb, but the regular sidebar is still `float: left`. This fixes it to be `float: none`.

This also moves the taglist back beneath the image, like it was with responsive tag list, except using CSS instead of duplicating the markup. This means it works on all pages too, including for the sidebars on /favorites and wiki pages.