### PR TITLE
Fix #1566: disallow blank note bodies.

### DIFF
--- a/app/assets/javascripts/notes.js
+++ b/app/assets/javascripts/notes.js
@@ -447,7 +447,7 @@ Danbooru.Note = {
     },
 
     error_handler: function(xhr, status, exception) {
-      Danbooru.error("There was an error saving the note");
+      Danbooru.error("Error: " + xhr.responseJSON.reasons.join("; "));
     },
 
     success_handler: function(data, status, xhr) {

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -8,8 +8,7 @@ class Note < ActiveRecord::Base
   has_many :versions, lambda {order("note_versions.id ASC")}, :class_name => "NoteVersion", :dependent => :destroy
   before_validation :initialize_creator, :on => :create
   before_validation :initialize_updater
-  before_validation :blank_body
-  validates_presence_of :post_id, :creator_id, :updater_id, :x, :y, :width, :height
+  validates_presence_of :post_id, :creator_id, :updater_id, :x, :y, :width, :height, :body
   validate :post_must_exist
   validate :note_within_image
   after_save :update_post
@@ -122,10 +121,6 @@ class Note < ActiveRecord::Base
 
   def is_locked?
     Post.exists?(["id = ? AND is_note_locked = ?", post_id, true])
-  end
-
-  def blank_body
-    self.body = "(empty)" if body.blank?
   end
 
   def creator_name

--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -67,6 +67,13 @@ class NoteTest < ActiveSupport::TestCase
         assert_equal(["Post must exist"], @note.errors.full_messages)
       end
 
+      should "not validate if the body is blank" do
+        @note = FactoryGirl.build(:note, body: "   ")
+
+        assert_equal(false, @note.valid?)
+        assert_equal(["Body can't be blank"], @note.errors.full_messages)
+      end
+
       should "create a version" do
         assert_difference("NoteVersion.count", 1) do
           Timecop.travel(1.day.from_now) do


### PR DESCRIPTION
Fixes #1566. Disallows blank note bodies instead of setting them to `(empty)`. There are about ~20 blank notes in existence, but they're all deleted. There were about ~60 active notes with `(empty)` bodies as well, all of which were either mistakes or vandalism. Disallowing blank notes should prevent these mistakes.