### PR TITLE
Fix #3048: Artist Lookup Failing Due to Changing Usernames

### DIFF
--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -42,7 +42,7 @@ module Sources
       end
 
       def normalized_for_artist_finder?
-        url =~ %r!https?://img\.pixiv\.net/img/#{MONIKER}/?$!i
+        url =~ %r!\Ahttp://www\.pixiv\.net/member\.php\?id=[0-9]+\z/!
       end
 
       def normalizable_for_artist_finder?
@@ -50,15 +50,10 @@ module Sources
       end
 
       def normalize_for_artist_finder!
-        if has_moniker?
-          moniker = get_moniker_from_url
-        else
-          @illust_id = illust_id_from_url!
-          @metadata = get_metadata_from_papi(@illust_id)
-          moniker = @metadata.moniker
-        end
+        @illust_id = illust_id_from_url!
+        @metadata = get_metadata_from_papi(@illust_id)
 
-        "http://img.pixiv.net/img/#{moniker}/"
+        "http://www.pixiv.net/member.php?id=#{@metadata.user_id}/"
       end
 
       def get

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -23,7 +23,7 @@ class ArtistsControllerTest < ActionController::TestCase
       CurrentUser.ip_addr = "127.0.0.1"
       @artist = FactoryGirl.create(:artist, :notes => "message")
 
-      @masao = FactoryGirl.create(:artist, :name => "masao",   :url_string => "http://i2.pixiv.net/img04/img/syounen_no_uta/")
+      @masao = FactoryGirl.create(:artist, :name => "masao",   :url_string => "http://www.pixiv.net/member.php?id=32777")
       @artgerm = FactoryGirl.create(:artist, :name => "artgerm", :url_string => "http://artgerm.deviantart.com/")
     end
 

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -204,8 +204,8 @@ class ArtistTest < ActiveSupport::TestCase
 
     context "when finding pixiv artists" do
       setup do
-        FactoryGirl.create(:artist, :name => "masao",:url_string => "http://i2.pixiv.net/img04/img/syounen_no_uta/")
-        FactoryGirl.create(:artist, :name => "bkub", :url_string => "http://i1.pixiv.net/img01/img/bkubb/")
+        FactoryGirl.create(:artist, :name => "masao",:url_string => "http://www.pixiv.net/member.php?id=32777")
+        FactoryGirl.create(:artist, :name => "bkub", :url_string => "http://www.pixiv.net/member.php?id=9948")
         FactoryGirl.create(:artist, :name => "ryuura", :url_string => "http://www.pixiv.net/member.php?id=8678371")
       end
 

--- a/test/unit/artist_url_test.rb
+++ b/test/unit/artist_url_test.rb
@@ -52,9 +52,9 @@ class ArtistUrlTest < ActiveSupport::TestCase
     end
 
     should "normalize pixiv urls" do
-      url = FactoryGirl.create(:artist_url, :url => "http://img55.pixiv.net/img/monet")
-      assert_equal("http://img55.pixiv.net/img/monet", url.url)
-      assert_equal("http://img.pixiv.net/img/monet/", url.normalized_url)
+      url = FactoryGirl.create(:artist_url, :url => "https://i.pximg.net/img-original/img/2010/11/30/08/39/58/14901720_p0.png")
+      assert_equal("https://i.pximg.net/img-original/img/2010/11/30/08/39/58/14901720_p0.png", url.url)
+      assert_equal("http://www.pixiv.net/member.php?id=339253/", url.normalized_url)
     end
 
     should "normalize twitter urls" do


### PR DESCRIPTION
Fixes #3048. Normalizes Pixiv URLs to `http://www.pixiv.net/member.php?id=#{id}/` instead of `http://img.pixiv.net/img/#{moniker}/`.