### PR TITLE
Don't return `domains` in /artists.json.

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -55,14 +55,7 @@ class ArtistsController < ApplicationController
   def show
     @artist = Artist.find(params[:id])
     @post_set = PostSets::Artist.new(@artist)
-    respond_with(@artist) do |format|
-      format.xml do
-        render :xml => @artist.to_xml(:include => [:urls])
-      end
-      format.json do
-        render :json => @artist.to_json(:include => [:urls])
-      end
-    end
+    respond_with(@artist, methods: [:domains], include: [:urls])
   end
 
   def create

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -538,10 +538,6 @@ class Artist < ActiveRecord::Base
       super + [:other_names_index]
     end
 
-    def method_attributes
-      super + [:domains]
-    end
-
     def legacy_api_hash
       return {
         :id => id,


### PR DESCRIPTION
Problem: autocomplete on the `/artists` page is slow. The cause is that `/artists.json` includes the `domains` list for each artist, which is slow to calculate.

This changes it so that `domains` is only returned by `/artists/1234.json`, not `/artists.json`. We do the same thing with `/users/1234.json` for certain fields that are too heavy to calculate for `/users.json`.