### PR TITLE
Fix #3070: add wildcard support to wiki "other names" search.

### DIFF
--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -54,7 +54,7 @@ module Sources
           tag
         end
       end
-      WikiPage.other_names_match(untranslated_tags).map{|wiki_page| [wiki_page.title, wiki_page.category_name]}
+      WikiPage.other_names_equal(untranslated_tags).map{|wiki_page| [wiki_page.title, wiki_page.category_name]}
     end
 
     def to_h

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -4,7 +4,7 @@
       <%= search_field "title", :hint => "Use * for wildcard searches" %>
       <%= search_field "creator_name" %>
       <%= search_field "body_matches", :label => "Body" %>
-      <%= search_field "other_names_match", :label => "Other names" %>
+      <%= search_field "other_names_match", :label => "Other names", :hint => "Use * for wildcard searches" %>
 
       <div class="input">
         <label for="search_other_names_present">Other names present?</label>

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -47,7 +47,7 @@ class WikiPageTest < ActiveSupport::TestCase
       setup do
         @user = FactoryGirl.create(:user)
         CurrentUser.user = @user
-        @wiki_page = FactoryGirl.create(:wiki_page, :title => "HOT POTATO")
+        @wiki_page = FactoryGirl.create(:wiki_page, :title => "HOT POTATO", :other_names => "foo*bar baz")
       end
 
       should "not allow the is_locked attribute to be updated" do
@@ -65,6 +65,11 @@ class WikiPageTest < ActiveSupport::TestCase
         matches = WikiPage.titled("hot potato")
         assert_equal(1, matches.count)
         assert_equal("hot_potato", matches.first.title)
+      end
+
+      should "search other names with wildcards" do
+        matches = WikiPage.search(other_names_match: "fo*")
+        assert_equal([@wiki_page.id], matches.map(&:id))
       end
 
       should "create versions" do


### PR DESCRIPTION
Fixes #3070. Allows using `*` wildcards when searching wiki pages by "other names".

The way that other names are stored as a string of space-separated words makes the query somewhat awkward. It also prevents it from being indexed. However, the size of the wiki pages table is small enough that the search isn't too slow.