### PR TITLE
Fix #3051: disable S3 proxy by default.

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -430,7 +430,7 @@ module Danbooru
 
     # enable s3-nginx proxy caching
     def use_s3_proxy?(post)
-      post.id < 10_000
+      false
     end
 
     # include essential tags in image urls (requires nginx/apache rewrites)


### PR DESCRIPTION
Fixes #3051. People outside Danbooru are unlikely to need this and it requires additional configuration to work, so disable it by default.