### PR TITLE
Add ability to start/stop delayed jobs.

### DIFF
--- a/app/controllers/delayed_jobs_controller.rb
+++ b/app/controllers/delayed_jobs_controller.rb
@@ -1,7 +1,41 @@
 class DelayedJobsController < ApplicationController
-  respond_to :html, :xml, :json
+  respond_to :html, :xml, :json, :js
+  before_filter :admin_only, except: [:index]
+
   def index
     @delayed_jobs = Delayed::Job.order("created_at desc").paginate(params[:page], :limit => params[:limit])
     respond_with(@delayed_jobs)
+  end
+
+  def cancel
+    @job = Delayed::Job.find(params[:id])
+    if !@job.locked_at?
+      @job.fail!
+    end
+    respond_with(@job)
+  end
+
+  def retry
+    @job = Delayed::Job.find(params[:id])
+    if !@job.locked_at?
+      @job.update({failed_at: nil, attempts: 0}, without_protection: true)
+    end
+    respond_with(@job)
+  end
+
+  def run
+    @job = Delayed::Job.find(params[:id])
+    if !@job.locked_at?
+      @job.update(run_at: Time.now)
+    end
+    respond_with(@job)
+  end
+
+  def destroy
+    @job = Delayed::Job.find(params[:id])
+    if !@job.locked_at?
+      @job.destroy
+    end
+    respond_with(@job)
   end
 end

--- a/app/controllers/delayed_jobs_controller.rb
+++ b/app/controllers/delayed_jobs_controller.rb
@@ -3,7 +3,7 @@ class DelayedJobsController < ApplicationController
   before_filter :admin_only, except: [:index]
 
   def index
-    @delayed_jobs = Delayed::Job.order("created_at desc").paginate(params[:page], :limit => params[:limit])
+    @delayed_jobs = Delayed::Job.order("run_at asc").paginate(params[:page], :limit => params[:limit])
     respond_with(@delayed_jobs)
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -90,7 +90,11 @@ module ApplicationHelper
   end
 
   def time_ago_in_words_tagged(time)
-    raw time_tag(time_ago_in_words(time) + " ago", time)
+    if time.past?
+      raw time_tag(time_ago_in_words(time) + " ago", time)
+    else
+      raw time_tag("in " + distance_of_time_in_words(Time.now, time), time)
+    end
   end
 
   def compact_time(time)

--- a/app/views/delayed_jobs/cancel.js.erb
+++ b/app/views/delayed_jobs/cancel.js.erb
@@ -1,0 +1,1 @@
+location.reload();

--- a/app/views/delayed_jobs/destroy.js.erb
+++ b/app/views/delayed_jobs/destroy.js.erb
@@ -1,0 +1,1 @@
+location.reload();

--- a/app/views/delayed_jobs/index.html.erb
+++ b/app/views/delayed_jobs/index.html.erb
@@ -1,42 +1,46 @@
-<h1>Delayed Jobs</h1>
+<div id="c-delayed-jobs">
+  <div id="a-index">
+    <h1>Delayed Jobs</h1>
 
-<table class="striped" width="100%">
-  <thead>
-    <tr>
-      <th>ID</th>
-      <th>Name</th>
-      <% if CurrentUser.is_admin? %>
-        <th>Handler</th>
-      <% end %>
-      <th>Attempts</th>
-      <th>Priority</th>
-      <th>Last error</th>
-      <th>Run at</th>
-      <th>Failed at</th>
-      <th>Queue</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @delayed_jobs.each do |job| %>
-      <tr>
-        <td><%= job.id %></td>
-        <td><%= raw print_name(job) %></td>
-        <% if CurrentUser.is_admin? %>
-          <td><%= raw print_handler(job) %></td>
+    <table class="striped" width="100%">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Name</th>
+          <% if CurrentUser.is_admin? %>
+            <th>Handler</th>
+          <% end %>
+          <th>Attempts</th>
+          <th>Priority</th>
+          <th>Last error</th>
+          <th>Run at</th>
+          <th>Failed at</th>
+          <th>Queue</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @delayed_jobs.each do |job| %>
+          <tr>
+            <td><%= job.id %></td>
+            <td><%= raw print_name(job) %></td>
+            <% if CurrentUser.is_admin? %>
+              <td><%= raw print_handler(job) %></td>
+            <% end %>
+            <td><%= job.attempts %></td>
+            <td><%= job.priority %></td>
+            <td><%= job.last_error %></td>
+            <td><%= job.run_at %></td>
+            <td><%= job.failed_at %></td>
+            <td><%= job.queue %></td>
+          </tr>
         <% end %>
-        <td><%= job.attempts %></td>
-        <td><%= job.priority %></td>
-        <td><%= job.last_error %></td>
-        <td><%= job.run_at %></td>
-        <td><%= job.failed_at %></td>
-        <td><%= job.queue %></td>
-      </tr>
+      </tbody>
+    </table>
+
+    <%= numbered_paginator(@delayed_jobs) %>
+
+    <% content_for(:page_title) do %>
+      Delayed Jobs - <%= Danbooru.config.app_name %>
     <% end %>
-  </tbody>
-</table>
-
-<%= numbered_paginator(@delayed_jobs) %>
-
-<% content_for(:page_title) do %>
-  Delayed Jobs - <%= Danbooru.config.app_name %>
-<% end %>
+  </div>
+</div>

--- a/app/views/delayed_jobs/index.html.erb
+++ b/app/views/delayed_jobs/index.html.erb
@@ -14,6 +14,7 @@
           <th>Last error</th>
           <th>Failed at</th>
           <th>Run at</th>
+          <th></th>
         </tr>
       </thead>
       <tbody>
@@ -28,6 +29,19 @@
             <td class="col-expand"><%= job.last_error %></td>
             <td><%= time_ago_in_words_tagged(job.failed_at) if job.failed_at %></td>
             <td><%= time_ago_in_words_tagged(job.run_at) %></td>
+            <td>
+              <% if CurrentUser.is_admin? %>
+                <% if job.locked_at? %>
+                  Running
+                <% elsif job.failed? %>
+                  <%= link_to "Retry", retry_delayed_job_path(job), method: :put, remote: true %> |
+                  <%= link_to "Delete", delayed_job_path(job), method: :delete, remote: true %>
+                <% else %>
+                  <%= link_to "Run", run_delayed_job_path(job), method: :put, remote: true %> |
+                  <%= link_to "Cancel", cancel_delayed_job_path(job), method: :put, remote: true %>
+                <% end %>
+              <% end %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/delayed_jobs/index.html.erb
+++ b/app/views/delayed_jobs/index.html.erb
@@ -2,36 +2,32 @@
   <div id="a-index">
     <h1>Delayed Jobs</h1>
 
-    <table class="striped" width="100%">
+    <table class="striped autofit">
       <thead>
         <tr>
-          <th>ID</th>
+          <th>Queue</th>
           <th>Name</th>
           <% if CurrentUser.is_admin? %>
             <th>Handler</th>
           <% end %>
           <th>Attempts</th>
-          <th>Priority</th>
           <th>Last error</th>
-          <th>Run at</th>
           <th>Failed at</th>
-          <th>Queue</th>
+          <th>Run at</th>
         </tr>
       </thead>
       <tbody>
         <% @delayed_jobs.each do |job| %>
           <tr>
-            <td><%= job.id %></td>
+            <td><%= job.queue %></td>
             <td><%= raw print_name(job) %></td>
             <% if CurrentUser.is_admin? %>
-              <td><%= raw print_handler(job) %></td>
+              <td class="col-expand"><%= raw print_handler(job) %></td>
             <% end %>
             <td><%= job.attempts %></td>
-            <td><%= job.priority %></td>
-            <td><%= job.last_error %></td>
-            <td><%= job.run_at %></td>
-            <td><%= job.failed_at %></td>
-            <td><%= job.queue %></td>
+            <td class="col-expand"><%= job.last_error %></td>
+            <td><%= time_ago_in_words_tagged(job.failed_at) if job.failed_at %></td>
+            <td><%= time_ago_in_words_tagged(job.run_at) %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/delayed_jobs/retry.js.erb
+++ b/app/views/delayed_jobs/retry.js.erb
@@ -1,0 +1,1 @@
+location.reload();

--- a/app/views/delayed_jobs/run.js.erb
+++ b/app/views/delayed_jobs/run.js.erb
@@ -1,0 +1,1 @@
+location.reload();

--- a/config/initializers/delayed_jobs.rb
+++ b/config/initializers/delayed_jobs.rb
@@ -1,0 +1,2 @@
+Delayed::Worker.default_queue_name = "default"
+Delayed::Worker.destroy_failed_jobs = false

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -110,7 +110,13 @@ Rails.application.routes.draw do
       get :posts
     end
   end
-  resources :delayed_jobs, :only => [:index]
+  resources :delayed_jobs, :only => [:index, :destroy] do
+    member do
+      put :run
+      put :retry
+      put :cancel
+    end
+  end
   resources :dmails, :only => [:new, :create, :index, :show, :destroy] do
     collection do
       get :search


### PR DESCRIPTION
Adds admin-only run, cancel, retry, and delete actions to the `/delayed_jobs` listing:

* Run: set the job to run immediately.
* Cancel: marks the job as failed. Prevents the job from running, effectively putting it on pause.
* Retry: unmarks the job as failed. Allows the job to run again, effectively unpausing a cancelled job.
* Delete: delete the job entirely.

Also adjusts the layout of `/delayed_jobs` a bit to fix column widths and make things easier to read.

This is mainly intended to support #3015, but it could also be useful for dealing with aliases/implications.