### PR TITLE
Saved searches: drop unused name and category columns.

### DIFF
--- a/db/migrate/20170428220448_remove_name_and_category_from_saved_searches.rb
+++ b/db/migrate/20170428220448_remove_name_and_category_from_saved_searches.rb
@@ -1,0 +1,8 @@
+class RemoveNameAndCategoryFromSavedSearches < ActiveRecord::Migration
+  def change
+    SavedSearch.without_timeout do
+      remove_column :saved_searches, :name, :text
+      remove_column :saved_searches, :category, :text
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6886,13 +6886,6 @@ CREATE INDEX index_posts_on_uploader_id ON posts USING btree (uploader_id);
 
 
 --
--- Name: index_saved_searches_on_category; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_saved_searches_on_category ON saved_searches USING btree (category);
-
-
---
 -- Name: index_saved_searches_on_labels; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7475,4 +7468,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170414233426');
 INSERT INTO schema_migrations (version) VALUES ('20170414233617');
 
 INSERT INTO schema_migrations (version) VALUES ('20170416224142');
+
+INSERT INTO schema_migrations (version) VALUES ('20170428220448');
 


### PR DESCRIPTION
`name` and `category` haven't been used since saved searches were rewritten.