### PR TITLE
Fix API limits being lowered when user doesn't have api key.

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -606,9 +606,9 @@ class User < ActiveRecord::Base
 
     def api_regen_multiplier
       # regen this amount per second
-      if is_platinum? && api_key.present?
+      if is_platinum?
         4
-      elsif is_gold? && api_key.present?
+      elsif is_gold?
         2
       else
         1
@@ -618,9 +618,9 @@ class User < ActiveRecord::Base
     def api_burst_limit
       # can make this many api calls at once before being bound by
       # api_regen_multiplier refilling your pool
-      if is_platinum? && api_key.present?
+      if is_platinum?
         60
-      elsif is_gold? && api_key.present?
+      elsif is_gold?
         30
       else
         10

--- a/test/unit/api_key_test.rb
+++ b/test/unit/api_key_test.rb
@@ -3,9 +3,8 @@ require 'test_helper'
 class ApiKeyTest < ActiveSupport::TestCase
   context "in all cases a user" do
     setup do
-      @user = FactoryGirl.create(:user, :name => "abcdef")
+      @user = FactoryGirl.create(:gold_user, :name => "abcdef")
       @api_key = ApiKey.generate!(@user)
-      @user.name.mb_chars.downcase
     end
 
     should "authenticate via api key" do
@@ -18,6 +17,12 @@ class ApiKeyTest < ActiveSupport::TestCase
 
     should "not authenticate with the wrong name" do
       assert_nil(User.authenticate_api_key("xxx", @api_key.key))
+    end
+
+    should "have the same limits whether or not they have an api key" do
+      assert_no_difference(["@user.reload.api_regen_multiplier", "@user.reload.api_burst_limit"]) do
+        @user.api_key.destroy
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes Gold+ users having the same API limits as Members if they haven't generated an API key. This can affect tag scripting, among other things.

#3023, #2693.