### PR TITLE
Fix missing spaces between tags on /post_versions

### DIFF
--- a/app/helpers/artist_versions_helper.rb
+++ b/app/helpers/artist_versions_helper.rb
@@ -13,6 +13,7 @@ module ArtistVersionsHelper
     end
     diff[:unchanged_names].each do |name|
       html << '<span>' + h(name) + '</span>'
+      html << " "
     end
 
     html << "</span>"

--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -13,6 +13,7 @@ module PostVersionsHelper
     end
     diff[:unchanged_tags].each do |tag|
       html << '<span>' + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</span>'
+      html << " "
     end
 
     html << "</span>"


### PR DESCRIPTION
Fixes missing spaces between tags on [/post_versions](https://danbooru.donmai.us/post_versions).

https://danbooru.donmai.us/forum_topics/9127?page=188#forum_post_132042:

> When viewing tag history in individual posts all non added tags at last edit appears without any spaces making it looks really awkward, at least Firefox add in line breaks here and there while Explorer just gives me a long string of text. Global changes page seems to be affected too.