### PR TITLE
Fix gallery warning for non-Pixiv galleries.

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -102,7 +102,7 @@
 
     $("#source-record").html($("<a>").attr("href", new_artist_href).text("Create New"));
 
-    if (data.page_count > 1) {
+    if (data.image_urls.length > 1) {
       $("#gallery-warning").show();
     } else {
       $("#gallery-warning").hide();

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -5,7 +5,7 @@ module Sources
     attr_reader :url, :strategy
     delegate :get, :get_size, :site_name, :artist_name, 
       :profile_url, :image_url, :tags, :artist_record, :unique_id, 
-      :page_count, :file_url, :ugoira_frame_data, :ugoira_content_type, :image_urls,
+      :file_url, :ugoira_frame_data, :ugoira_content_type, :image_urls,
       :artist_commentary_title, :artist_commentary_desc,
       :dtext_artist_commentary_title, :dtext_artist_commentary_desc,
       :rewrite_thumbnails, :illust_id_from_url, :to => :strategy
@@ -63,13 +63,13 @@ module Sources
         :artist_name => artist_name,
         :profile_url => profile_url,
         :image_url => image_url,
+        :image_urls => image_urls,
         :normalized_for_artist_finder_url => normalize_for_artist_finder!,
         :tags => tags,
         :translated_tags => translated_tags,
         :danbooru_name => artist_record.try(:first).try(:name),
         :danbooru_id => artist_record.try(:first).try(:id),
         :unique_id => unique_id,
-        :page_count => page_count,
         :artist_commentary => {
           :title => artist_commentary_title,
           :description => artist_commentary_desc,

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -10,7 +10,7 @@ module Sources
   module Strategies
     class Base
       attr_reader :url, :referer_url
-      attr_reader :artist_name, :profile_url, :image_url, :tags, :page_count
+      attr_reader :artist_name, :profile_url, :image_url, :tags
       attr_reader :artist_commentary_title, :artist_commentary_desc
 
       def self.url_match?(url)
@@ -20,7 +20,6 @@ module Sources
       def initialize(url, referer_url = nil)
         @url = url
         @referer_url = referer_url
-        @page_count = 1
       end
 
       # No remote calls are made until this method is called.

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -77,7 +77,7 @@ module Sources
         end
 
         should "get the page count" do
-          assert_equal(3, @site.page_count)
+          assert_equal(3, @site.image_urls.size)
         end
 
         should "get the tags" do
@@ -108,7 +108,7 @@ module Sources
         end
 
         should "get the page count" do
-          assert_equal(1, @site.page_count)
+          assert_equal(1, @site.image_urls.size)
         end
 
         should "get the full size image url" do


### PR DESCRIPTION
Bug: The `"Gallery. Tags may not apply to all images."` warning doesn't appear when uploading from non-Pixiv galleries, namely Twitter and ArtStation.

The problem is that the check relies on a `page_count` field that is only set for Pixiv. The fix is to return the `image_urls` list and check that instead to see if it's a single image or a gallery.

Test case: https://danbooru.donmai.us/uploads/new?ref=https%3A%2F%2Ftwitter.com%2Fpon0737%2Fstatus%2F866610987192811520&url=http%3A%2F%2Fpbs.twimg.com%2Fmedia%2FDAbSAUAWsAIhy35.jpg%3Aorig