### PR TITLE
Posts: redefine source column to be non-NULL (fixes #3090).

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -175,7 +175,7 @@ class PostQueryBuilder
     # URLs unchanged.  This is to ease database load for Pixiv source searches.
     if q[:source]
       if q[:source] == "none%"
-        relation = relation.where("(posts.source = '' OR posts.source IS NULL)")
+        relation = relation.where("posts.source = ''")
       elsif q[:source] == "http%"
         relation = relation.where("(lower(posts.source) like ?)", "http%")
       elsif q[:source] =~ /^(?:https?:\/\/)?%\.?pixiv(?:\.net(?:\/img)?)?(?:%\/img\/|%\/|(?=%$))(.+)$/i
@@ -189,7 +189,7 @@ class PostQueryBuilder
 
     if q[:source_neg]
       if q[:source_neg] == "none%"
-        relation = relation.where("(posts.source != '' AND posts.source IS NOT NULL)")
+        relation = relation.where("posts.source != ''")
       elsif q[:source_neg] == "http%"
         relation = relation.where("(lower(posts.source) not like ?)", "http%")
       elsif q[:source_neg] =~ /^(?:https?:\/\/)?%\.?pixiv(?:\.net(?:\/img)?)?(?:%\/img\/|%\/|(?=%$))(.+)$/i

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -818,7 +818,7 @@ class Post < ActiveRecord::Base
           end
 
         when /^source:none$/i
-          self.source = nil
+          self.source = ""
 
         when /^source:"(.*)"$/i
           self.source = $1

--- a/db/migrate/20170526183928_change_source_to_non_null_on_posts.rb
+++ b/db/migrate/20170526183928_change_source_to_non_null_on_posts.rb
@@ -1,0 +1,15 @@
+class ChangeSourceToNonNullOnPosts < ActiveRecord::Migration
+  def up
+    Post.without_timeout do
+      change_column_null(:posts, :source, false, "")
+      change_column_default(:posts, :source, "")
+    end
+  end
+
+  def down
+    Post.without_timeout do
+      change_column_null(:posts, :source, true)
+      change_column_default(:posts, :source, nil)
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2773,7 +2773,7 @@ CREATE TABLE posts (
     up_score integer DEFAULT 0 NOT NULL,
     down_score integer DEFAULT 0 NOT NULL,
     score integer DEFAULT 0 NOT NULL,
-    source character varying,
+    source character varying DEFAULT ''::character varying NOT NULL,
     md5 character varying NOT NULL,
     rating character(1) DEFAULT 'q'::bpchar NOT NULL,
     is_note_locked boolean DEFAULT false NOT NULL,
@@ -7546,4 +7546,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170512221200');
 INSERT INTO schema_migrations (version) VALUES ('20170515235205');
 
 INSERT INTO schema_migrations (version) VALUES ('20170519204506');
+
+INSERT INTO schema_migrations (version) VALUES ('20170526183928');
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -848,7 +848,7 @@ class PostTest < ActiveSupport::TestCase
           should "clear the source with source:none" do
             @post.update(:source => "foobar")
             @post.update(:tag_string => "source:none")
-            assert_nil(@post.source)
+            assert_equal("", @post.source)
           end
 
           should "set the pixiv id with source:https://img18.pixiv.net/img/evazion/14901720.png" do
@@ -1204,7 +1204,7 @@ class PostTest < ActiveSupport::TestCase
         end
 
         should "merge any parent, source, and rating changes that were made after loading the initial set" do
-          post = FactoryGirl.create(:post, :parent => nil, :source => nil, :rating => "q")
+          post = FactoryGirl.create(:post, :parent => nil, :source => "", :rating => "q")
           parent_post = FactoryGirl.create(:post)
 
           # user a changes rating to safe, adds parent
@@ -2349,7 +2349,7 @@ class PostTest < ActiveSupport::TestCase
     context "a post that has been updated" do
       setup do
         PostArchive.sqs_service.stubs(:merge?).returns(false)
-        @post = FactoryGirl.create(:post, :rating => "q", :tag_string => "aaa", :source => nil)
+        @post = FactoryGirl.create(:post, :rating => "q", :tag_string => "aaa", :source => "")
         @post.update_attributes(:tag_string => "aaa bbb ccc ddd")
         @post.update_attributes(:tag_string => "bbb xxx yyy", :source => "xyz")
         @post.update_attributes(:tag_string => "bbb mmm yyy", :source => "abc")
@@ -2362,7 +2362,7 @@ class PostTest < ActiveSupport::TestCase
 
         should "correctly revert all fields" do
           assert_equal("aaa bbb ccc ddd", @post.tag_string)
-          assert_nil(@post.source)
+          assert_equal("", @post.source)
           assert_equal("q", @post.rating)
         end
       end


### PR DESCRIPTION
Fixes #3090 by enforcing blank sources to be the empty string instead of NULL.