### PR TITLE
Fix responsive menu

### DIFF
--- a/app/assets/stylesheets/common/responsive.scss
+++ b/app/assets/stylesheets/common/responsive.scss
@@ -129,14 +129,6 @@
     }
   }
 
-  nav {
-    background: none;
-    float: right;
-    font-size: 1.125em;
-    width: 100%;
-    margin-bottom: 1em;
-  }
-  
   #nav {
     display: none;
   }

--- a/app/assets/stylesheets/common/responsive.scss
+++ b/app/assets/stylesheets/common/responsive.scss
@@ -44,15 +44,19 @@
     }
   }
 
+  /* Make the quick search box in the navbar full width. */
+  header#top menu form input {
+    width: auto;
+  }
+
   h1 {
     display: none;
   }
 
-  input[type=text], input[type=submit] {
-    font-size: 18pt;
-    border-color: default;
-    border-style: solid;
-    border-width: .1rem;
+  form {
+    input[type=text], input[type=submit], select {
+      font-size: 1.5em;
+    }
   }
 
   div#page section#content {

--- a/app/assets/stylesheets/common/simple_form.scss
+++ b/app/assets/stylesheets/common/simple_form.scss
@@ -13,7 +13,7 @@ form.simple_form {
     margin-bottom: 1em;
 
     input[type=text], input[type=file], input[type=password], input[type=email] {
-      width: 20em;
+      max-width: 20em;
     }
 
     span.hint {
@@ -61,6 +61,7 @@ form.inline-form {
     label, input {
       display: table-cell;
       padding-right: 1em;
+      white-space: nowrap;
     }
   }
 }

--- a/app/views/layouts/_main_links.html.erb
+++ b/app/views/layouts/_main_links.html.erb
@@ -19,5 +19,5 @@
   <% if CurrentUser.is_moderator? %>
     <%= nav_link_to("Dashboard", moderator_dashboard_path) %>
   <% end %>
-  <%= nav_link_to("More &raquo;".html_safe, site_map_path, :id => "site-map-link") %>
+  <%= nav_link_to("More&nbsp;&raquo;".html_safe, site_map_path, :id => "site-map-link") %>
 </menu>


### PR DESCRIPTION
https://danbooru.donmai.us/forum_topics/9127?page=179#forum_post_130662:

> ...the top menu (the one you open with that blue thing beside the site's name) is behind everything else. So you can't click on parts of it. In posts it's like this - https://my.mixtape.moe/klsxqi.png In the pools section it's even worse, can't click on almost anything. Also the input fields are larger than the rest of the page - https://my.mixtape.moe/iuhewy.png

Fixes the responsive menu to not overlap the content. Fixes `<input>` sizes to be more reasonable. Fixes the `More »` link from line breaking in between `More` and `»`.