### PR TITLE
Fix #2949: Sample image replacement ability

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -23,6 +23,7 @@
       this.initialize_post_image_resize_links();
       this.initialize_post_image_resize_to_window_link();
       this.initialize_similar();
+      this.initialize_replace_image_dialog();
 
       if (Danbooru.meta("always-resize-images") === "true") {
         $("#image-resize-to-window-link").click();
@@ -606,6 +607,32 @@
       e.preventDefault();
     });
   }
+
+  Danbooru.Post.initialize_replace_image_dialog = function() {
+    $("#replace-image-dialog").dialog({
+      autoOpen: false,
+      width: 700,
+      modal: true,
+      buttons: {
+        "Submit": function() {
+          $("#replace-image-dialog form").submit();
+          $(this).dialog("close");
+        },
+        "Cancel": function() {
+          $(this).dialog("close");
+        }
+      }
+    });
+
+    $('#replace-image-dialog form').submit(function() {
+      $('#replace-image-dialog').dialog('close');
+    });
+
+    $("#replace-image").click(function(e) {
+      e.preventDefault();
+      $("#replace-image-dialog").dialog("open");
+    });
+  };
 })();
 
 $(document).ready(function() {

--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -1,9 +1,11 @@
 module Moderator
   module Post
     class PostsController < ApplicationController
-      before_filter :approver_only, :only => [:delete, :undelete, :move_favorites, :ban, :unban, :confirm_delete, :confirm_move_favorites, :confirm_ban]
+      before_filter :approver_only, :only => [:delete, :undelete, :move_favorites, :replace, :ban, :unban, :confirm_delete, :confirm_move_favorites, :confirm_ban]
       before_filter :admin_only, :only => [:expunge]
       skip_before_filter :api_check
+
+      respond_to :html, :json, :xml
 
       def confirm_delete
         @post = ::Post.find(params[:id])
@@ -33,6 +35,15 @@ module Moderator
           @post.give_favorites_to_parent
         end
         redirect_to(post_path(@post))
+      end
+
+      def replace
+        @post = ::Post.find(params[:id])
+        @post.replace!(params[:post][:source])
+
+        respond_with(@post) do |format|
+          format.html { redirect_to(@post) }
+        end
       end
 
       def expunge

--- a/app/helpers/delayed_jobs_helper.rb
+++ b/app/helpers/delayed_jobs_helper.rb
@@ -61,6 +61,9 @@ module DelayedJobsHelper
     when "Pool#update_category_pseudo_tags_for_posts"
       "<strong>update pool category pseudo tags for posts</strong>"
 
+    when "Post.delete_files"
+      "<strong>delete old files</strong>"
+
     else
       h(job.name)
     end
@@ -121,6 +124,9 @@ module DelayedJobsHelper
 
     when "Pool#update_category_pseudo_tags_for_posts"
       %{<a href="/pools/#{job.payload_object.id}">#{h(job.payload_object.name)}</a>}
+
+    when "Post.delete_files"
+      %{<a href="/posts/#{job.payload_object.args.first}">post ##{job.payload_object.args.first}</a>}
 
     else
       h(job.handler)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1403,6 +1403,21 @@ class Post < ActiveRecord::Base
     end
 
     def replace!(url)
+      # TODO for posts with notes we need to rescale the notes if the dimensions change.
+      if notes.size > 0
+        raise NotImplementedError.new("Replacing images with notes not yet supported.")
+      end
+
+      # TODO for ugoiras we need to replace the frame data.
+      if is_ugoira?
+        raise NotImplementedError.new("Replacing ugoira images not yet supported.")
+      end
+
+      # TODO images hosted on s3 need to be deleted from s3 instead of the local filesystem.
+      if Danbooru.config.use_s3_proxy?(self)
+        raise NotImplementedError.new("Replacing S3 hosted images not yet supported.")
+      end
+
       transaction do
         upload = Upload.create!(source: url, rating: self.rating, tag_string: self.tag_string)
         upload.process_upload

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,6 +7,8 @@ class Post < ActiveRecord::Base
   class RevertError < Exception ; end
   class SearchError < Exception ; end
 
+  DELETION_GRACE_PERIOD = 3.days
+
   before_validation :initialize_uploader, :on => :create
   before_validation :merge_old_changes
   before_validation :normalize_tags
@@ -29,7 +31,6 @@ class Post < ActiveRecord::Base
   after_save :expire_essential_tag_string_cache
   after_destroy :remove_iqdb_async
   after_destroy :delete_files
-  after_destroy :delete_remote_files
   after_commit :update_iqdb_async, :on => :create
   after_commit :notify_pubsub
 
@@ -60,22 +61,29 @@ class Post < ActiveRecord::Base
   attr_accessor :old_tag_string, :old_parent_id, :old_source, :old_rating, :has_constraints, :disable_versioning, :view_count
 
   module FileMethods
+    extend ActiveSupport::Concern
+
+    module ClassMethods
+      def delete_files(post_id, file_path, large_file_path, preview_file_path)
+        # the large file and the preview don't necessarily exist. if so errors will be ignored.
+        FileUtils.rm_f(file_path)
+        FileUtils.rm_f(large_file_path)
+        FileUtils.rm_f(preview_file_path)
+
+        RemoteFileManager.new(file_path).delete
+        RemoteFileManager.new(large_file_path).delete
+        RemoteFileManager.new(preview_file_path).delete
+      end
+    end
+
+    def delete_files
+      Post.delete_files(id, file_path, large_file_path, preview_file_path)
+    end
+
     def distribute_files
       RemoteFileManager.new(file_path).distribute
       RemoteFileManager.new(preview_file_path).distribute if has_preview?
       RemoteFileManager.new(large_file_path).distribute if has_large?
-    end
-
-    def delete_remote_files
-      RemoteFileManager.new(file_path).delete
-      RemoteFileManager.new(preview_file_path).delete if has_preview?
-      RemoteFileManager.new(large_file_path).delete if has_large?
-    end
-
-    def delete_files
-      FileUtils.rm_f(file_path)
-      FileUtils.rm_f(large_file_path)
-      FileUtils.rm_f(preview_file_path)
     end
 
     def file_path_prefix
@@ -1399,6 +1407,11 @@ class Post < ActiveRecord::Base
         upload = Upload.create!(source: url, rating: self.rating, tag_string: self.tag_string)
         upload.process_upload
         upload.update(status: "completed", post_id: id)
+
+        # queue the deletion *before* updating the post so that we use the old
+        # md5/file_ext to delete the old files. if saving the post fails,
+        # this is rolled back so the job won't run.
+        Post.delay(queue: "default", run_at: Time.now + DELETION_GRACE_PERIOD).delete_files(id, file_path, large_file_path, preview_file_path)
 
         self.md5 = upload.md5
         self.file_ext = upload.file_ext

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -7,7 +7,7 @@ class Post < ActiveRecord::Base
   class RevertError < Exception ; end
   class SearchError < Exception ; end
 
-  DELETION_GRACE_PERIOD = 3.days
+  DELETION_GRACE_PERIOD = 30.days
 
   before_validation :initialize_uploader, :on => :create
   before_validation :merge_old_changes

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -279,4 +279,53 @@ class PostPresenter < Presenter
     pool_html << "</li>"
     pool_html
   end
+
+  def comment_replacement_message(replacer = CurrentUser.user)
+    "@#{replacer.name} replaced this post with a new image:\n\n#{replacement_message}"
+  end
+
+  def modaction_replacement_message
+    "replaced post ##{@post.id}:\n\n#{replacement_message}"
+  end
+
+  def replacement_message
+    linked_source = linked_source(@post.source)
+    linked_source_was = linked_source(@post.source_was)
+
+    <<-EOS.strip_heredoc
+      [table]
+        [tbody]
+          [tr]
+            [th]Old[/th]
+            [td]#{linked_source_was}[/td]
+            [td]#{@post.md5_was}[/td]
+            [td]#{@post.file_ext_was}[/td]
+            [td]#{@post.image_width_was} x #{@post.image_height_was}[/td]
+            [td]#{@post.file_size_was.to_s(:human_size, precision: 4)}[/td]
+          [/tr]
+          [tr]
+            [th]New[/th]
+            [td]#{linked_source}[/td]
+            [td]#{@post.md5}[/td]
+            [td]#{@post.file_ext}[/td]
+            [td]#{@post.image_width} x #{@post.image_height}[/td]
+            [td]#{@post.file_size.to_s(:human_size, precision: 4)}[/td]
+          [/tr]
+        [/tbody]
+      [/table]
+    EOS
+  end
+
+protected
+
+  def linked_source(source)
+    # truncate long sources in the middle: "www.pixiv.net...lust_id=23264933"
+    truncated_source = source.gsub(%r{\Ahttps?://}, "").truncate(64, omission: "...#{source.last(32)}")
+
+    if source =~ %r{\Ahttps?://}i
+      %("#{truncated_source}":[#{source}])
+    else
+      truncated_source
+    end
+  end
 end

--- a/app/views/moderator/post/posts/_replace.html.erb
+++ b/app/views/moderator/post/posts/_replace.html.erb
@@ -1,0 +1,11 @@
+<%= simple_form_for(@post, url: replace_moderator_post_post_path, method: :post) do |f| %>
+  <h1>Replace Image</h1>
+
+  <p>
+    Delete the current image and replace it with another one, keeping
+    everything else in the post intact. This is meant for upgrading
+    lower-quality images, such as image samples, to higher-quality versions.
+  </p>
+
+  <%= f.input :source, label: "New Source", input_html: { value: "" } %>
+<% end %>

--- a/app/views/moderator/post/posts/replace.html.erb
+++ b/app/views/moderator/post/posts/replace.html.erb
@@ -1,0 +1,5 @@
+<div id="c-moderator-post-posts">
+  <div id="a-replace">
+    <%= render "moderator/post/posts/replace" %>
+  </div>
+</div>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -55,6 +55,8 @@
         <li><%= link_to "Expunge", expunge_moderator_post_post_path(:post_id => post.id), :remote => true, :method => :post, :id => "expunge", :data => {:confirm => "This will permanently delete this post (meaning the file will be deleted). Are you sure you want to delete this post?"} %></li>
       <% end %>
 
+      <li><%= link_to "Replace Image", replace_moderator_post_post_path(:post_id => post.id), :id => "replace-image" %></li>
+
       <li id="mobile-version-list"><%= link_to "Mobile version", mobile_post_path(post) %></li>
     <% end %>
   <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -121,6 +121,10 @@
     <%= render "post_appeals/new", post_appeal: @post.appeals.new %>
   </div>
 
+  <div id="replace-image-dialog" class="prose" title="Replace image" style="display: none;">
+    <%= render "moderator/post/posts/replace" %>
+  </div>
+
   <div id="add-to-pool-dialog" title="Add to pool" style="display: none;">
     <%= render "pool_elements/new" %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Rails.application.routes.draw do
         member do
           get :confirm_delete
           post :expunge
+          post :replace
           post :delete
           post :undelete
           get :confirm_move_favorites


### PR DESCRIPTION
Fixes #2949. Adds the ability to replace the image file of an existing post.

* Adds a "Replace Image" link in the options sidebar. Replacement is approvers up.
* A delayed job deletes the old files 3 days later. This gives time for recovery in case of mistakes.
* A mod action is logged containing all the old file metadata, to track what exactly changed.

Some corner cases are not handled yet and so are disallowed:

* Replacing posts that have notes is disallowed. Notes need to be rescaled to the new image dimensions.
* Replacing posts hosted on S3 is disallowed. There needs to be a way to delete S3 hosted files.
* Replacing ugoiras is disallowed. The old frame data will need to be replaced.