### PR TITLE
Allow backslash escaping wildcards in wildcard searches.

### DIFF
--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -2,7 +2,18 @@ module Danbooru
   module Extensions
     module String
       def to_escaped_for_sql_like
-        return self.gsub(/\\/, '\0\0').gsub(/(%|_)/, "\\\\\\1").gsub(/\*/, '%')
+        string = self.gsub(/%|_|\*|\\\*|\\\\|\\/) do |str|
+          case str
+          when '%'    then '\%'
+          when '_'    then '\_'
+          when '*'    then '%'
+          when '\*'   then '*'
+          when '\\\\' then '\\\\'
+          when '\\'   then '\\\\'
+          end
+        end
+
+        string
       end
 
       def to_escaped_for_tsquery_split

--- a/test/unit/string_test.rb
+++ b/test/unit/string_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class StringTest < ActiveSupport::TestCase
+  context "String#to_escaped_for_sql_like" do
+    should "work" do
+      assert_equal('foo\%bar', 'foo%bar'.to_escaped_for_sql_like)
+      assert_equal('foo\_bar', 'foo_bar'.to_escaped_for_sql_like)
+      assert_equal('foo%bar', 'foo*bar'.to_escaped_for_sql_like)
+      assert_equal('foo*bar', 'foo\*bar'.to_escaped_for_sql_like)
+      assert_equal('foo\\\\%bar', 'foo\\\\*bar'.to_escaped_for_sql_like)
+      assert_equal('foo\\\\bar', 'foo\bar'.to_escaped_for_sql_like)
+
+      assert_equal('%\\\\%', '*\\\\*'.to_escaped_for_sql_like)
+      assert_equal('%*%', '*\**'.to_escaped_for_sql_like)
+    end
+  end
+end

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -310,5 +310,17 @@ class UserTest < ActiveSupport::TestCase
         end
       end
     end
+
+    context "when searched by name" do
+      should "match wildcards" do
+        user1 = FactoryGirl.create(:user, :name => "foo")
+        user2 = FactoryGirl.create(:user, :name => "foo*bar")
+        user3 = FactoryGirl.create(:user, :name => "bar\*baz")
+
+        assert_equal([user2.id, user1.id], User.search(name: "foo*").map(&:id))
+        assert_equal([user2.id], User.search(name: "foo\*bar").map(&:id))
+        assert_equal([user3.id], User.search(name: "bar\\\*baz").map(&:id))
+      end
+    end
   end
 end


### PR DESCRIPTION
Related to #3070. This allows escaping `*` wildcard characters in searches. This makes it possible to search for things that may contain `*` characters: artist other names, usernames, pool names, note bodies, etc.

These are the escaping rules:

* `*` - wildcard
* `\*` - literal `*`
* `\\` - literal `\`

In other words: to search for strings containing a `*`, say `*\**`. For strings containing a `\`, say `*\\*`.