### PR TITLE
Fix flagging cooldown preventing manual deletions.

### DIFF
--- a/app/controllers/moderator/post/posts_controller.rb
+++ b/app/controllers/moderator/post/posts_controller.rb
@@ -14,8 +14,7 @@ module Moderator
       def delete
         @post = ::Post.find(params[:id])
         if params[:commit] == "Delete"
-          @post.flag!(params[:reason], :is_deletion => true)
-          @post.delete!(:reason => params[:reason], :move_favorites => params[:move_favorites].present?)
+          @post.delete!(params[:reason], :move_favorites => params[:move_favorites].present?)
         end
         redirect_to(post_path(@post))
       end

--- a/app/logical/post_pruner.rb
+++ b/app/logical/post_pruner.rb
@@ -13,11 +13,10 @@ protected
     CurrentUser.scoped(User.system, "127.0.0.1") do
       Post.where("is_deleted = ? and is_pending = ? and created_at < ?", false, true, 3.days.ago).each do |post|
         begin
-          post.flag!("Unapproved in three days")
+          post.delete!("Unapproved in three days")
         rescue PostFlag::Error
           # swallow
         end
-        post.delete!
       end
     end
   end
@@ -27,11 +26,10 @@ protected
       Post.where("is_deleted = ? and is_flagged = ?", false, true).each do |post|
         if post.flags.unresolved.old.any?
           begin
-            post.flag!("Unapproved in three days after returning to moderation queue")
+            post.delete!("Unapproved in three days after returning to moderation queue")
           rescue PostFlag::Error
             # swallow
           end
-          post.delete!
         end
       end
     end

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -139,9 +139,9 @@ class PostFlag < ActiveRecord::Base
   end
 
   def validate_creator_is_not_limited
+    return if is_deletion
+
     if CurrentUser.can_approve_posts?
-      # do nothing
-    elsif User.system.present? && CurrentUser.id == User.system.id
       # do nothing
     elsif creator.created_at > 1.week.ago
       errors[:creator] << "cannot flag within the first week of sign up"
@@ -150,16 +150,16 @@ class PostFlag < ActiveRecord::Base
     elsif !creator.is_gold? && flag_count_for_creator >= 1
       errors[:creator] << "can flag 1 post a day"
     end
-  end
-
-  def validate_post
-    errors[:post] << "is locked and cannot be flagged" if post.is_status_locked?
-    errors[:post] << "is deleted" if post.is_deleted?
 
     flag = post.flags.in_cooldown.last
     if flag.present?
       errors[:post] << "cannot be flagged more than once every #{COOLDOWN_PERIOD.inspect} (last flagged: #{flag.created_at.to_s(:long)})"
     end
+  end
+
+  def validate_post
+    errors[:post] << "is locked and cannot be flagged" if post.is_status_locked?
+    errors[:post] << "is deleted" if post.is_deleted?
   end
 
   def initialize_creator

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -95,6 +95,17 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      context "that is still in cooldown after being flagged" do
+        should "succeed" do
+          post = FactoryGirl.create(:post)
+          post.flag!("test flag")
+          post.delete!("test deletion")
+
+          assert_equal(true, post.is_deleted)
+          assert_equal(2, post.flags.size)
+        end
+      end
+
       should "update the fast count" do
         Danbooru.config.stubs(:estimate_post_counts).returns(false)
         post = FactoryGirl.create(:post, :tag_string => "aaa")

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -80,7 +80,7 @@ class PostTest < ActiveSupport::TestCase
         end
 
         should "fail" do
-          @post.delete!
+          @post.delete!("test")
           assert_equal(["Is status locked ; cannot delete post"], @post.errors.full_messages)
           assert_equal(1, Post.where("id = ?", @post.id).count)
         end
@@ -89,7 +89,7 @@ class PostTest < ActiveSupport::TestCase
       context "with the banned_artist tag" do
         should "also ban the post" do
           post = FactoryGirl.create(:post, :tag_string => "banned_artist")
-          post.delete!
+          post.delete!("test")
           post.reload
           assert(post.is_banned?)
         end
@@ -100,7 +100,7 @@ class PostTest < ActiveSupport::TestCase
         post = FactoryGirl.create(:post, :tag_string => "aaa")
         assert_equal(1, Post.fast_count)
         assert_equal(1, Post.fast_count("aaa"))
-        post.delete!
+        post.delete!("test")
         assert_equal(1, Post.fast_count)
         assert_equal(1, Post.fast_count("aaa"))
       end
@@ -108,14 +108,14 @@ class PostTest < ActiveSupport::TestCase
       should "toggle the is_deleted flag" do
         post = FactoryGirl.create(:post)
         assert_equal(false, post.is_deleted?)
-        post.delete!
+        post.delete!("test")
         assert_equal(true, post.is_deleted?)
       end
 
       should "not decrement the tag counts" do
         post = FactoryGirl.create(:post, :tag_string => "aaa")
         assert_equal(1, Tag.find_by_name("aaa").post_count)
-        post.delete!
+        post.delete!("test")
         assert_equal(1, Tag.find_by_name("aaa").post_count)
       end
     end
@@ -209,7 +209,7 @@ class PostTest < ActiveSupport::TestCase
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
           user = FactoryGirl.create(:gold_user)
           c1.add_favorite!(user)
-          c1.delete!
+          c1.delete!("test")
           p1.reload
           assert(Favorite.exists?(:post_id => c1.id, :user_id => user.id))
           assert(!Favorite.exists?(:post_id => p1.id, :user_id => user.id))
@@ -220,7 +220,7 @@ class PostTest < ActiveSupport::TestCase
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
           user = FactoryGirl.create(:gold_user)
           c1.add_favorite!(user)
-          c1.delete!(:move_favorites => true)
+          c1.delete!("test", :move_favorites => true)
           p1.reload
           assert(!Favorite.exists?(:post_id => c1.id, :user_id => user.id), "Child should not still have favorites")
           assert(Favorite.exists?(:post_id => p1.id, :user_id => user.id), "Parent should have favorites")
@@ -229,7 +229,7 @@ class PostTest < ActiveSupport::TestCase
         should "not update the parent's has_children flag" do
           p1 = FactoryGirl.create(:post)
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
-          c1.delete!
+          c1.delete!("test")
           p1.reload
           assert(p1.has_children?, "Parent should have children")
         end
@@ -239,7 +239,7 @@ class PostTest < ActiveSupport::TestCase
         should "not remove the has_children flag" do
           p1 = FactoryGirl.create(:post)
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
-          p1.delete!
+          p1.delete!("test")
           p1.reload
           assert_equal(true, p1.has_children?)
         end
@@ -247,7 +247,7 @@ class PostTest < ActiveSupport::TestCase
         should "not remove the parent of that child" do
           p1 = FactoryGirl.create(:post)
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
-          p1.delete!
+          p1.delete!("test")
           c1.reload
           assert_not_nil(c1.parent)
         end
@@ -259,7 +259,7 @@ class PostTest < ActiveSupport::TestCase
           c1 = FactoryGirl.create(:post, :parent_id => p1.id)
           c2 = FactoryGirl.create(:post, :parent_id => p1.id)
           c3 = FactoryGirl.create(:post, :parent_id => p1.id)
-          p1.delete!
+          p1.delete!("test")
           c1.reload
           c2.reload
           c3.reload
@@ -275,7 +275,7 @@ class PostTest < ActiveSupport::TestCase
         new_user = FactoryGirl.create(:moderator_user)
         p1 = FactoryGirl.create(:post)
         c1 = FactoryGirl.create(:post, :parent_id => p1.id)
-        c1.delete!
+        c1.delete!("test")
         CurrentUser.scoped(new_user, "127.0.0.1") do
           c1.undelete!
         end
@@ -286,7 +286,7 @@ class PostTest < ActiveSupport::TestCase
       should "preserve the parent's has_children flag" do
         p1 = FactoryGirl.create(:post)
         c1 = FactoryGirl.create(:post, :parent_id => p1.id)
-        c1.delete!
+        c1.delete!("test")
         c1.undelete!
         p1.reload
         assert_not_nil(c1.parent_id)


### PR DESCRIPTION
https://danbooru.donmai.us/forum_topics/9127?page=185#forum_post_131440

The three day flagging cooldown prevents flagged posts from being manually deleted. This does two things:

* Makes `delete!` call `flag!` itself, instead of making the caller flag the post beforehand.
* Makes all deletions (automatic or manual) ignore any flagging rate limits.