### PR TITLE
Fix #3073: Add attribute "data-is-moderator" to the <body> element.

### DIFF
--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -129,7 +129,7 @@ a.blacklisted-active {
 }
 
 /* Flagged posts have red borders for approvers. */
-body[data-can-approve-posts="true"] .post-preview {
+body[data-user-can-approve-posts="true"] .post-preview {
   &.post-status-flagged img {
     border-color: $preview_flagged_color;
   }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,6 +163,18 @@ module ApplicationHelper
     string += '</div>'
     string.html_safe
   end
+
+  def body_attributes(user = CurrentUser.user)
+    attributes = [:id, :name, :level, :level_string, :can_approve_posts?, :can_upload_free?]
+    attributes += User::Roles.map { |role| :"is_#{role}?" }
+
+    attributes.map do |attr|
+      name = attr.to_s.dasherize.delete("?")
+      value = user.send(attr)
+
+      %{data-user-#{name}="#{h(value)}"}
+    end.join(" ").html_safe
+  end
   
 protected
   def nav_link_match(controller, url)

--- a/app/logical/anonymous_user.rb
+++ b/app/logical/anonymous_user.rb
@@ -8,6 +8,10 @@ class AnonymousUser
     0
   end
 
+  def level_string
+    "Anonymous"
+  end
+
   def comment_threshold
     0
   end
@@ -34,10 +38,6 @@ class AnonymousUser
 
   def is_anonymous?
     true
-  end
-
-  def is_banned?
-    false
   end
 
   def is_banned_or_ip_banned?
@@ -245,14 +245,6 @@ class AnonymousUser
     false
   end
 
-  def is_voter?
-    false
-  end
-
-  def is_super_voter?
-    false
-  end
-
   def disable_tagged_filenames?
     false
   end
@@ -261,7 +253,7 @@ class AnonymousUser
     false
   end
 
-  %w(member banned gold builder platinum moderator admin).each do |name|
+  User::Roles.reject {|r| r == :anonymous}.each do |name|
     define_method("is_#{name}?") do
       false
     end

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -69,7 +69,7 @@
   }
   </script>
 </head>
-<body lang="en" data-can-approve-posts="<%= CurrentUser.user.can_approve_posts? %>">
+<body lang="en" <%= body_attributes(CurrentUser.user) %>>
   <header id="top">
     <%= render "news_updates/listing" %>
 


### PR DESCRIPTION
Fixes #3073. Adds `data-user-is-<role>` data attributes to the `<body>` element. This allows one to use CSS to show/hide page elements based on the current user's permissions.