### PR TITLE
Add post replacements controller.

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -1,7 +1,7 @@
 module Moderator
   module Post
     class PostsController < ApplicationController
-      before_filter :approver_only, :only => [:delete, :undelete, :move_favorites, :replace, :ban, :unban, :confirm_delete, :confirm_move_favorites, :confirm_ban]
+      before_filter :approver_only, :only => [:delete, :undelete, :move_favorites, :ban, :unban, :confirm_delete, :confirm_move_favorites, :confirm_ban]
       before_filter :admin_only, :only => [:expunge]
       skip_before_filter :api_check
 
@@ -35,15 +35,6 @@ module Moderator
           @post.give_favorites_to_parent
         end
         redirect_to(post_path(@post))
-      end
-
-      def replace
-        @post = ::Post.find(params[:id])
-        @post.replace!(params[:post][:source])
-
-        respond_with(@post) do |format|
-          format.html { redirect_to(@post) }
-        end
       end
 
       def expunge

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -2,10 +2,27 @@ class PostReplacementsController < ApplicationController
   respond_to :html, :xml, :json
   before_filter :approver_only, except: [:index]
 
+  def new
+    @post = Post.find(params[:post_id])
+  end
+
+  def create
+    @post = Post.find(params[:post_id])
+    @post_replacement = @post.replace!(create_params)
+
+    flash[:notice] = "Post replaced"
+    respond_with(@post_replacement, location: @post)
+  end
+
   def index
     params[:search][:post_id] = params.delete(:post_id) if params.has_key?(:post_id)
     @post_replacements = PostReplacement.search(params[:search]).paginate(params[:page], limit: params[:limit])
 
     respond_with(@post_replacements)
+  end
+
+private
+  def create_params
+    params.require(:post_replacement).permit(:replacement_url)
   end
 end

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -1,0 +1,11 @@
+class PostReplacementsController < ApplicationController
+  respond_to :html, :xml, :json
+  before_filter :approver_only, except: [:index]
+
+  def index
+    params[:search][:post_id] = params.delete(:post_id) if params.has_key?(:post_id)
+    @post_replacements = PostReplacement.search(params[:search]).paginate(params[:page], limit: params[:limit])
+
+    respond_with(@post_replacements)
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1429,9 +1429,12 @@ class Post < ActiveRecord::Base
       ModAction.log("undeleted post ##{id}")
     end
 
-    def replace!(url)
-      replacement = replacements.create(replacement_url: url)
-      replacement.process!
+    def replace!(params)
+      transaction do
+        replacement = replacements.create(params)
+        replacement.process!
+        replacement
+      end
     end
   end
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -61,4 +61,32 @@ class PostReplacement < ActiveRecord::Base
     post.distribute_files
     post.update_iqdb_async
   end
+
+  module SearchMethods
+    def search(params = {})
+      q = all
+
+      if params[:creator_id].present?
+        q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
+      end
+
+      if params[:creator_name].present?
+        q = q.where(creator_name: User.name_to_id(params[:creator_name]))
+      end
+
+      if params[:id].present?
+        q = q.where(id: params[:id].split(",").map(&:to_i))
+      end
+
+      if params[:post_id].present?
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
+      end
+
+      q = q.order("created_at DESC")
+
+      q
+    end
+  end
+
+  extend SearchMethods
 end

--- a/app/views/moderator/post/posts/replace.html.erb
+++ b/app/views/moderator/post/posts/replace.html.erb
@@ -1,5 +1,0 @@
-<div id="c-moderator-post-posts">
-  <div id="a-replace">
-    <%= render "moderator/post/posts/replace" %>
-  </div>
-</div>

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for(@post, url: replace_moderator_post_post_path, method: :post) do |f| %>
+<%= simple_form_for(post_replacement, url: post_replacements_path(post_id: post_replacement.post_id), method: :post) do |f| %>
   <h1>Replace Image</h1>
 
   <p>
@@ -7,5 +7,5 @@
     lower-quality images, such as image samples, to higher-quality versions.
   </p>
 
-  <%= f.input :source, label: "New Source", input_html: { value: "" } %>
+  <%= f.input :replacement_url, label: "New Source", input_html: { value: "" } %>
 <% end %>

--- a/app/views/post_replacements/new.html.erb
+++ b/app/views/post_replacements/new.html.erb
@@ -1,0 +1,5 @@
+<div id="c-post-replacements">
+  <div id="a-new">
+    <%= render "new", post_replacement: @post.replacements.new %>
+  </div>
+</div>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -55,7 +55,7 @@
         <li><%= link_to "Expunge", expunge_moderator_post_post_path(:post_id => post.id), :remote => true, :method => :post, :id => "expunge", :data => {:confirm => "This will permanently delete this post (meaning the file will be deleted). Are you sure you want to delete this post?"} %></li>
       <% end %>
 
-      <li><%= link_to "Replace Image", replace_moderator_post_post_path(:post_id => post.id), :id => "replace-image" %></li>
+      <li><%= link_to "Replace Image", new_post_replacement_path(:post_id => post.id), :id => "replace-image" %></li>
 
       <li id="mobile-version-list"><%= link_to "Mobile version", mobile_post_path(post) %></li>
     <% end %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -122,7 +122,7 @@
   </div>
 
   <div id="replace-image-dialog" class="prose" title="Replace image" style="display: none;">
-    <%= render "moderator/post/posts/replace" %>
+    <%= render "post_replacements/new", post_replacement: @post.replacements.new %>
   </div>
 
   <div id="add-to-pool-dialog" title="Add to pool" style="display: none;">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -199,6 +199,7 @@ Rails.application.routes.draw do
   end
   resources :posts do
     resources :events, :only => [:index], :controller => "post_events"
+    resources :replacements, :only => [:index], :controller => "post_replacements"
     resource :artist_commentary, :only => [:index, :show] do
       collection { put :create_or_update }
       member { put :revert }
@@ -217,6 +218,7 @@ Rails.application.routes.draw do
   end
   resources :post_appeals
   resources :post_flags
+  resources :post_replacements, :only => [:index]
   resources :post_versions, :only => [:index, :search] do
     member do
       put :undo

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,6 @@ Rails.application.routes.draw do
         member do
           get :confirm_delete
           post :expunge
-          post :replace
           post :delete
           post :undelete
           get :confirm_move_favorites
@@ -199,7 +198,7 @@ Rails.application.routes.draw do
   end
   resources :posts do
     resources :events, :only => [:index], :controller => "post_events"
-    resources :replacements, :only => [:index], :controller => "post_replacements"
+    resources :replacements, :only => [:index, :new, :create], :controller => "post_replacements"
     resource :artist_commentary, :only => [:index, :show] do
       collection { put :create_or_update }
       member { put :revert }
@@ -218,7 +217,7 @@ Rails.application.routes.draw do
   end
   resources :post_appeals
   resources :post_flags
-  resources :post_replacements, :only => [:index]
+  resources :post_replacements, :only => [:index, :new, :create]
   resources :post_versions, :only => [:index, :search] do
     member do
       put :undo

--- a/test/factories/post_replacement.rb
+++ b/test/factories/post_replacement.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory(:post_replacement) do
+    original_url { FFaker::Internet.http_url }
+    replacement_url { FFaker::Internet.http_url }
+  end
+end

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class PostReplacementsControllerTest < ActionController::TestCase
+  context "The post replacements controller" do
+    setup do
+      @user = FactoryGirl.create(:user, can_approve_posts: true)
+      CurrentUser.user = @user
+      CurrentUser.ip_addr = "127.0.0.1"
+
+      @post = FactoryGirl.create(:post)
+      @post_replacement = FactoryGirl.create(:post_replacement, post_id: @post.id)
+    end
+
+    context "index action" do
+      should "render" do
+        get :index, {format: :json}
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -3,12 +3,34 @@ require 'test_helper'
 class PostReplacementsControllerTest < ActionController::TestCase
   context "The post replacements controller" do
     setup do
-      @user = FactoryGirl.create(:user, can_approve_posts: true)
+      @user = FactoryGirl.create(:user, can_approve_posts: true, created_at: 1.month.ago)
       CurrentUser.user = @user
       CurrentUser.ip_addr = "127.0.0.1"
 
       @post = FactoryGirl.create(:post)
       @post_replacement = FactoryGirl.create(:post_replacement, post_id: @post.id)
+    end
+
+    context "create action" do
+      should "render" do
+        params = {
+          format: :json,
+          post_id: @post.id,
+          post_replacement: {
+            replacement_url: "https://www.google.com/intl/en_ALL/images/logo.gif",
+          }
+        }
+
+        assert_difference("@post.replacements.size") do
+          post :create, params, { user_id: @user.id }
+          @post.reload
+        end
+
+        assert_response :success
+        assert_equal("https://www.google.com/intl/en_ALL/images/logo.gif", @post.source)
+        assert_equal("e80d1c59a673f560785784fb1ac10959", @post.md5)
+        assert_equal("e80d1c59a673f560785784fb1ac10959", Digest::MD5.file(@post.file_path).hexdigest)
+      end
     end
 
     context "index action" do


### PR DESCRIPTION
Adds a basic controller for post replacements. The create action is moved from the `moderator/post/posts` controller to here. The index action doesn't have a view, but it does provide API access to replacements at least.

API endpoints added:

* `POST /post_replacements.json`
* `GET /post_replacements.json`
* `GET /posts/1234/replacements.json`