### PR TITLE
Fix #3069: Reverse forum post order for forum topic Atom feed

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -45,7 +45,7 @@ class ForumTopicsController < ApplicationController
     @forum_posts = ForumPost.search(:topic_id => @forum_topic.id).order("forum_posts.id").paginate(params[:page])
     respond_with(@forum_topic) do |format|
       format.atom do
-        @forum_posts = @forum_posts.includes(:creator).load
+        @forum_posts = @forum_posts.reverse_order.includes(:creator).load
       end
     end
   end


### PR DESCRIPTION
Fixes #3069.