### PR TITLE
Fix #3036: Add Additional ATOM Feeds (forum_posts, comments)

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,7 +4,7 @@ class CommentsController < ApplicationController
   skip_before_filter :api_check
 
   def index
-    if params[:group_by] == "comment"
+    if params[:group_by] == "comment" || request.format == Mime::ATOM
       index_by_comment
     elsif request.format == Mime::JS
       index_for_post
@@ -92,6 +92,10 @@ private
     @comments = Comment.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@comments) do |format|
       format.html {render :action => "index_by_comment"}
+      format.atom do
+        @comments = @comments.includes(:post, :creator).load
+        render :action => "index"
+      end
       format.xml do
         render :xml => @comments.to_xml(:root => "comments")
       end

--- a/app/views/comments/index.atom.builder
+++ b/app/views/comments/index.atom.builder
@@ -1,0 +1,24 @@
+atom_feed do |feed|
+  title = "Comments"
+  title += " by #{params[:search][:creator_name]}" if params.dig(:search, :creator_name).present?
+  title += " on #{params[:search][:post_tags_match]}" if params.dig(:search, :post_tags_match).present?
+
+  feed.title(title)
+  feed.updated(@comments.first.try(:updated_at))
+
+  @comments.each do |comment|
+    feed.entry(comment, published: comment.created_at, updated: comment.updated_at) do |entry|
+      entry.title("@#{comment.creator_name} on post ##{comment.post_id} (#{comment.post.humanized_essential_tag_string})")
+      entry.content(<<-EOS.strip_heredoc, type: "html")
+        <img src="#{comment.post.complete_preview_file_url}"/>
+
+        #{format_text(comment.body)}
+      EOS
+
+      entry.author do |author|
+        author.name(comment.creator_name)
+        author.uri(user_url(comment.creator))
+      end
+    end
+  end
+end

--- a/app/views/comments/index_by_comment.html.erb
+++ b/app/views/comments/index_by_comment.html.erb
@@ -29,3 +29,5 @@
 <% content_for(:page_title) do %>
   Comments - <%= Danbooru.config.app_name %>
 <% end %>
+
+<% content_for(:html_header, auto_discovery_link_tag(:atom, comments_url(:atom, search: params[:search]), title: "Comments")) %>

--- a/app/views/comments/index_by_post.html.erb
+++ b/app/views/comments/index_by_post.html.erb
@@ -37,3 +37,5 @@
 <% content_for(:page_title) do %>
   Comments - <%= Danbooru.config.app_name %>
 <% end %>
+
+<% content_for(:html_header, auto_discovery_link_tag(:atom, comments_url(:atom, search: { do_not_bump_post: true }), title: "Comments")) %>

--- a/app/views/forum_topics/index.atom.builder
+++ b/app/views/forum_topics/index.atom.builder
@@ -1,0 +1,16 @@
+atom_feed do |feed|
+  feed.title("Forum Topics")
+  feed.updated(@forum_topics.first.try(:updated_at))
+
+  @forum_topics.each do |topic|
+    feed.entry(topic, published: topic.created_at, updated: topic.updated_at) do |entry|
+      entry.title("[#{topic.category_name}] #{topic.title}")
+      entry.content(format_text(topic.original_post.body), type: "html")
+
+      entry.author do |author|
+        author.name(topic.creator.name)
+        author.uri(user_url(topic.creator_id))
+      end
+    end
+  end
+end

--- a/app/views/forum_topics/index.html.erb
+++ b/app/views/forum_topics/index.html.erb
@@ -22,3 +22,5 @@
 <% content_for(:page_title) do %>
   Forum - <%= Danbooru.config.app_name %>
 <% end %>
+
+<% content_for(:html_header, auto_discovery_link_tag(:atom, forum_topics_url(:atom), title: "Forum Topics")) %>

--- a/app/views/forum_topics/show.atom.builder
+++ b/app/views/forum_topics/show.atom.builder
@@ -1,0 +1,16 @@
+atom_feed do |feed|
+  feed.title(@forum_topic.title)
+  feed.updated(@forum_topic.try(:updated_at))
+
+  @forum_posts.each do |post|
+    feed.entry(post, published: post.created_at, updated: post.updated_at) do |entry|
+      entry.title("@#{post.creator.name}: #{strip_dtext(post.body).truncate(50, separator: /[[:space:]]/)}")
+      entry.content(format_text(post.body), type: "html")
+
+      entry.author do |author|
+        author.name(post.creator.name)
+        author.uri(user_url(post.creator))
+      end
+    end
+  end
+end

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -57,3 +57,5 @@
     });
   </script>
 <% end %>
+
+<% content_for(:html_header, auto_discovery_link_tag(:atom, forum_topics_url(@forum_topic, :atom), title: @forum_topic.title)) %>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -79,6 +79,7 @@
         <li><h1>Forum</h1></li>
         <li><%= link_to("Help", wiki_pages_path(:title => "help:forum")) %></li>
         <li><%= link_to("Listing", forum_topics_path) %></li>
+        <li><%= link_to("RSS", forum_topics_path(:atom)) %></li>
       </ul>
       <ul>
         <li><h1>Wiki</h1></li>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -73,6 +73,7 @@
         <li><h1>Comments</h1></li>
         <li><%= link_to("Help", wiki_pages_path(:title => "help:comments")) %></li>
         <li><%= link_to("Listing", comments_path) %></li>
+        <li><%= link_to("RSS", comments_path(:atom)) %></li>
       </ul>
       <ul>
         <li><h1>Forum</h1></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -15,3 +15,6 @@
 <% content_for(:page_title) do %>
   User - <%= @presenter.name %> - <%= Danbooru.config.app_name %>
 <% end %>
+
+<% content_for(:html_header, auto_discovery_link_tag(:atom, comments_url(:atom, search: { post_tags_match: "user:#{@user.name}" }), title: "Comments on #{@user.name}'s uploads")) %>
+<% content_for(:html_header, auto_discovery_link_tag(:atom, comments_url(:atom, search: { post_tags_match: "commenter:#{@user.name}" }), title: "Comments on posts commented on by #{@user.name}")) %>

--- a/test/functional/comments_controller_test.rb
+++ b/test/functional/comments_controller_test.rb
@@ -36,6 +36,11 @@ class CommentsControllerTest < ActionController::TestCase
         get :index, {:group_by => "comment"}
         assert_response :success
       end
+
+      should "render for atom feeds" do
+        get :index, {:format => "atom"}
+        assert_response :success
+      end
     end
 
     context "search action" do

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -56,11 +56,21 @@ class ForumTopicsControllerTest < ActionController::TestCase
         get :show, {:id => @forum_topic.id}
         assert_response :success
       end
+
+      should "render for atom feed" do
+        get :show, {:id => @forum_topic.id, :format => :atom}
+        assert_response :success
+      end
     end
 
     context "index action" do
       should "list all forum topics" do
         get :index
+        assert_response :success
+      end
+
+      should "render for atom feed" do
+        get :index, {:format => :atom}
         assert_response :success
       end
 


### PR DESCRIPTION
Fixes #3036. Adds the following:

* Adds `/comments.atom`, `/forum_topics.atom`, and `/forum_topics/1234.atom`.
* Adds RSS feed links in the site map.
* Adds feed discovery links to `/comments` and `/forum_topics`.
* Adds feed discovery links on `/users/1234` for tracking new comments on your uploads, and for tracking new comments on posts you've commented on.