### PR TITLE
Forum topics: don't list sticky topics first in json/atom responses.

### DIFF
--- a/app/controllers/forum_topics_controller.rb
+++ b/app/controllers/forum_topics_controller.rb
@@ -19,8 +19,11 @@ class ForumTopicsController < ApplicationController
   end
 
   def index
+    params[:search] ||= {}
+    params[:search][:order] ||= "sticky" if request.format == Mime::HTML
+
     @query = ForumTopic.active.search(params[:search])
-    @forum_topics = @query.order("is_sticky DESC, updated_at DESC").paginate(params[:page], :limit => per_page, :search_count => params[:search])
+    @forum_topics = @query.paginate(params[:page], :limit => per_page, :search_count => params[:search])
 
     respond_with(@forum_topics) do |format|
       format.html do

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -68,9 +68,12 @@ class ForumTopic < ActiveRecord::Base
       where("min_level <= ?", CurrentUser.level)
     end
 
+    def sticky_first
+      order(is_sticky: :desc, updated_at: :desc)
+    end
+
     def search(params)
       q = permitted
-      return q if params.blank?
 
       if params[:id].present?
         q = q.where(id: params[:id].split(",").map(&:to_i))
@@ -90,6 +93,13 @@ class ForumTopic < ActiveRecord::Base
 
       if params[:title].present?
         q = q.where("title = ?", params[:title])
+      end
+
+      case params[:order]
+      when "sticky"
+        q = q.sticky_first
+      else
+        q = q.order(updated_at: :desc)
       end
 
       q

--- a/test/functional/forum_topics_controller_test.rb
+++ b/test/functional/forum_topics_controller_test.rb
@@ -74,9 +74,21 @@ class ForumTopicsControllerTest < ActionController::TestCase
     end
 
     context "index action" do
+      setup do
+        @topic1 = FactoryGirl.create(:forum_topic, :is_sticky => true, :creator => @user, :original_post_attributes => {:body => "xxx"})
+        @topic2 = FactoryGirl.create(:forum_topic, :creator => @user, :original_post_attributes => {:body => "xxx"})
+      end
+
       should "list all forum topics" do
         get :index
         assert_response :success
+      end
+
+      should "not list stickied topics first for JSON responses" do
+        get :index, {format: :json}
+        forum_topics = JSON.parse(response.body)
+
+        assert_equal([@topic2.id, @topic1.id, @forum_topic.id], forum_topics.map {|t| t["id"]})
       end
 
       should "render for atom feed" do


### PR DESCRIPTION
Bug: [/forum_topics.json](https://danbooru.donmai.us/forum_topics.json) and [/forum_topics.atom](https://danbooru.donmai.us/forum_topics.atom) always return stickied topics first.

This fixes topic listing to only sticky topics in the HTML response, not API responses.