### PR TITLE
Multiple ArtStation fixes

### DIFF
--- a/app/logical/downloads/file.rb
+++ b/app/logical/downloads/file.rb
@@ -57,7 +57,7 @@ module Downloads
     def after_download(src)
       src = fix_twitter_sources(src)
       if options[:referer_url].present?
-        src = set_source_to_referer(src)
+        src = set_source_to_referer(src, options[:referer_url])
       end
       src
     end
@@ -137,12 +137,13 @@ module Downloads
       end
     end
 
-    def set_source_to_referer(src)
+    def set_source_to_referer(src, referer)
       if Sources::Strategies::Nijie.url_match?(src) ||
          Sources::Strategies::Twitter.url_match?(src) ||
          Sources::Strategies::Tumblr.url_match?(src) ||
-         Sources::Strategies::Pawoo.url_match?(src)
-        strategy = Sources::Site.new(src, :referer_url => options[:referer_url])
+         Sources::Strategies::Pawoo.url_match?(src) ||
+         Sources::Strategies::ArtStation.url_match?(src) || Sources::Strategies::ArtStation.url_match?(referer)
+        strategy = Sources::Site.new(src, :referer_url => referer)
         strategy.referer_url
       else
         src

--- a/app/logical/sources/site.rb
+++ b/app/logical/sources/site.rb
@@ -14,12 +14,12 @@ module Sources
       [Strategies::PixivWhitecube, Strategies::Pixiv, Strategies::NicoSeiga, Strategies::DeviantArt, Strategies::ArtStation, Strategies::Nijie, Strategies::Twitter, Strategies::Tumblr, Strategies::Pawoo]
     end
 
-    def initialize(url, options = {})
+    def initialize(url, referer_url: nil)
       @url = url
 
       Site.strategies.each do |strategy|
-        if strategy.url_match?(url)
-          @strategy = strategy.new(url, options[:referer_url])
+        if strategy.url_match?(url) || strategy.url_match?(referer_url)
+          @strategy = strategy.new(url, referer_url)
           break
         end
       end

--- a/app/logical/sources/strategies/art_station.rb
+++ b/app/logical/sources/strategies/art_station.rb
@@ -54,7 +54,8 @@ module Sources::Strategies
           @json = JSON.parse(resp.body)
           @artist_name = json["user"]["username"]
           @profile_url = json["user"]["permalink"]
-          @image_urls = json["assets"].map do |x| 
+          images = json["assets"].select { |asset| asset["asset_type"] == "image" }
+          @image_urls = images.map do |x|
             y, _, _ = image_url_rewriter.rewrite(x["image_url"], nil)
             y
           end

--- a/app/logical/sources/strategies/art_station.rb
+++ b/app/logical/sources/strategies/art_station.rb
@@ -6,8 +6,11 @@ module Sources::Strategies
       self.project_id(url).present?
     end
 
+    # https://www.artstation.com/artwork/04XA4"
+    # https://dantewontdie.artstation.com/projects/YZK5q"
+    # https://www.artstation.com/artwork/cody-from-sf"
     def self.project_id(url)
-      if url =~ %r!\Ahttps?://\w+\.artstation\.com/(?:artwork|projects)/(?<project_id>[a-z0-9]+)\z!i
+      if url =~ %r!\Ahttps?://\w+\.artstation\.com/(?:artwork|projects)/(?<project_id>[a-z0-9-]+)\z!i
         $~[:project_id]
       else
         nil

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -528,6 +528,11 @@ class Post < ActiveRecord::Base
       # https://yande.re/sample/ceb6a12e87945413a95b90fada406f91/.jpg
       when %r{\Ahttps?://(?:ayase\.|yuno\.|files\.)?yande\.re/(?:image|jpeg|sample)/(?<md5>[a-z0-9]{32})(?:/yande\.re.*|/?\.(?:jpg|png))\Z}i
         "https://yande.re/post?tags=md5:#{$~[:md5]}"
+
+      # https://gfee_li.artstation.com/projects/XPGOD
+      # https://gfee_li.artstation.com/projects/asuka-7
+      when %r{\Ahttps?://\w+\.artstation.com/(?:artwork|projects)/(?<project_id>[a-z0-9-]+)\z/}i
+        "https://www.artstation.com/artwork/#{$~[:project_id]}"
         
       when %r{\Ahttps?://(?:o|image-proxy-origin)\.twimg\.com/\d/proxy\.jpg\?t=(\w+)&}i
         str = Base64.decode64($1)

--- a/test/unit/sources/art_station_test.rb
+++ b/test/unit/sources/art_station_test.rb
@@ -71,6 +71,19 @@ module Sources
       end
     end
 
+    context "The source site for a http://cdna.artstation.com/p/assets/... url" do
+      setup do
+        @url = "https://cdna.artstation.com/p/assets/images/images/006/029/978/large/amama-l-z.jpg"
+        @ref = "https://www.artstation.com/artwork/4BWW2"
+        @site = Sources::Site.new(@url, referer_url: @ref)
+        @site.get
+      end
+
+      should "fetch the source data" do
+        assert_equal("amama", @site.artist_name)
+      end
+    end
+
     context "The source site for an ArtStation gallery" do
       setup do
         @site = Sources::Site.new("https://www.artstation.com/artwork/BDxrA")

--- a/test/unit/sources/art_station_test.rb
+++ b/test/unit/sources/art_station_test.rb
@@ -58,5 +58,17 @@ module Sources
         assert_equal("From Gantz.", @site.artist_commentary_desc)
       end
     end
+
+    context "The source site for a www.artstation.com/artwork/$slug page" do
+      setup do
+        @site = Sources::Site.new("https://www.artstation.com/artwork/cody-from-sf")
+        @site.get
+      end
+
+      should "get the image url" do
+        url = "https://cdna.artstation.com/p/assets/images/images/000/144/922/original/cassio-yoshiyaki-cody2backup2-yoshiyaki.jpg?1406314198"
+        assert_equal(url, @site.image_url)
+      end
+    end
   end
 end

--- a/test/unit/sources/art_station_test.rb
+++ b/test/unit/sources/art_station_test.rb
@@ -70,5 +70,17 @@ module Sources
         assert_equal(url, @site.image_url)
       end
     end
+
+    context "The source site for an ArtStation gallery" do
+      setup do
+        @site = Sources::Site.new("https://www.artstation.com/artwork/BDxrA")
+        @site.get
+      end
+
+      should "get only image urls, not video urls" do
+        urls = %w[https://cdnb.artstation.com/p/assets/images/images/006/037/253/original/astri-lohne-sjursen-eva.jpg?1495573664]
+        assert_equal(urls, @site.image_urls)
+      end
+    end
   end
 end


### PR DESCRIPTION
A few fixes for ArtStation:

* Recognize <http://www.artstation.com/artwork/cody-from-sf> style URLs.
* Change source from image URL to HTML page URL after upload.
* Include only images in `image_urls`. ArtStation posts can contain Youtube videos and 3D models ([example](https://www.artstation.com/artwork/1Grqo)), but those should be ignored by the batch upload bookmarklet.
* Normalize sources to <https://www.artstation.com/artwork/XPGOD> for the sidebar.
* Fix `Fetch source data` to work when uploading from a direct image URL ([example](https://danbooru.donmai.us/uploads/new?url=https://cdna.artstation.com/p/assets/images/images/006/029/978/large/amama-l-z.jpg&ref=https://www.artstation.com/artwork/4BWW2)).