### PR TITLE
Fix #3108: support https://$artist.artstation.com/projects/$id urls

### DIFF
--- a/app/logical/downloads/rewrite_strategies/art_station.rb
+++ b/app/logical/downloads/rewrite_strategies/art_station.rb
@@ -8,7 +8,7 @@ module Downloads
           if test_original(original_url)
             url = original_url
           end
-        elsif url =~ %r!https?://\w+\.artstation\.com/artwork/!
+        else
           url, headers = rewrite_html_url(url, headers)
         end
 
@@ -22,6 +22,8 @@ module Downloads
       end
 
       def rewrite_html_url(url, headers)
+        return [url, headers] unless Sources::Strategies::ArtStation.url_match?(url)
+
         source = Sources::Site.new(url)
         source.get
         [source.image_url, headers]

--- a/app/logical/sources/strategies/art_station.rb
+++ b/app/logical/sources/strategies/art_station.rb
@@ -3,11 +3,19 @@ module Sources::Strategies
     attr_reader :json, :image_urls
 
     def self.url_match?(url)
-      url =~ %r!^https?://\w+\.artstation\.com/artwork/[a-z0-9]+!i
+      self.project_id(url).present?
+    end
+
+    def self.project_id(url)
+      if url =~ %r!\Ahttps?://\w+\.artstation\.com/(?:artwork|projects)/(?<project_id>[a-z0-9]+)\z!i
+        $~[:project_id]
+      else
+        nil
+      end
     end
 
     def referer_url
-      if @referer_url =~ %r!^https?://\w+\.artstation\.com/artwork/[a-z0-9]+!i
+      if self.class.url_match?(@referer_url)
         @referer_url
       else
         @url
@@ -18,8 +26,16 @@ module Sources::Strategies
       "ArtStation"
     end
 
+    def project_id
+      self.class.project_id(referer_url)
+    end
+
+    def page_url
+      "https://www.artstation.com/artwork/#{project_id}"
+    end
+
     def api_url
-      url.sub(%r!^https?://\w+\.!, "https://www.").sub(%r!/artwork/!, "/projects/") + ".json"
+      "https://www.artstation.com/projects/#{project_id}.json"
     end
 
     def image_url

--- a/test/unit/downloads/art_station_test.rb
+++ b/test/unit/downloads/art_station_test.rb
@@ -27,5 +27,18 @@ module Downloads
         assert_equal("https://cdna.artstation.com/p/assets/images/images/004/730/278/large/mendel-oh-dragonll.jpg", @download.source)
       end
     end
+
+    context "a download for a https://$artist.artstation.com/projects/$id page" do
+      setup do
+        @source = "https://dantewontdie.artstation.com/projects/YZK5q"
+        @tempfile = Tempfile.new("danbooru-test")
+        @download = Downloads::File.new(@source, @tempfile.path)
+        @download.download!
+      end
+
+      should "download the original image instead" do
+        assert_equal("https://cdna.artstation.com/p/assets/images/images/006/066/534/original/yinan-cui-reika.jpg?1495781565", @download.source)
+      end
+    end
   end
 end

--- a/test/unit/sources/art_station_test.rb
+++ b/test/unit/sources/art_station_test.rb
@@ -4,7 +4,7 @@ module Sources
   class ArtStationTest < ActiveSupport::TestCase
     context "The source site for an art station artwork page" do
       setup do
-        @site = Sources::Site.new("https://jeyrain.artstation.com/artwork/04XA4")
+        @site = Sources::Site.new("https://www.artstation.com/artwork/04XA4")
         @site.get
       end
 
@@ -27,6 +27,35 @@ module Sources
       should "get the artist commentary" do
         assert_equal("pink", @site.artist_commentary_title)
         assert_equal("", @site.artist_commentary_desc)
+      end
+    end
+
+    context "The source site for an art station projects page" do
+      setup do
+        @site = Sources::Site.new("https://dantewontdie.artstation.com/projects/YZK5q")
+        @site.get
+      end
+
+      should "get the image url" do
+        url = "https://cdna.artstation.com/p/assets/images/images/006/066/534/original/yinan-cui-reika.jpg?1495781565"
+        assert_equal(url, @site.image_url)
+      end
+
+      should "get the profile" do
+        assert_equal("https://www.artstation.com/artist/dantewontdie", @site.profile_url)
+      end
+
+      should "get the artist name" do
+        assert_equal("dantewontdie", @site.artist_name)
+      end
+
+      should "get the tags" do
+        assert_equal(%w[gantz reika], @site.tags.map(&:first))
+      end
+
+      should "get the artist commentary" do
+        assert_equal("Reika ", @site.artist_commentary_title)
+        assert_equal("From Gantz.", @site.artist_commentary_desc)
       end
     end
   end


### PR DESCRIPTION
Fixes #3108. Adds support for https://dantewontdie.artstation.com/projects/YZK5q style urls during source fetching and download rewriting.