### PR TITLE
Fix #3121: No Blacklist Box on the various controllers

### DIFF
--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -504,7 +504,7 @@ div#c-explore-posts {
   }
 }
 
-div#c-explore-posts, div#c-post-appeals, div#c-post-flags, div#c-pools, div#c-notes, div#c-comments, div#c-favorite-groups {
+.inline-blacklist {
   #blacklist-box {
     margin-bottom: 1em;
   }

--- a/app/views/artist_commentaries/index.html.erb
+++ b/app/views/artist_commentaries/index.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Artist Commentary</h1>
 
+    <%= render "posts/partials/common/inline_blacklist" %>
+
     <table width="100%" class="striped">
       <thead>
         <tr>

--- a/app/views/comments/index_by_comment.html.erb
+++ b/app/views/comments/index_by_comment.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Comments</h1>
 
+    <%= render "posts/partials/common/inline_blacklist" %>
+
     <div class="comments-for-post">
       <div class="list-of-comments">
         <% @comments.each do |comment| %>

--- a/app/views/moderator/dashboards/show.html.erb
+++ b/app/views/moderator/dashboards/show.html.erb
@@ -3,6 +3,7 @@
     <h1>Moderator Dashboard</h1>
 
     <%= render "search" %>
+    <%= render "posts/partials/common/inline_blacklist" %>
 
     <div id="col1">
       <div class="activity"><%= render "activity_upload" %></div>

--- a/app/views/posts/partials/common/_inline_blacklist.html.erb
+++ b/app/views/posts/partials/common/_inline_blacklist.html.erb
@@ -1,4 +1,4 @@
-<div id="blacklist-box">
+<div id="blacklist-box" class="inline-blacklist">
   <strong>Blacklisted: </strong>
   <ul id="blacklist-list">
     <li id="disable-all-blacklists" style="display: none;"><span class="link">Disable all</span></li>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,6 +5,7 @@
     <%= render "statistics", :presenter => @presenter, :user => @user %>
 
     <% if !CurrentUser.is_admin? && !@user.enable_privacy_mode? || CurrentUser.id == @user.id %>
+      <%= render "posts/partials/common/inline_blacklist" %>
       <%= render "post_summary", :presenter => @presenter, :user => @user %>
     <% end %>
   </div>


### PR DESCRIPTION
Fixes #3121. Adds blacklist controls to these pages:

* /comments?group_by=comment
* /users/$ID
* /artist_commentaries
* /moderator/dashboard