### PR TITLE
Allow search[*_id] params to accept lists of ids in more places

### DIFF
--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -30,7 +30,7 @@ class ArtistCommentary < ActiveRecord::Base
       end
 
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:original_present] == "yes"

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -26,11 +26,11 @@ class ArtistVersion < ActiveRecord::Base
       end
 
       if params[:updater_id].present?
-        q = q.for_user(params[:updater_id].to_i)
+        q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
       end
 
       if params[:artist_id].present?
-        q = q.where("artist_id = ?", params[:artist_id].to_i)
+        q = q.where(artist_id: params[:artist_id].split(",").map(&:to_i))
       end
 
       params[:order] ||= params.delete(:sort)

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -72,6 +72,10 @@ class ForumTopic < ActiveRecord::Base
       q = permitted
       return q if params.blank?
 
+      if params[:id].present?
+        q = q.where(id: params[:id].split(",").map(&:to_i))
+      end
+
       if params[:mod_only].present?
         q = q.where("min_level >= ?", MIN_LEVELS[:Moderator])
       end

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -56,7 +56,7 @@ class Note < ActiveRecord::Base
       end
 
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:post_tags_match].present?
@@ -68,7 +68,7 @@ class Note < ActiveRecord::Base
       end
 
       if params[:creator_id].present?
-        q = q.where("creator_id = ?", params[:creator_id].to_i)
+        q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
       end
 
       q

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -9,15 +9,15 @@ class NoteVersion < ActiveRecord::Base
     params = {} if params.blank?
 
     if params[:updater_id]
-      q = q.where("updater_id = ?", params[:updater_id].to_i)
+      q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
     end
 
     if params[:post_id]
-      q = q.where("post_id = ?", params[:post_id].to_i)
+      q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
     end
 
     if params[:note_id]
-      q = q.where("note_id = ?", params[:note_id].to_i)
+      q = q.where(note_id: params[:note_id].split(",").map(&:to_i))
     end
 
     q

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -71,7 +71,7 @@ class Pool < ActiveRecord::Base
       end
 
       if params[:creator_id].present?
-        q = q.where("creator_id = ?", params[:creator_id].to_i)
+        q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
       end
 
       if params[:is_active] == "true"

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -19,7 +19,7 @@ class PoolArchive < ActiveRecord::Base
       return q if params.blank?
 
       if params[:updater_id].present?
-        q = q.for_user(params[:updater_id].to_i)
+        q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
       end
 
       if params[:updater_name].present?
@@ -27,7 +27,7 @@ class PoolArchive < ActiveRecord::Base
       end
 
       if params[:pool_id].present?
-        q = q.where("pool_id = ?", params[:pool_id].to_i)
+        q = q.where(pool_id: params[:pool_id].split(",").map(&:to_i))
       end
 
       q

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -52,7 +52,7 @@ class PostAppeal < ActiveRecord::Base
       end
 
       if params[:creator_id].present?
-        q = q.for_user(params[:creator_id].to_i)
+        q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
       end
 
       if params[:creator_name].present?
@@ -60,7 +60,7 @@ class PostAppeal < ActiveRecord::Base
       end
 
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:post_tags_match].present?

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -34,11 +34,11 @@ class PostArchive < ActiveRecord::Base
       end
 
       if params[:updater_id].present?
-        q = q.where("updater_id = ?", params[:updater_id].to_i)
+        q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
       end
 
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:start_id].present?

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -74,7 +74,7 @@ class PostFlag < ActiveRecord::Base
       end
 
       if params[:post_id].present?
-        q = q.where("post_id = ?", params[:post_id].to_i)
+        q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
       end
 
       if params[:post_tags_match].present?


### PR DESCRIPTION
This allows giving comma-separated lists of IDs to `search[*_id]` params in a number of places where it currently isn't possible.