### PR TITLE
Fix case sensitivity bug in dmail title search.

### DIFF
--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -19,7 +19,7 @@ class Ban < ActiveRecord::Base
 
   def self.reason_matches(query)
     if query =~ /\*/
-      where("lower(bans.reason) LIKE ?", query.to_escaped_for_sql_like)
+      where("lower(bans.reason) LIKE ?", query.mb_chars.downcase.to_escaped_for_sql_like)
     else
       where("bans.reason @@ plainto_tsquery(?)", query)
     end

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -104,7 +104,7 @@ class Dmail < ActiveRecord::Base
 
     def title_matches(query)
       query = "*#{query}*" unless query =~ /\*/
-      where("lower(dmails.title) LIKE ?", query.to_escaped_for_sql_like)
+      where("lower(dmails.title) LIKE ?", query.mb_chars.downcase.to_escaped_for_sql_like)
     end
 
     def search_message(query)

--- a/test/unit/dmail_test.rb
+++ b/test/unit/dmail_test.rb
@@ -78,6 +78,9 @@ class DmailTest < ActiveSupport::TestCase
         matches = Dmail.search(title_matches: "x")
         assert_equal([dmail.id], matches.map(&:id))
 
+        matches = Dmail.search(title_matches: "X")
+        assert_equal([dmail.id], matches.map(&:id))
+
         matches = Dmail.search(message_matches: "xxx")
         assert_equal([dmail.id], matches.map(&:id))
 


### PR DESCRIPTION
Fixes a bug with dmail title search not being correctly case-insensitive.

EDIT: also fixes a similar bug when searching ban reasons.