### PR TITLE
Fix links to DeviantArt sources

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -387,11 +387,27 @@ class Post < ActiveRecord::Base
         base_36_id = base_10_id.to_s(36)
         "http://twitpic.com/#{base_36_id}"
 
-      when %r{\Ahttps?://(?:fc|th|pre|orig|img)\d{2}\.deviantart\.net/.+/[a-z0-9_]*_by_([a-z0-9_]+)-d([a-z0-9]+)\.}i
-        "http://#{$1}.deviantart.com/gallery/#/d#{$2}"
+      # http://orig12.deviantart.net/9b69/f/2017/023/7/c/illustration___tokyo_encount_oei__by_melisaongmiqin-dawi58s.png
+      # http://pre15.deviantart.net/81de/th/pre/f/2015/063/5/f/inha_by_inhaestudios-d8kfzm5.jpg
+      # http://th00.deviantart.net/fs71/PRE/f/2014/065/3/b/goruto_by_xyelkiltrox-d797tit.png
+      # http://th04.deviantart.net/fs70/300W/f/2009/364/4/d/Alphes_Mimic___Rika_by_Juriesute.png
+      # http://fc02.deviantart.net/fs48/f/2009/186/2/c/Animation_by_epe_tohri.swf
+      # http://fc08.deviantart.net/files/f/2007/120/c/9/Cool_Like_Me_by_47ness.jpg
+      # http://fc08.deviantart.net/images3/i/2004/088/8/f/Blackrose_for_MuzicFreq.jpg
+      # http://img04.deviantart.net/720b/i/2003/37/9/6/princess_peach.jpg
+      when %r{\Ahttps?://(?:fc|th|pre|orig|img|prnt)\d{2}\.deviantart\.net/.+/(?<title>[a-z0-9_]+)_by_(?<artist>[a-z0-9_]+)-d(?<id>[a-z0-9]+)\.}i
+        artist = $~[:artist].dasherize
+        title = $~[:title].titleize.strip.squeeze(" ").tr(" ", "-")
+        id = $~[:id].to_i(36)
+        "http://#{artist}.deviantart.com/art/#{title}-#{id}"
 
-      when %r{\Ahttps?://(?:fc|th|pre|orig|img)\d{2}\.deviantart\.net/.+/[a-f0-9]+-d([a-z0-9]+)\.}i
-        "http://deviantart.com/gallery/#/d#{$1}"
+      # http://prnt00.deviantart.net/9b74/b/2016/101/4/468a9d89f52a835d4f6f1c8caca0dfb2-pnjfbh.jpg
+      # http://fc00.deviantart.net/fs71/f/2013/234/d/8/d84e05f26f0695b1153e9dab3a962f16-d6j8jl9.jpg
+      # http://th04.deviantart.net/fs71/PRE/f/2013/337/3/5/35081351f62b432f84eaeddeb4693caf-d6wlrqs.jpg
+      # http://fc09.deviantart.net/fs22/o/2009/197/3/7/37ac79eaeef9fb32e6ae998e9a77d8dd.jpg
+      when %r{\Ahttps?://(?:fc|th|pre|orig|img|prnt)\d{2}\.deviantart\.net/.+/[a-f0-9]{32}-d(?<id>[a-z0-9]+)\.}i
+        id = $~[:id].to_i(36)
+        "http://deviantart.com/deviation/#{id}"
 
       when %r{\Ahttp://www\.karabako\.net/images(?:ub)?/karabako_(\d+)(?:_\d+)?\.}i
         "http://www.karabako.net/post/view/#{$1}"

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1361,9 +1361,9 @@ class PostTest < ActiveSupport::TestCase
 
         should "normalize deviantart links" do
           @post.source = "http://fc06.deviantart.net/fs71/f/2013/295/d/7/you_are_already_dead__by_mar11co-d6rgm0e.jpg"
-          assert_equal("http://mar11co.deviantart.com/gallery/#/d6rgm0e", @post.normalized_source)
+          assert_equal("http://mar11co.deviantart.com/art/You-Are-Already-Dead-408921710", @post.normalized_source)
           @post.source = "http://fc00.deviantart.net/fs71/f/2013/337/3/5/35081351f62b432f84eaeddeb4693caf-d6wlrqs.jpg"
-          assert_equal("http://deviantart.com/gallery/#/d6wlrqs", @post.normalized_source)
+          assert_equal("http://deviantart.com/deviation/417560500", @post.normalized_source)
         end
 
         should "normalize karabako links" do


### PR DESCRIPTION
Discussion: https://danbooru.donmai.us/forum_topics/9127?page=179#forum_post_130592:

Current DeviantArt sources as linked as http://misumi_illustration.deviantart.com/gallery/#/db7ibsi in the sidebar. This relies on a javascript redirect on DeviantArt's end which doesn't work for everyone. This links the source as http://misumi-illustration.deviantart.com/art/Lethargic-friends-677740338 instead.

The comments in 1baffb3 are just documentation, the only change in the regexes was adding a `prnt` subdomain.