### PR TITLE
Fix #2352: Return raw usernames in API instead of pretty names.

### DIFF
--- a/app/assets/javascripts/blacklists.js
+++ b/app/assets/javascripts/blacklists.js
@@ -147,7 +147,7 @@
     var tags = String($post.attr("data-tags")).match(/\S+/g) || [];
     tags = tags.concat(String($post.attr("data-pools")).match(/\S+/g) || []);
     tags.push("rating:" + $post.data("rating"));
-    tags.push("user:" + $post.attr("data-uploader").toLowerCase().replace(/ /g, "_"));
+    tags.push("user:" + $post.attr("data-uploader").toLowerCase());
     $.each(String($post.data("flags")).match(/\S+/g) || [], function(i, v) {
       tags.push("status:" + v);
     });

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -288,7 +288,7 @@
     } else {
       score = " score:" + $post.data("score");
     }
-    $img.attr("title", $post.attr("data-tags") + " user:" + $post.attr("data-uploader") + " rating:" + $post.data("rating") + score);
+    $img.attr("title", $post.attr("data-tags") + " user:" + $post.attr("data-uploader").replace(/_/g, " ") + " rating:" + $post.data("rating") + score);
   }
 
   Danbooru.Post.initialize_post_image_resize_links = function() {

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -109,6 +109,6 @@ class ArtistVersion < ActiveRecord::Base
   end
 
   def updater_name
-    User.id_to_name(updater_id).tr("_", " ")
+    User.id_to_name(updater_id)
   end
 end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -124,7 +124,7 @@ class Note < ActiveRecord::Base
   end
 
   def creator_name
-    User.id_to_name(creator_id).tr("_", " ")
+    User.id_to_name(creator_id)
   end
 
   def update_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1000,7 +1000,7 @@ class Post < ActiveRecord::Base
     end
 
     def uploader_name
-      User.id_to_name(uploader_id).tr("_", " ")
+      User.id_to_name(uploader_id)
     end
   end
 

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -166,7 +166,7 @@ class WikiPage < ActiveRecord::Base
   end
 
   def creator_name
-    User.id_to_name(creator_id).tr("_", " ")
+    User.id_to_name(creator_id)
   end
 
   def category_name


### PR DESCRIPTION
Fixes #2352. Makes posts, notes, wiki pages, and artist versions return raw usernames instead of "pretty" names (names with spaces instead of underscores) in the API.