### PR TITLE
Add search form to /bulk_update_requests.

### DIFF
--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -46,7 +46,7 @@ class BulkUpdateRequestsController < ApplicationController
   end
 
   def index
-    @bulk_update_requests = BulkUpdateRequest.search(params[:search]).order("(case status when 'pending' then 0 when 'approved' then 1 else 2 end), id desc").paginate(params[:page], :limit => params[:limit])
+    @bulk_update_requests = BulkUpdateRequest.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@bulk_update_requests)
   end
 

--- a/app/views/bulk_update_requests/_search.html.erb
+++ b/app/views/bulk_update_requests/_search.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for(:search, url: bulk_update_requests_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :user_name, label: "Creator", input_html: { value: params[:search][:user_name] } %>
+  <%= f.input :approver_name, label: "Approver", input_html: { value: params[:search][:approver_name] } %>
+  <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: true, selected: params[:search][:status] %>
+  <%= f.input :order, collection: [%w[Status status_desc], %w[Last\ updated updated_at_desc], %w[Newest id_desc], %w[Oldest id_asc]], include_blank: false, selected: params[:search][:order] %>
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/bulk_update_requests/index.html.erb
+++ b/app/views/bulk_update_requests/index.html.erb
@@ -2,6 +2,7 @@
   <div id="a-index">
     <h1>Bulk Update Requests</h1>
 
+    <%= render "search" %>
     <%= render "listing", :bulk_update_requests => @bulk_update_requests %>
 
     <%= numbered_paginator(@bulk_update_requests) %>

--- a/test/unit/bulk_update_request_test.rb
+++ b/test/unit/bulk_update_request_test.rb
@@ -106,5 +106,18 @@ class BulkUpdateRequestTest < ActiveSupport::TestCase
         assert_match(/\[REJECTED\]/, @topic.title)
       end
     end
+
+    context "when searching" do
+      setup do
+        @bur1 = FactoryGirl.create(:bulk_update_request, title: "foo", script: "create alias aaa -> bbb", user_id: @admin.id)
+        @bur2 = FactoryGirl.create(:bulk_update_request, title: "bar", script: "create implication bbb -> ccc", user_id: @admin.id)
+        @bur1.approve!(@admin)
+      end
+
+      should "work" do
+        assert_equal([@bur2.id, @bur1.id], BulkUpdateRequest.search.map(&:id))
+        assert_equal([@bur1.id], BulkUpdateRequest.search(user_name: @admin.name, approver_name: @admin.name, status: "approved").map(&:id))
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds a basic search form to the [/bulk_update_requests](https://danbooru.donmai.us/bulk_update_requests) page. The added search fields are Creator, Approver, Status, and Order. Also adds `search[forum_topic_id]` and `search[forum_post_id]`, which aren't in the form but are accessible for the API.