### PR TITLE
Fix commentary box on upload page (fixes #3037)

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -103,6 +103,9 @@
       $("#gallery-warning").hide();
     }
 
+    $("#upload_artist_commentary_title").val(data.artist_commentary.dtext_title);
+    $("#upload_artist_commentary_desc").val(data.artist_commentary.dtext_description);
+
     $("#source-info span#loading-data").hide();
     $("#source-info ul").show();
   }

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -15,7 +15,6 @@ class UploadsController < ApplicationController
       end
 
       @post = find_post_by_url(@normalized_url)
-      extract_artist_commentary(@upload, data)
 
       begin
         @source = Sources::Site.new(params[:url], :referer_url => params[:ref])
@@ -72,17 +71,6 @@ class UploadsController < ApplicationController
   end
 
 protected
-  def extract_artist_commentary(upload, data)
-    if data[:artist_commentary_desc]
-      upload.artist_commentary_title = strip_tags(data[:artist_commentary_title])
-      upload.artist_commentary_desc = strip_tags(data[:artist_commentary_desc])
-    end
-  end
-
-  def strip_tags(s)
-    Rails::Html::FullSanitizer.new.sanitize(s, encode_special_chars: false)
-  end
-
   def find_post_by_url(normalized_url)
     if normalized_url.nil?
       Post.where(source: params[:url]).first

--- a/app/logical/downloads/rewrite_strategies/deviant_art.rb
+++ b/app/logical/downloads/rewrite_strategies/deviant_art.rb
@@ -11,8 +11,6 @@ module Downloads
         if url =~ %r{deviantart\.com/art/} || url =~ %r{deviantart\.net/.+/[a-z0-9_]+(_by_[a-z0-9_]+)?-d([a-z0-9]+)\.}i
           url, headers = rewrite_html_pages(url, headers)
           url, headers = rewrite_thumbnails(url, headers)
-          data[:artist_commentary_title] = source.artist_commentary_title
-          data[:artist_commentary_desc] = source.artist_commentary_desc
         end
 
         return [url, headers, data]

--- a/app/logical/downloads/rewrite_strategies/pixiv.rb
+++ b/app/logical/downloads/rewrite_strategies/pixiv.rb
@@ -18,8 +18,6 @@ module Downloads
           url, headers = rewrite_thumbnails(url, headers)
           url, headers = rewrite_old_small_manga_pages(url, headers)
           url, headers = rewrite_to_thumbnails(url, headers) if data.delete(:get_thumbnail)
-          data[:artist_commentary_title] = source.artist_commentary_title
-          data[:artist_commentary_desc] = source.artist_commentary_desc
         end
 
         # http://i2.pixiv.net/img-zip-ugoira/img/2014/08/05/06/01/10/44524589_ugoira1920x1080.zip

--- a/app/logical/downloads/rewrite_strategies/twitter.rb
+++ b/app/logical/downloads/rewrite_strategies/twitter.rb
@@ -9,7 +9,7 @@ module Downloads
 
       def rewrite(url, headers, data = {})
         if url =~ %r!^https?://(?:mobile\.)?twitter\.com!
-          url, headers = rewrite_status_page(url, headers, data)
+          url = source.image_url
         elsif url =~ %r{^https?://pbs\.twimg\.com}
           url, headers = rewrite_thumbnails(url, headers, data)
         end
@@ -18,12 +18,6 @@ module Downloads
       end
 
     protected
-      def rewrite_status_page(url, headers, data)
-        url = source.image_url
-        data[:artist_commentary_desc] = source.artist_commentary_desc
-        return [url, headers, data]
-      end
-
       def rewrite_thumbnails(url, headers, data)
         if url =~ %r{^(https?://pbs\.twimg\.com/media/[^:]+)}
           url = $1 + ":orig"

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -7,6 +7,7 @@ module Sources
       :profile_url, :image_url, :tags, :artist_record, :unique_id, 
       :page_count, :file_url, :ugoira_frame_data, :ugoira_content_type, :image_urls,
       :artist_commentary_title, :artist_commentary_desc,
+      :dtext_artist_commentary_title, :dtext_artist_commentary_desc,
       :rewrite_thumbnails, :illust_id_from_url, :to => :strategy
 
     def self.strategies
@@ -70,6 +71,8 @@ module Sources
         :artist_commentary => {
           :title => artist_commentary_title,
           :description => artist_commentary_desc,
+          :dtext_title => dtext_artist_commentary_title,
+          :dtext_description => dtext_artist_commentary_desc,
         }
       }
     end

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -6,8 +6,8 @@ module Sources
     delegate :get, :get_size, :site_name, :artist_name, 
       :profile_url, :image_url, :tags, :artist_record, :unique_id, 
       :page_count, :file_url, :ugoira_frame_data, :ugoira_content_type, :image_urls,
-      :has_artist_commentary?, :artist_commentary_title,
-      :artist_commentary_desc, :rewrite_thumbnails, :illust_id_from_url, :to => :strategy
+      :artist_commentary_title, :artist_commentary_desc,
+      :rewrite_thumbnails, :illust_id_from_url, :to => :strategy
 
     def self.strategies
       [Strategies::PixivWhitecube, Strategies::Pixiv, Strategies::NicoSeiga, Strategies::DeviantArt, Strategies::ArtStation, Strategies::Nijie, Strategies::Twitter, Strategies::Tumblr, Strategies::Pawoo]

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -86,9 +86,24 @@ module Sources
         nil
       end
 
+      def dtext_artist_commentary_title
+        self.class.to_dtext(artist_commentary_title)
+      end
+
+      def dtext_artist_commentary_desc
+        self.class.to_dtext(artist_commentary_desc)
+      end
+
     protected
       def agent
         raise NotImplementedError
+      end
+
+      # Convert commentary to dtext by stripping html tags. Sites can override
+      # this to customize how their markup is translated to dtext.
+      def self.to_dtext(text)
+        text = Rails::Html::FullSanitizer.new.sanitize(text, encode_special_chars: false)
+        text
       end
     end
   end

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -103,6 +103,7 @@ module Sources
       # this to customize how their markup is translated to dtext.
       def self.to_dtext(text)
         text = Rails::Html::FullSanitizer.new.sanitize(text, encode_special_chars: false)
+        text = CGI::unescapeHTML(text)
         text
       end
     end

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -53,11 +53,6 @@ module Sources
         false
       end
 
-      # Determines whether or not to automatically create an ArtistCommentary
-      def has_artist_commentary?
-        false
-      end
-
       def normalize_for_artist_finder!
         url
       end

--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -41,10 +41,6 @@ module Sources
         "http://www.pixiv.net"
       end
 
-      def has_artist_commentary?
-        @artist_commentary_desc.present?
-      end
-
       def normalized_for_artist_finder?
         url =~ %r!https?://img\.pixiv\.net/img/#{MONIKER}/?$!i
       end

--- a/app/logical/sources/strategies/pixiv_whitecube.rb
+++ b/app/logical/sources/strategies/pixiv_whitecube.rb
@@ -26,10 +26,6 @@ module Sources
         "http://www.pixiv.net"
       end
 
-      def has_artist_commentary?
-        @artist_commentary_desc.present?
-      end
-
       def normalizable_for_artist_finder?
         true
       end

--- a/app/logical/sources/strategies/twitter.rb
+++ b/app/logical/sources/strategies/twitter.rb
@@ -30,10 +30,6 @@ module Sources::Strategies
       @artist_commentary_desc = attrs[:text]
     end
 
-    def has_artist_commentary?
-      @artist_commentary_desc.present?
-    end
-
     def image_urls
       TwitterService.new.image_urls(url)
     end

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -509,10 +509,6 @@ class Upload < ActiveRecord::Base
         :original_description => artist_commentary_desc
       )
     end
-
-    def has_artist_commentary?
-      artist_commentary_desc.present?
-    end
   end
 
   include ConversionMethods

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -69,15 +69,15 @@
           <%= f.text_field :parent_id %>
         </div>
 
-        <% if @upload.has_artist_commentary? %>
+        <div>
           <div class="input">
             <%= f.label :artist_commentary_title, "Artist Commentary Title" %>
-            <%= f.text_field :artist_commentary_title, :value => @upload.artist_commentary_title %>
+            <%= f.text_field :artist_commentary_title %>
           </div>
 
           <div class="input">
             <%= f.label :artist_commentary_desc, "Artist Commentary" %>
-            <%= f.text_area :artist_commentary_desc, :value => @upload.artist_commentary_desc, :size => "60x5" %>
+            <%= f.text_area :artist_commentary_desc, :size => "60x5" %>
           </div>
 
           <div class="input">
@@ -86,7 +86,7 @@
               Include Commentary
             </label>
           </div>
-        <% end %>
+        </div>
 
         <% if Danbooru.config.iqdbs_server %>
           <% if params[:url] %>


### PR DESCRIPTION
Commentary on the uploads page has multiple issues:

* The commentary box isn't available if you don't use the bookmarklet.
* Commentary isn't populated when the title is present but the description is not (#3037).
* Special html characters are escaped (`&` -> `&amp;`) as a side effect of stripping html. This is not desired.
* Loading the commentary from the source blocks the page load.

This fixes the above issues in the following way:

* Makes the commentary box always present on the uploads page.

* Adds `dtext_title` and `dtext_commentary` fields to `/source.json`. These contain the commentary converted from whatever markup format the source uses to our own dtext format.

* Populates the commentary box using the above fields in `/source.json`. We fetch `/source.json` already, so we can populate the commentary while we're filling in everything else.

This simplifies commentary handling greatly, as we don't have to pass the commentary up from the download rewriting strategy, which was fairly awkward and unrelated to the task of rewriting the url.