### PR TITLE
Fix exception when user with expired ban logs in.

### DIFF
--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -20,7 +20,7 @@ class SessionLoader
     end
     
     if CurrentUser.user
-      CurrentUser.user.unban! if ban_expired?
+      CurrentUser.user.unban! if CurrentUser.user.ban_expired?
     else
       CurrentUser.user = AnonymousUser.new
     end
@@ -84,10 +84,6 @@ private
     CurrentUser.user = User.find_by_name(cookies.signed[:user_name])
     CurrentUser.ip_addr = request.remote_ip
     session[:user_id] = CurrentUser.user.id
-  end
-
-  def ban_expired?
-    CurrentUser.user.is_banned? && CurrentUser.user.recent_ban && CurrentUser.user.recent_ban.expired?
   end
 
   def cookie_password_hash_valid?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,6 +80,7 @@ class User < ActiveRecord::Base
   has_many :post_votes
   has_many :bans, lambda {order("bans.id desc")}
   has_one :recent_ban, lambda {order("bans.id desc")}, :class_name => "Ban"
+
   has_one :api_key
   has_one :dmail_filter
   has_one :super_voter
@@ -109,7 +110,10 @@ class User < ActiveRecord::Base
     def unban!
       self.is_banned = false
       save
-      ban.destroy
+    end
+
+    def ban_expired?
+      is_banned? && recent_ban.try(:expired?)
     end
   end
 

--- a/test/factories/user.rb
+++ b/test/factories/user.rb
@@ -13,8 +13,9 @@ FactoryGirl.define do
     bit_prefs 0
 
     factory(:banned_user) do
+      transient { ban_duration 3 }
       is_banned true
-      after(:create) { |user| create(:ban, user: user) }
+      after(:create) { |user, ctx| create(:ban, user: user, duration: ctx.ban_duration) }
     end
 
     factory(:member_user) do

--- a/test/functional/sessions_controller_test.rb
+++ b/test/functional/sessions_controller_test.rb
@@ -21,6 +21,21 @@ class SessionsControllerTest < ActionController::TestCase
         assert_equal(@user.id, session[:user_id])
         assert_not_nil(@user.last_ip_addr)
       end
+
+      should "unban user if user has expired ban" do
+        CurrentUser.scoped(@user, "127.0.0.1") do
+          @banned = FactoryGirl.create(:banned_user, ban_duration: 3)
+        end
+
+        travel_to(4.days.from_now) do
+          post :create, {name: @banned.name, password: "password"}
+          SessionLoader.new(session, {}, request, {}).load
+
+          assert_equal(@banned.id, session[:user_id])
+          assert_equal(true, @banned.ban_expired?)
+          assert_equal(false, @banned.reload.is_banned)
+        end
+      end
     end
 
     context "destroy action" do


### PR DESCRIPTION
Bug: logging in with an expired ban throws an exception when `User#unban!` calls `ban.destroy`. `ban` doesn't exist; users have many `bans` instead. Despite this bug, the `is_banned` flag is still cleared, so the next login attempt succeeds in any case.

This just removes the `ban.destroy` call, since expired bans shouldn't be destroyed to begin with.