### PR TITLE
Fix date:, age: metatags to use the index. (fix #672).

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -378,6 +378,17 @@ class PostQueryBuilder
       relation = relation.where("favorites.user_id % 100 = ? and favorites.user_id = ?", user_id % 100, user_id).order("favorites.id DESC")
     end
 
+    # HACK: if we're using a date: or age: metatag, default to ordering by
+    # created_at instead of id so that the query will use the created_at index.
+    if q[:date].present? || q[:age].present?
+      case q[:order]
+      when "id", "id_asc"
+        q[:order] = "created_at_asc"
+      when "id_desc", nil
+        q[:order] = "created_at_desc"
+      end
+    end
+
     if q[:order] == "rank"
       relation = relation.where("posts.score > 0 and posts.created_at >= ?", 2.days.ago)
     elsif q[:order] == "landscape" || q[:order] == "portrait"
@@ -402,6 +413,12 @@ class PostQueryBuilder
 
     when "favcount_asc"
       relation = relation.order("posts.fav_count ASC, posts.id ASC")
+
+    when "created_at", "created_at_desc"
+      relation = relation.order("posts.created_at DESC")
+
+    when "created_at_asc"
+      relation = relation.order("posts.created_at ASC")
 
     when "change", "change_desc"
       relation = relation.order("posts.updated_at DESC, posts.id DESC")


### PR DESCRIPTION
Fixes #672. Ensures that the `date:` and `age:` metatags use the `created_at` index. See the comments on #672 for further discussion.