### PR TITLE
Add commentary toggle button on uploads page.

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -13,6 +13,11 @@
       this.initialize_similar();
       $("#related-tags-button").trigger("click");
       $("#find-artist-button").trigger("click");
+
+      $("#toggle-artist-commentary").click(function(e) {
+        Danbooru.Upload.toggle_commentary();
+        e.preventDefault();
+      });
     }
 
     if ($("#iqdb-similar").length) {
@@ -105,6 +110,7 @@
 
     $("#upload_artist_commentary_title").val(data.artist_commentary.dtext_title);
     $("#upload_artist_commentary_desc").val(data.artist_commentary.dtext_description);
+    Danbooru.Upload.toggle_commentary();
 
     $("#source-info span#loading-data").hide();
     $("#source-info ul").show();
@@ -133,6 +139,16 @@
       $("#image-resize-to-window-link").click(Danbooru.Upload.update_scale);
     }
   }
+
+  Danbooru.Upload.toggle_commentary = function() {
+    if ($(".artist-commentary").is(":visible")) {
+      $("#toggle-artist-commentary").text("show »");
+    } else {
+      $("#toggle-artist-commentary").text("« hide");
+    }
+
+    $(".artist-commentary").slideToggle();
+  };
 })();
 
 $(function() {

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -69,14 +69,17 @@
           <%= f.text_field :parent_id %>
         </div>
 
-        <div>
+        <strong>Commentary</strong>
+        <a href="#" id="toggle-artist-commentary">show »</a>
+
+        <div class="artist-commentary" style="display: none;">
           <div class="input">
-            <%= f.label :artist_commentary_title, "Artist Commentary Title" %>
+            <%= f.label :artist_commentary_title, "Title" %>
             <%= f.text_field :artist_commentary_title %>
           </div>
 
           <div class="input">
-            <%= f.label :artist_commentary_desc, "Artist Commentary" %>
+            <%= f.label :artist_commentary_desc, "Description" %>
             <%= f.text_area :artist_commentary_desc, :size => "60x5" %>
           </div>
 


### PR DESCRIPTION
#3038 made the commentary box always present on the uploads page, but some non-bookmarklet uploaders complained about mistaking it for the tags box. This:

* adds a show/hide toggle button to the commentary.
* hides the commentary box by default.
* shows the commentary box when the source autofills it in.