### PR TITLE
Resize images for mobile layout

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -25,7 +25,7 @@
       this.initialize_similar();
       this.initialize_replace_image_dialog();
 
-      if (Danbooru.meta("always-resize-images") === "true") {
+      if ((Danbooru.meta("always-resize-images") === "true") || ((Danbooru.Cookie.get("dm") != "1") && (window.innerWidth <= 660))) {
         $("#image-resize-to-window-link").click();
       }
     }


### PR DESCRIPTION
Partial fix for #3074.  It resizes images automatically if it detects a mobile layout.  It currently does nothing for Anonymous since they don't get a resize link.