### PR TITLE
Fix exception when fetched commentary is nil.

### DIFF
--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -102,6 +102,7 @@ module Sources
       # Convert commentary to dtext by stripping html tags. Sites can override
       # this to customize how their markup is translated to dtext.
       def self.to_dtext(text)
+        text = text.to_s
         text = Rails::Html::FullSanitizer.new.sanitize(text, encode_special_chars: false)
         text = CGI::unescapeHTML(text)
         text

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -91,6 +91,8 @@ module Sources
         should "get the artist commentary" do
           assert_not_nil(@site.artist_commentary_title)
           assert_not_nil(@site.artist_commentary_desc)
+          assert_not_nil(@site.dtext_artist_commentary_title)
+          assert_not_nil(@site.dtext_artist_commentary_desc)
         end
 
         should "convert a page into a json representation" do
@@ -111,6 +113,17 @@ module Sources
 
         should "get the full size image url" do
           assert_equal("https://i.pximg.net/img-original/img/2014/10/29/09/27/19/46785915_p0.jpg", @site.image_url)
+        end
+      end
+
+      context "fetching the commentary" do
+        setup do
+          get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=46337015")
+        end
+
+        should "work when the description is blank" do
+          assert_equal("Illustration (PNG) - foo & bar", @site.dtext_artist_commentary_title)
+          assert_equal("", @site.dtext_artist_commentary_desc)
         end
       end
     end


### PR DESCRIPTION
https://danbooru.donmai.us/forum_topics/9127?page=184#forum_post_131127:

> Error: undefined method `include?' for nil:NilClass

Fix a bug in a2a6a0c (#3038). If the fetched commentary is `nil`, then `CGI::unescapeHTML` will throw an exception.