### PR TITLE
Disallow flagging pending posts.

### DIFF
--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -158,6 +158,7 @@ class PostFlag < ActiveRecord::Base
   end
 
   def validate_post
+    errors[:post] << "is pending and cannot be flagged" if post.is_pending? && !is_deletion
     errors[:post] << "is locked and cannot be flagged" if post.is_status_locked?
     errors[:post] << "is deleted" if post.is_deleted?
   end

--- a/test/unit/post_flag_test.rb
+++ b/test/unit/post_flag_test.rb
@@ -64,6 +64,13 @@ class PostFlagTest < ActiveSupport::TestCase
         assert_equal(["Post is deleted"], @post_flag.errors.full_messages)
       end
 
+      should "not be able to flag a pending post" do
+        @post.update_columns(is_pending: true)
+        @flag = @post.flags.create(reason: "test")
+
+        assert_equal(["Post is pending and cannot be flagged"], @flag.errors.full_messages)
+      end
+
       should "not be able to flag a post in the cooldown period" do
         users = FactoryGirl.create_list(:user, 2, created_at: 2.weeks.ago)
         flag1 = FactoryGirl.create(:post_flag, post: @post, creator: users.first)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -86,6 +86,20 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      context "that is pending" do
+        setup do
+          @post = FactoryGirl.create(:post, is_pending: true)
+        end
+
+        should "succeed" do
+          @post.delete!("test")
+
+          assert_equal(true, @post.is_deleted)
+          assert_equal(1, @post.flags.size)
+          assert_match(/test/, @post.flags.last.reason)
+        end
+      end
+
       context "with the banned_artist tag" do
         should "also ban the post" do
           post = FactoryGirl.create(:post, :tag_string => "banned_artist")


### PR DESCRIPTION
Discussion: https://danbooru.donmai.us/forum_topics/13177?page=25#forum_post_131285

Disallows flagging pending posts. This was previous attempted in #1327, but it was reverted due to it preventing pending posts from being deleted. But #3063 ensured that deletions always set the `is_deletion` flag, which lets us ignore this validation when we're deleting posts.