### PR TITLE
Log correct post id when approving deleted posts.

### DIFF
--- a/app/models/post_approval.rb
+++ b/app/models/post_approval.rb
@@ -28,7 +28,7 @@ class PostApproval < ActiveRecord::Base
   end
 
   def approve_post
-    ModAction.log("undeleted post ##{id}") if post.is_deleted
+    ModAction.log("undeleted post ##{post_id}") if post.is_deleted
 
     post.flags.each(&:resolve!)
     post.update({ approver: user, is_flagged: false, is_pending: false, is_deleted: false }, without_protection: true)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -349,9 +349,8 @@ class PostTest < ActiveSupport::TestCase
         end
 
         should "create a mod action" do
-          assert_difference("ModAction.count", 1) do
-            @post.undelete!
-          end
+          @post.undelete!
+          assert_equal("undeleted post ##{@post.id}", ModAction.last.description)
         end
       end
 
@@ -362,9 +361,8 @@ class PostTest < ActiveSupport::TestCase
         end
 
         should "create a mod action" do
-          assert_difference("ModAction.count", 1) do
-            @post.approve!
-          end
+          @post.approve!
+          assert_equal("undeleted post ##{@post.id}", ModAction.last.description)
         end
       end
 


### PR DESCRIPTION
Bug: approving a deleted post logs the wrong thing as the post id for the mod action. Instead of logging the post id, it logs the id of the PostApproval.