### PR TITLE
Mass updates: fix exception when moving saved searches.

### DIFF
--- a/app/logical/moderator/tag_batch_change.rb
+++ b/app/logical/moderator/tag_batch_change.rb
@@ -12,8 +12,6 @@ module Moderator
 
       CurrentUser.without_safe_mode do
         CurrentUser.scoped(updater, updater_ip_addr) do
-          ModAction.log("processed mass update: #{antecedent} -> #{consequent}")
-
           ::Post.tag_match(antecedent).where("true /* Moderator::TagBatchChange#perform */").find_each do |post|
             post.reload
             tags = (post.tag_array - normalized_antecedent + normalized_consequent).join(" ")
@@ -31,6 +29,8 @@ module Moderator
           end
         end
       end
+
+      ModAction.log("processed mass update: #{antecedent} -> #{consequent}")
     end
   end
 end

--- a/app/logical/moderator/tag_batch_change.rb
+++ b/app/logical/moderator/tag_batch_change.rb
@@ -25,7 +25,7 @@ module Moderator
           conds = [conds, *tags.map {|x| "%#{x.to_escaped_for_sql_like}%"}]
           if SavedSearch.enabled?
             SavedSearch.where(*conds).find_each do |ss|
-              ss.query = (ss.query_array - tags + [consequent]).uniq.join(" ")
+              ss.query = (ss.query.split - tags + [consequent]).uniq.join(" ")
               ss.save
             end
           end


### PR DESCRIPTION
https://danbooru.donmai.us/forum_topics/9127?page=187#forum_post_131849:

> Is there a reason why there are so many mass update actions on the mod action page:
http://danbooru.donmai.us/mod_actions
> Is not the first tag I observe that from. Is is really wanted that it creates so many listings? Because it gets kinda confusing if you read the same entry over and over again.

This fixes two problems:

* Mass updates fail when trying to move saved searches because `query_array` doesn't exist (I removed it in 0b63dd32d1747fcbfce3f54eb4ead45269f37e24 but forgot to update this callsite).

* When the mass update delayed job fails, it tries again later but it generates a new modaction each time it tries again.