### PR TITLE
Fix #3000: order: metatags aren't indexed.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -78,7 +78,7 @@ private
   end
 
   def index_by_post
-    @posts = Post.where("last_comment_bumped_at IS NOT NULL").tag_match(params[:tags]).reorder("last_comment_bumped_at DESC").paginate(params[:page], :limit => 5, :search_count => params[:search])
+    @posts = Post.where("last_comment_bumped_at IS NOT NULL").tag_match(params[:tags]).reorder("last_comment_bumped_at DESC NULLS LAST").paginate(params[:page], :limit => 5, :search_count => params[:search])
     @posts.each # hack to force rails to eager load
     respond_with(@posts) do |format|
       format.html {render :action => "index_by_post"}

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -392,28 +392,28 @@ class PostQueryBuilder
       relation = relation.order("posts.id DESC")
 
     when "score", "score_desc"
-      relation = relation.order("posts.score DESC")
+      relation = relation.order("posts.score DESC, posts.id DESC")
 
     when "score_asc"
-      relation = relation.order("posts.score ASC")
+      relation = relation.order("posts.score ASC, posts.id ASC")
 
     when "favcount"
-      relation = relation.order("posts.fav_count DESC")
+      relation = relation.order("posts.fav_count DESC, posts.id DESC")
 
     when "favcount_asc"
-      relation = relation.order("posts.fav_count ASC")
+      relation = relation.order("posts.fav_count ASC, posts.id ASC")
 
     when "change", "change_desc"
-      relation = relation.order("posts.updated_at DESC")
+      relation = relation.order("posts.updated_at DESC, posts.id DESC")
 
     when "change_asc"
-      relation = relation.order("posts.updated_at ASC")
+      relation = relation.order("posts.updated_at ASC, posts.id ASC")
 
     when "comment", "comm"
-      relation = relation.order("posts.last_commented_at DESC NULLS LAST")
+      relation = relation.order("posts.last_commented_at DESC NULLS LAST, posts.id DESC")
 
     when "comment_asc", "comm_asc"
-      relation = relation.order("posts.last_commented_at ASC NULLS LAST")
+      relation = relation.order("posts.last_commented_at ASC NULLS LAST, posts.id ASC")
 
     when "comment_bumped"
       relation = relation.order("posts.last_comment_bumped_at DESC NULLS LAST")

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -419,7 +419,7 @@ class PostQueryBuilder
       relation = relation.order("posts.last_comment_bumped_at DESC NULLS LAST")
 
     when "comment_bumped_asc"
-      relation = relation.order("posts.last_comment_bumped_at ASC NULLS LAST")
+      relation = relation.order("posts.last_comment_bumped_at ASC NULLS FIRST")
 
     when "note"
       relation = relation.order("posts.last_noted_at DESC NULLS LAST")

--- a/db/migrate/20170519204506_fix_last_noted_at_index_on_posts.rb
+++ b/db/migrate/20170519204506_fix_last_noted_at_index_on_posts.rb
@@ -6,6 +6,8 @@ class FixLastNotedAtIndexOnPosts < ActiveRecord::Migration
 
       remove_index :posts, column: :last_noted_at
       add_index :posts, :last_noted_at, order: "DESC NULLS LAST"
+      
+      execute "analyze posts"
     end
   end
 end

--- a/db/migrate/20170519204506_fix_last_noted_at_index_on_posts.rb
+++ b/db/migrate/20170519204506_fix_last_noted_at_index_on_posts.rb
@@ -1,0 +1,11 @@
+class FixLastNotedAtIndexOnPosts < ActiveRecord::Migration
+  def up
+    Post.without_timeout do
+      remove_index :posts, column: :last_comment_bumped_at
+      add_index :posts, :last_comment_bumped_at, order: "DESC NULLS LAST"
+
+      remove_index :posts, column: :last_noted_at
+      add_index :posts, :last_noted_at, order: "DESC NULLS LAST"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6599,6 +6599,13 @@ CREATE INDEX index_forum_topics_on_creator_id ON forum_topics USING btree (creat
 
 
 --
+-- Name: index_forum_topics_on_is_sticky_and_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_forum_topics_on_is_sticky_and_updated_at ON forum_topics USING btree (is_sticky, updated_at);
+
+
+--
 -- Name: index_forum_topics_on_text_index; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7535,4 +7542,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170416224142');
 INSERT INTO schema_migrations (version) VALUES ('20170428220448');
 
 INSERT INTO schema_migrations (version) VALUES ('20170512221200');
+
+INSERT INTO schema_migrations (version) VALUES ('20170515235205');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6896,14 +6896,14 @@ CREATE INDEX index_posts_on_image_width ON posts USING btree (image_width);
 -- Name: index_posts_on_last_comment_bumped_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_posts_on_last_comment_bumped_at ON posts USING btree (last_comment_bumped_at);
+CREATE INDEX index_posts_on_last_comment_bumped_at ON posts USING btree (last_comment_bumped_at DESC NULLS LAST);
 
 
 --
 -- Name: index_posts_on_last_noted_at; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_posts_on_last_noted_at ON posts USING btree (last_noted_at);
+CREATE INDEX index_posts_on_last_noted_at ON posts USING btree (last_noted_at DESC NULLS LAST);
 
 
 --
@@ -7544,4 +7544,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170428220448');
 INSERT INTO schema_migrations (version) VALUES ('20170512221200');
 
 INSERT INTO schema_migrations (version) VALUES ('20170515235205');
+
+INSERT INTO schema_migrations (version) VALUES ('20170519204506');
 


### PR DESCRIPTION
Fixes #3000.

* Adds back the `posts.id` secondary sort for unindexed metatags where it doesn't hurt performance anyway.

* Redefines the `last_noted_at` and `last_commented_bumped_at` indexes to be `DESC NULLS LAST` so that `order:note` and `order:comment_bumped` use these indexes. Currently the indexes default to `ASC NULLS LAST`, which isn't compatible with the queries we do.