### PR TITLE
Fix #2995: Saved searches’ tags are getting reordered

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -236,6 +236,15 @@ class Tag < ActiveRecord::Base
       query.to_s.gsub(/\u3000/, " ").strip
     end
 
+    def normalize_query(query, sort: true)
+      tags = Tag.scan_query(query.to_s)
+      tags = tags.map { |t| Tag.normalize_name(t) }
+      tags = TagAlias.to_aliased(tags)
+      tags = tags.sort if sort
+      tags = tags.uniq
+      tags.join(" ")
+    end
+
     def scan_query(query)
       tagstr = normalize(query)
       list = tagstr.scan(/-?source:".*?"/) || []

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -186,8 +186,8 @@ class TagAlias < ActiveRecord::Base
   end
 
   def initialize_creator
-    self.creator_id = CurrentUser.user.id
-    self.creator_ip_addr = CurrentUser.ip_addr
+    self.creator_id ||= CurrentUser.user.id
+    self.creator_ip_addr ||= CurrentUser.ip_addr
   end
 
   def antecedent_tag

--- a/test/factories/tag_alias.rb
+++ b/test/factories/tag_alias.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     consequent_name "bbb"
     status "active"
     skip_secondary_validations true
+    creator_ip_addr { FFaker::Internet.ip_v4_address }
 
     after(:create) do |tag_alias|
       unless tag_alias.status == "pending"

--- a/test/unit/saved_search_test.rb
+++ b/test/unit/saved_search_test.rb
@@ -30,13 +30,18 @@ class SavedSearchTest < ActiveSupport::TestCase
   context ".queries_for" do
     setup do
       @user = FactoryGirl.create(:user)
+      FactoryGirl.create(:tag_alias, antecedent_name: "bbb", consequent_name: "ccc", creator: @user)
       FactoryGirl.create(:saved_search, user: @user, label_string: "blah", query: "aaa")
-      FactoryGirl.create(:saved_search, user: @user, label_string: "zah", query: "bbb")
+      FactoryGirl.create(:saved_search, user: @user, label_string: "zah", query: "CCC BBB AAA")
+      FactoryGirl.create(:saved_search, user: @user, label_string: "qux", query: " aaa  bbb  ccc ")
     end
 
     should "fetch the queries used by a user for a label" do
       assert_equal(%w(aaa), SavedSearch.queries_for(@user.id, "blah"))
-      assert_equal(%w(aaa bbb), SavedSearch.queries_for(@user.id))
+    end
+
+    should "return fully normalized queries" do
+      assert_equal(["aaa", "aaa ccc"], SavedSearch.queries_for(@user.id))
     end
   end
 
@@ -84,7 +89,8 @@ class SavedSearchTest < ActiveSupport::TestCase
   context "Creating a saved search" do
     setup do
       @user = FactoryGirl.create(:gold_user)
-      @saved_search = @user.saved_searches.create(:query => " xxx ")
+      FactoryGirl.create(:tag_alias, antecedent_name: "zzz", consequent_name: "yyy", creator: @user)
+      @saved_search = @user.saved_searches.create(:query => " ZZZ xxx ")
     end
 
     should "update the bitpref on the user" do
@@ -92,8 +98,8 @@ class SavedSearchTest < ActiveSupport::TestCase
       assert(@user.has_saved_searches?, "should have saved_searches bitpref set")
     end
 
-    should "normalize whitespace" do
-      assert_equal("xxx", @saved_search.query)
+    should "normalize the query aside from the order" do
+      assert_equal("yyy xxx", @saved_search.query)
     end
 
     should "normalize the label string" do


### PR DESCRIPTION
Fixes #2995. Normalize the query \*except\* for the tag ordering when the saved search is saved. Normalize everything \*including\* the ordering when the search is sent to listbooru.

This normalization applies tag aliases as well, which should mean that rewriting saved searches when an alias is approved isn't necessary.