### PR TITLE
Avoid pruning post replacement delayed jobs.

### DIFF
--- a/app/logical/daily_maintenance.rb
+++ b/app/logical/daily_maintenance.rb
@@ -5,7 +5,7 @@ class DailyMaintenance
     TagPruner.new.prune!
     Upload.delete_all(['created_at < ?', 1.day.ago])
     ModAction.delete_all(['created_at < ?', 30.days.ago])
-    Delayed::Job.delete_all(['created_at < ?', 7.days.ago])
+    Delayed::Job.delete_all(['created_at < ?', 45.days.ago])
     PostVote.prune!
     CommentVote.prune!
     ApiCacheGenerator.new.generate_tag_cache


### PR DESCRIPTION
Currently delayed jobs are pruned after one week. But replacing a post spawns a file deletion job that runs in 30 days. This increases the job pruning threshold to 45 days to avoid deleting these jobs.