### PR TITLE
Fix #3024: strip '?' from API attributes

### DIFF
--- a/config/initializers/active_record_api_extensions.rb
+++ b/config/initializers/active_record_api_extensions.rb
@@ -26,6 +26,11 @@ module Danbooru
         super(options, &block)
       end
 
+      def serializable_hash(*args)
+        hash = super(*args)
+        hash.transform_keys { |key| key.delete("?") }
+      end
+
     protected
       def hidden_attributes
         [:uploader_ip_addr, :updater_ip_addr, :creator_ip_addr, :ip_addr]

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -64,6 +64,14 @@ class UsersControllerTest < ActionController::TestCase
         assert_response :success
         assert_nil(json["last_logged_in_at"])
       end
+
+      should "strip '?' from attributes" do
+        get :show, {id: @user.id, format: :xml}, {user_id: @user.id}
+        xml = Hash.from_xml(response.body)
+
+        assert_response :success
+        assert_equal(false, xml["user"]["can_upload"])
+      end
     end
 
     context "new action" do


### PR DESCRIPTION
Fixes #3024 by stripping `?` from API attributes globally. This means it applies to both JSON and XML.