### PR TITLE
Fix username changes forcing new name to lowercase.

### DIFF
--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -37,10 +37,6 @@ class UserNameChangeRequest < ActiveRecord::Base
     status == "pending"
   end
   
-  def desired_name=(name)
-    super(User.normalize_name(name))
-  end
-  
   def feedback
     UserFeedback.for_user(user_id).order("id desc")
   end

--- a/test/factories/user_name_change_request.rb
+++ b/test/factories/user_name_change_request.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory(:user_name_change_request) do
+    desired_name {FFaker::Internet.user_name}
+    change_reason {FFaker::Lorem.sentence}
+  end
+end

--- a/test/unit/user_name_change_request_test.rb
+++ b/test/unit/user_name_change_request_test.rb
@@ -91,6 +91,13 @@ class UserNameChangeRequestTest < ActiveSupport::TestCase
           assert_equal(["Desired name already exists"], req.errors.full_messages)
         end
       end
+
+      should "not convert the desired name to lower case" do
+        uncr = FactoryGirl.create(:user_name_change_request, user: @requester, original_name: "provence.", desired_name: "Provence")
+        CurrentUser.scoped(@admin) { uncr.approve! }
+
+        assert_equal("Provence", @requester.name)
+      end
     end
   end
 end


### PR DESCRIPTION
Provence reported that when attempting to change his name from `provence.` to `Provence`, it was instead changed to `provence`. The cause is the `desired_name` being normalized to lowercase, which we don't want.