### PR TITLE
Add 3 day cooldown between flags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -301,8 +301,6 @@ class Post < ActiveRecord::Base
       if flag.errors.any?
         raise PostFlag::Error.new(flag.errors.full_messages.join("; "))
       end
-
-      update_column(:is_flagged, true) unless is_flagged?
     end
 
     def appeal!(reason)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -296,10 +296,6 @@ class Post < ActiveRecord::Base
     end
 
     def flag!(reason, options = {})
-      if is_status_locked?
-        raise PostFlag::Error.new("Post is locked and cannot be flagged")
-      end
-
       flag = flags.create(:reason => reason, :is_resolved => false, :is_deletion => options[:is_deletion])
 
       if flag.errors.any?

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -11,7 +11,7 @@ class PostFlag < ActiveRecord::Base
   belongs_to :post
   validates_presence_of :reason, :creator_id, :creator_ip_addr
   validate :validate_creator_is_not_limited
-  validate :validate_post_is_active
+  validate :validate_post
   before_validation :initialize_creator, :on => :create
   validates_uniqueness_of :creator_id, :scope => :post_id, :on => :create, :unless => :is_deletion, :message => "have already flagged this post"
   before_save :update_post
@@ -146,10 +146,9 @@ class PostFlag < ActiveRecord::Base
     end
   end
 
-  def validate_post_is_active
-    if post.is_deleted?
-      errors[:post] << "is deleted"
-    end
+  def validate_post
+    errors[:post] << "is locked and cannot be flagged" if post.is_status_locked?
+    errors[:post] << "is deleted" if post.is_deleted?
   end
 
   def initialize_creator

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -163,8 +163,8 @@ class PostFlag < ActiveRecord::Base
   end
 
   def initialize_creator
-    self.creator_id = CurrentUser.id
-    self.creator_ip_addr = CurrentUser.ip_addr
+    self.creator_id ||= CurrentUser.id
+    self.creator_ip_addr ||= CurrentUser.ip_addr
   end
 
   def resolve!

--- a/test/unit/post_approval_test.rb
+++ b/test/unit/post_approval_test.rb
@@ -49,7 +49,9 @@ class PostApprovalTest < ActiveSupport::TestCase
           @post.approve!(@approver2)
           assert_not_equal(@approver.id, @post.approver_id)
           CurrentUser.user = @user3
-          @post.flag!("blah blah")
+          travel_to(PostFlag::COOLDOWN_PERIOD.from_now + 1.minute) do
+            @post.flag!("blah blah")
+          end
 
           approval = @post.approve!(@approver)
           assert_includes(approval.errors.full_messages, "You have previously approved this post and cannot approve it again")


### PR DESCRIPTION
Discussion: https://danbooru.donmai.us/forum_topics/14010

Adds a three day cooldown after a post has been flagged before it can be flagged again. This cooldown only applies to user-generated flags, not to system-generated `Unapproved in three days` flags.