### PR TITLE
Fix /comments.json returning results in undefined order.

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -86,7 +86,6 @@ class Comment < ActiveRecord::Base
 
     def search(params)
       q = where("true")
-      return q if params.blank?
 
       if params[:body_matches].present?
         q = q.body_matches(params[:body_matches])

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -209,6 +209,13 @@ class CommentTest < ActiveSupport::TestCase
         assert_equal(c1.id, matches.all[1].id)
       end
 
+      should "default to id_desc order when searched with no options specified" do
+        comms = FactoryGirl.create_list(:comment, 3)
+        matches = Comment.search({})
+
+        assert_equal([comms[2].id, comms[1].id, comms[0].id], matches.map(&:id))
+      end
+
       context "that is edited by a moderator" do
         setup do
           @post = FactoryGirl.create(:post)


### PR DESCRIPTION
https://danbooru.donmai.us/comments.json?group_by=comment returns comments in an undefined order instead of most recent first. This is because of the default ordering not being applied due to `Comment.search` bailing early when no params are given.