### PR TITLE
Fix #1551: Allow hidden user API attributes to be seen by the owner

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,7 +38,7 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
     @presenter = UserPresenter.new(@user)
-    respond_with(@user, :methods => [:wiki_page_version_count, :artist_version_count, :artist_commentary_version_count, :pool_version_count, :forum_post_count, :comment_count, :appeal_count, :flag_count, :positive_feedback_count, :neutral_feedback_count, :negative_feedback_count])
+    respond_with(@user, methods: @user.full_attributes)
   end
 
   def create

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -681,6 +681,18 @@ class User < ActiveRecord::Base
       list
     end
 
+    # extra attributes returned for /users/:id.json but not for /users.json.
+    def full_attributes
+      [
+        :wiki_page_version_count, :artist_version_count,
+        :artist_commentary_version_count, :pool_version_count,
+        :forum_post_count, :comment_count, :favorite_group_count,
+        :appeal_count, :flag_count, :positive_feedback_count,
+        :neutral_feedback_count, :negative_feedback_count, :upload_limit,
+        :max_upload_limit
+      ]
+    end
+
     def to_legacy_json
       return {
         "name" => name,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -652,15 +652,32 @@ class User < ActiveRecord::Base
   end
 
   module ApiMethods
+    # blacklist all attributes by default. whitelist only safe attributes.
     def hidden_attributes
-      super + [:password_hash, :bcrypt_password_hash, :email, :email_verification_key, :time_zone, :updated_at, :receive_email_notifications, :last_logged_in_at, :last_forum_read_at, :has_mail, :default_image_size, :comment_threshold, :always_resize_images, :favorite_tags, :blacklisted_tags, :recent_tags, :enable_privacy_mode, :enable_post_navigation, :new_post_navigation_layout, :enable_sequential_post_navigation, :hide_deleted_posts, :per_page, :style_usernames, :enable_auto_complete, :custom_style, :show_deleted_children, :has_saved_searches, :last_ip_addr, :bit_prefs, :favorite_count]
+      super + attributes.keys.map(&:to_sym)
     end
 
     def method_attributes
-      list = super + [:is_banned, :can_approve_posts, :can_upload_free, :is_super_voter, :level_string]
+      list = super + [
+        :id, :created_at, :name, :inviter_id, :level, :base_upload_limit,
+        :post_upload_count, :post_update_count, :note_update_count,
+        :is_banned, :can_approve_posts, :can_upload_free, :is_super_voter,
+        :level_string,
+      ]
+
       if id == CurrentUser.user.id
-        list += [:remaining_api_limit, :api_burst_limit]
+        list += BOOLEAN_ATTRIBUTES + [
+          :updated_at, :email, :last_logged_in_at, :last_forum_read_at,
+          :recent_tags, :comment_threshold, :default_image_size,
+          :favorite_tags, :blacklisted_tags, :time_zone, :per_page,
+          :custom_style, :favorite_count,
+          :api_regen_multiplier, :api_burst_limit, :remaining_api_limit,
+          :statement_timeout, :favorite_group_limit, :favorite_limit,
+          :tag_query_limit, :can_comment_vote?, :can_remove_from_pools?,
+          :is_comment_limited?, :can_comment?, :can_upload?, :max_saved_searches,
+        ]
       end
+
       list
     end
 

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -46,6 +46,24 @@ class UsersControllerTest < ActionController::TestCase
         get :show, {:id => @user.id}
         assert_response :success
       end
+
+      should "show hidden attributes to the owner" do
+        get :show, {id: @user.id, format: :json}, {user_id: @user.id}
+        json = JSON.parse(response.body)
+
+        assert_response :success
+        assert_not_nil(json["last_logged_in_at"])
+      end
+
+      should "not show hidden attributes to others" do
+        another = FactoryGirl.create(:user)
+
+        get :show, {id: another.id, format: :json}, {user_id: @user.id}
+        json = JSON.parse(response.body)
+
+        assert_response :success
+        assert_nil(json["last_logged_in_at"])
+      end
     end
 
     context "new action" do


### PR DESCRIPTION
Fixes #1551. Allows users to see their account settings in /users.json. Also includes various other privileges and limits like whether they can upload or comment, their current upload limits, etc.