### PR TITLE
Fix #3099: NilClass error for approval API request

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -512,23 +512,18 @@
   }
 
   Danbooru.Post.approve = function(post_id) {
-    $.ajax({
-      type: "POST",
-      url: "/moderator/post/approval.json",
-      data: {"post_id": post_id},
-      dataType: "json",
-      success: function(data) {
-        if (!data.success) {
-          Danbooru.error("Error: " + data.reason);
-        } else {
-          var $post = $("#post_" + post_id);
-          if ($post.length) {
-            $post.data("flags", $post.data("flags").replace(/pending/, ""));
-            $post.removeClass("post-status-pending");
-          }
-          Danbooru.notice("Approved post #" + post_id);
-          $("#pending-approval-notice").hide();
-        }
+    $.post(
+      "/moderator/post/approval.json",
+      {"post_id": post_id}
+    ).fail(function(data) {
+      var message = $.map(data.responseJSON.errors, function(msg, attr) { return msg; }).join("; ");
+      Danbooru.error("Error: " + message);
+    }).done(function(data) {
+      var $post = $("#post_" + post_id);
+      if ($post.length) {
+        $post.data("flags", $post.data("flags").replace(/pending/, ""));
+        $post.removeClass("post-status-pending");
+        Danbooru.notice("Approved post #" + post_id);
       }
     });
   }

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -174,6 +174,12 @@
         e.preventDefault();
       });
 
+      if (Danbooru.meta("current-user-can-approve-posts") === "true") {
+        Danbooru.keydown("shift+o", "approve", function(e) {
+          $("#quick-mod-approve").click();
+        });
+      }
+
       Danbooru.keydown("a", "prev_page", Danbooru.Post.nav_prev);
       Danbooru.keydown("d", "next_page", Danbooru.Post.nav_next);
       Danbooru.keydown("f", "favorite", Danbooru.Post.favorite);

--- a/app/assets/javascripts/shortcuts.js
+++ b/app/assets/javascripts/shortcuts.js
@@ -30,14 +30,6 @@
       });
     }
 
-    if ($("#c-posts").length && $("#a-show").length) {
-      Danbooru.keydown("shift+o", "approve", function(e) {
-        if (Danbooru.meta("current-user-can-approve-posts") === "true") {
-          Danbooru.Post.approve(Danbooru.meta("post-id"));
-        }
-      });
-    }
-
     if ($("#c-posts #a-index, #c-posts #a-show, #c-favorites #a-index").length) {
       Danbooru.keydown("r", "random", function(e) {
         $("#random-post")[0].click();

--- a/app/controllers/moderator/post/approvals_controller.rb
+++ b/app/controllers/moderator/post/approvals_controller.rb
@@ -9,7 +9,7 @@ module Moderator
         cookies.permanent[:moderated] = Time.now.to_i
         post = ::Post.find(params[:post_id])
         @approval = post.approve!
-        respond_with(@approval)
+        respond_with(:moderator, @approval)
       end
     end
   end

--- a/app/views/moderator/post/approvals/create.js.erb
+++ b/app/views/moderator/post/approvals/create.js.erb
@@ -8,7 +8,7 @@ $("#c-posts #approve").hide();
 $("#c-posts #disapprove").hide();
 $("#c-posts #flag").show();
 
-$("#pending-approval-notice").hide();
+$("#pending-approval-notice, .notice-flagged, .notice-appealed").hide();
 
 $("#c-moderator-post-queues #post-<%= @approval.post.id %>").hide();
 Danbooru.notice("Post was approved");

--- a/app/views/moderator/post/approvals/create.json.erb
+++ b/app/views/moderator/post/approvals/create.json.erb
@@ -1,1 +1,0 @@
-{"success": <%= @post.errors.empty? %>, "reason": <%= raw @post.errors.full_messages.join("; ").to_json %>}

--- a/app/views/posts/partials/show/_notices.html.erb
+++ b/app/views/posts/partials/show/_notices.html.erb
@@ -43,7 +43,7 @@
     <% if CurrentUser.can_approve_posts? && !post.disapproved_by?(CurrentUser.user) %>
       <div class="quick-mod">
         <% unless post.is_status_locked? %>
-          <%= link_to "Approve", moderator_post_approval_path(:post_id => post.id), :method => :post, :remote => true, :class => "btn" %> |
+          <%= link_to "Approve", moderator_post_approval_path(:post_id => post.id), :id => "quick-mod-approve", :method => :post, :remote => true, :class => "btn" %> |
         <% end %>
         <%= link_to "Breaks Rules", moderator_post_disapproval_path(:post_id => post.id, :reason => "breaks_rules"), :method => :post, :remote => true, :class => "btn" %> |
         <%= link_to "Poor Quality", moderator_post_disapproval_path(:post_id => post.id, :reason => "poor_quality"), :method => :post, :remote => true, :class => "btn" %> |


### PR DESCRIPTION
Fixes #3099:

* Fixes error in the `shift+o` shortcut that prevented it from showing the "post was approved" notice.
* Fixes error in the approve action in the mode menu that prevented it from showing the "post was approved" notice, and from removing the blue border.
* Fixes the `shift+o` shortcut to hide the flag/appeal notice bars.