### PR TITLE
Change flag borders from red to blue for non-approvers.

### DIFF
--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -102,23 +102,30 @@ a.blacklisted-active {
   }
 
 
-  &.post-status-pending:not(.mod-queue-preview) img {
+  /* Pending and flagged posts have blue borders (except in the modqueue). */
+  &.post-status-pending:not(.mod-queue-preview) img,
+  &.post-status-flagged:not(.mod-queue-preview) img {
     border-color: $preview_pending_color;
   }
 
-  &.post-status-has-children.post-status-pending:not(.mod-queue-preview) img {
+  &.post-status-has-children.post-status-pending:not(.mod-queue-preview) img,
+  &.post-status-has-children.post-status-flagged:not(.mod-queue-preview) img {
     border-color: $preview_has_children_color $preview_pending_color $preview_pending_color $preview_has_children_color;
   }
 
-  &.post-status-has-parent.post-status-pending:not(.mod-queue-preview) img {
+  &.post-status-has-parent.post-status-pending:not(.mod-queue-preview) img,
+  &.post-status-has-parent.post-status-flagged:not(.mod-queue-preview) img {
     border-color: $preview_has_parent_color $preview_pending_color $preview_pending_color $preview_has_parent_color;
   }
 
-  &.post-status-has-children.post-status-has-parent.post-status-pending:not(.mod-queue-preview) img {
+  &.post-status-has-children.post-status-has-parent.post-status-pending:not(.mod-queue-preview) img,
+  &.post-status-has-children.post-status-has-parent.post-status-flagged:not(.mod-queue-preview) img {
     border-color: $preview_has_children_color $preview_pending_color $preview_pending_color $preview_has_parent_color;
   }
+}
 
-
+/* Flagged posts have red borders for approvers. */
+body[data-can-approve-posts="true"] .post-preview {
   &.post-status-flagged img {
     border-color: $preview_flagged_color;
   }

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -69,7 +69,7 @@
   }
   </script>
 </head>
-<body lang="en">
+<body lang="en" data-can-approve-posts="<%= CurrentUser.user.can_approve_posts? %>">
   <header id="top">
     <%= render "news_updates/listing" %>
 


### PR DESCRIPTION
Discussion: https://danbooru.donmai.us/forum_topics/14010?page=1#forum_post_130629

This would change the flag border color from red to blue for non-approvers. Non-approvers can't do anything about flagged posts so IMO calling them out does nothing but create drama.

This is accomplished by setting a `data-can-approve-posts` attribute on the `<body>` element and styling borders based on that. This is to avoid making the thumbnail markup unnecessarily dependent on the current user, which precludes fragment caching (it's still precluded by other things, but it would be nice if it were possible).