### PR TITLE
Don't record forum topic visits for API requests.

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -33,7 +33,7 @@ class ForumTopicsController < ApplicationController
   end
 
   def show
-    unless CurrentUser.user.is_anonymous?
+    if request.format == Mime::HTML
       @forum_topic.mark_as_read!(CurrentUser.user)
     end
     @forum_posts = ForumPost.search(:topic_id => @forum_topic.id).order("forum_posts.id").paginate(params[:page])

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -103,8 +103,8 @@ class ForumTopic < ActiveRecord::Base
       ForumTopicVisit.where("user_id = ? and forum_topic_id = ? and last_read_at >= ?", user.id, id, updated_at).exists?
     end
 
-    def mark_as_read!(user = nil)
-      user ||= CurrentUser.user
+    def mark_as_read!(user = CurrentUser.user)
+      return if user.is_anonymous?
       
       match = ForumTopicVisit.where(:user_id => user.id, :forum_topic_id => id).first
       if match

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -56,6 +56,16 @@ class ForumTopicsControllerTest < ActionController::TestCase
         get :show, {:id => @forum_topic.id}
         assert_response :success
       end
+
+      should "record a topic visit for html requests" do
+        get :show, {id: @forum_topic.id}, {user_id: @user.id}
+        assert_not_nil(@user.reload.last_forum_read_at)
+      end
+
+      should "not record a topic visit for non-html requests" do
+        get :show, {id: @forum_topic.id, format: :json}, {user_id: @user.id}
+        assert_nil(@user.reload.last_forum_read_at)
+      end
     end
 
     context "index action" do


### PR DESCRIPTION
Visiting `/forum_topics/1234.json` records a forum topic visit. But simply performing an API request shouldn't mark a thread as read. This makes it so that visits are only recorded for HTML requests.