### PR TITLE
Fix pawoo sources after upload.

### DIFF
--- a/app/logical/downloads/file.rb
+++ b/app/logical/downloads/file.rb
@@ -130,13 +130,18 @@ module Downloads
     def fix_twitter_sources(src)
       if src =~ %r!^https?://pbs\.twimg\.com/! && original_source =~ %r!^https?://twitter\.com/!
         original_source
+      elsif src =~ %r!^https?://img\.pawoo\.net/! && original_source =~ %r!^https?://pawoo\.net/!
+        original_source
       else
         src
       end
     end
 
     def set_source_to_referer(src)
-      if Sources::Strategies::Nijie.url_match?(src) || Sources::Strategies::Twitter.url_match?(src) || Sources::Strategies::Tumblr.url_match?(src)
+      if Sources::Strategies::Nijie.url_match?(src) ||
+         Sources::Strategies::Twitter.url_match?(src) ||
+         Sources::Strategies::Tumblr.url_match?(src) ||
+         Sources::Strategies::Pawoo.url_match?(src)
         strategy = Sources::Site.new(src, :referer_url => options[:referer_url])
         strategy.referer_url
       else


### PR DESCRIPTION
Sets pawoo sources to the html page (https://pawoo.net/@kv18/6441531)  instead of the image file (https://img.pawoo.net/media_attachments/files/000/500/335/original/f682902651c2ca82.png) after upload.