### PR TITLE
Fix #3117: Nicoseiga handler grabbing wrong commentary source

### DIFF
--- a/app/logical/nico_seiga_api_client.rb
+++ b/app/logical/nico_seiga_api_client.rb
@@ -28,15 +28,16 @@ class NicoSeigaApiClient
   end
 
   def parse_artist_xml_response(text)
-    doc = Nokogiri::Slop(text)
-    @moniker = doc.response.user.nickname.content
+    doc = Hash.from_xml(text)
+    @moniker = doc["response"]["user"]["nickname"]
   end
 
   def parse_illust_xml_response(text)
-    doc = Nokogiri::Slop(text)
-    @image_id = doc.response.image.id.content.to_i
-    @user_id = doc.response.image.user_id.content.to_i
-    @title = doc.response.image.title.content
-    @desc = [doc.response.image.description.try(:content), doc.response.image.summary.try(:content)].compact.join("\n\n")
+    doc = Hash.from_xml(text)
+    image = doc["response"]["image"]
+    @image_id = image["id"].to_i
+    @user_id = image["user_id"].to_i
+    @title = image["title"]
+    @desc = image["description"]
   end
 end

--- a/test/unit/sources/nico_seiga_test.rb
+++ b/test/unit/sources/nico_seiga_test.rb
@@ -23,7 +23,7 @@ module Sources
 
       should "get the artist commentary" do
         assert_equal("コジコジ", @site_2.artist_commentary_title)
-        assert_equal("懐かしいですよね。テ また懐かしいものを ", @site_2.artist_commentary_desc)
+        assert_equal("コジコジのドット絵\nこんなかわいらしい容姿で毒を吐くコジコジが堪らん（切実）", @site_2.artist_commentary_desc)
       end
 
       should "get the image url" do


### PR DESCRIPTION
Fixes #3117. For some reason `doc.response.image.description` returns nil even though the description element exists. Switch to `Hash.from_xml` to avoid this.