### PR TITLE
Fix height of tag edit box in edit mode.

### DIFF
--- a/app/assets/javascripts/post_mode_menu.js
+++ b/app/assets/javascripts/post_mode_menu.js
@@ -138,7 +138,13 @@
     var $post = $("#post_" + post_id);
     $("#quick-edit-div").slideDown("fast");
     $("#quick-edit-form").attr("action", "/posts/" + post_id + ".json");
-    $("#post_tag_string").val($post.data("tags") + " ").focus().selectEnd().height($("#post_tag_string")[0].scrollHeight);
+    $("#post_tag_string").val($post.data("tags") + " ").focus().selectEnd();
+
+    /* Set height of tag edit box to fit content. */
+    $("#post_tag_string").height(80);  // min height: 80px.
+    var padding = $("#post_tag_string").innerHeight() - $("#post_tag_string").height();
+    var height = $("#post_tag_string").prop("scrollHeight") - padding;
+    $("#post_tag_string").height(height);
   }
 
   Danbooru.PostModeMenu.click = function(e) {


### PR DESCRIPTION
Bug: when using edit mode from the mode menu, each time you click a thumbnail the height of the tag edit box increases by 4px. This causes the edit box to constantly grow as you click thumbnails.

This is due to `scrollHeight` including vertical padding. The fix is to ignore the padding.