### PR TITLE
Add partial indexes on is_pending, is_flagged.

### DIFF
--- a/db/migrate/20170608043651_add_pending_flagged_indexes_to_posts.rb
+++ b/db/migrate/20170608043651_add_pending_flagged_indexes_to_posts.rb
@@ -1,0 +1,8 @@
+class AddPendingFlaggedIndexesToPosts < ActiveRecord::Migration
+  def change
+    Post.without_timeout do
+      add_index :posts, :is_pending, where: "is_pending = true"
+      add_index :posts, :is_flagged, where: "is_flagged = true"
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -6893,6 +6893,20 @@ CREATE INDEX index_posts_on_image_width ON posts USING btree (image_width);
 
 
 --
+-- Name: index_posts_on_is_flagged; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_is_flagged ON posts USING btree (is_flagged) WHERE (is_flagged = true);
+
+
+--
+-- Name: index_posts_on_is_pending; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_posts_on_is_pending ON posts USING btree (is_pending) WHERE (is_pending = true);
+
+
+--
 -- Name: index_posts_on_last_comment_bumped_at; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7548,4 +7562,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170515235205');
 INSERT INTO schema_migrations (version) VALUES ('20170519204506');
 
 INSERT INTO schema_migrations (version) VALUES ('20170526183928');
+
+INSERT INTO schema_migrations (version) VALUES ('20170608043651');
 


### PR DESCRIPTION
Problem: the modqueue loads slowly. This is because it queries for pending or flagged posts, but these columns are unindexed.

This adds partial indexes on `is_flagged` and `is_pending`, which speeds up the modqueue as well as `status:pending` and `status:flagged` searches. This would add more indexes to the posts table, but since these are partial indexes the cost should be minimal.