### PR TITLE
Autoconvert DeviantArt commentary from HTML to DText

### DIFF
--- a/app/assets/javascripts/artist_commentaries.js
+++ b/app/assets/javascripts/artist_commentaries.js
@@ -86,8 +86,8 @@
   Danbooru.ArtistCommentary.from_source = function(source) {
     return $.get("/source.json?url=" + encodeURIComponent(source)).then(function(data) {
       return {
-        original_title: data.artist_commentary.title,
-        original_description: data.artist_commentary.description,
+        original_title: data.artist_commentary.dtext_title,
+        original_description: data.artist_commentary.dtext_description,
         source: source,
       };
     });

--- a/app/logical/sources/strategies/deviant_art.rb
+++ b/app/logical/sources/strategies/deviant_art.rb
@@ -24,6 +24,7 @@ module Sources
 
       def get
         agent.get(URI.parse(normalized_url)) do |page|
+          page.encoding = "utf-8"
           @artist_name, @profile_url = get_profile_from_page(page)
           @image_url = get_image_url_from_page(page)
           @tags = get_tags_from_page(page)

--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -1,0 +1,79 @@
+require 'test_helper'
+
+module Sources
+  class DeviantArtTest < ActiveSupport::TestCase
+    context "The source for an DeviantArt artwork page" do
+      setup do
+        @site = Sources::Site.new("http://noizave.deviantart.com/art/test-post-please-ignore-685436408")
+        @site.get
+      end
+
+      should "get the image url" do
+        assert_equal("http://orig02.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png", @site.image_url)
+      end
+
+      should "get the profile" do
+        assert_equal("http://noizave.deviantart.com/", @site.profile_url)
+      end
+
+      should "get the artist name" do
+        assert_equal("noizave", @site.artist_name)
+      end
+
+      should "get the tags" do
+        assert_equal(%w[bar baz foo], @site.tags.map(&:first))
+      end
+
+      should "get the artist commentary" do
+        title = "test post please ignore"
+        desc = "<div align=\"center\"><span>blah blah<br><div align=\"left\">\n<a class=\"external\" href=\"http://www.deviantart.com/users/outgoing?http://www.google.com\">test link</a><br>\n</div></span></div>\n<br><h1>lol</h1>\n<br><br><b>blah</b> <i>blah</i> <u>blah</u> <strike>blah</strike><br>herp derp<br><br><blockquote>this is a quote</blockquote>\n<ol>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ol>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n<img src=\"http://e.deviantart.net/emoticons/h/heart.gif\" alt=\"Heart\" style=\"width: 15px; height: 13px;\" data-embed-type=\"emoticon\" data-embed-id=\"357\">  "
+
+        assert_equal(title, @site.artist_commentary_title)
+        assert_equal(desc, @site.artist_commentary_desc)
+      end
+
+      should "get the dtext-ified commentary" do
+        desc = <<-EOS.strip_heredoc.chomp
+          blah blah
+          
+          "test link":[http://www.google.com]
+          
+
+
+          h1. lol
+
+          
+
+          [b]blah[/b] [i]blah[/i] [u]blah[/u] [s]blah[/s]
+          herp derp
+          
+          [quote]this is a quote[/quote]
+          
+          * one
+          * two
+          * three
+          
+          
+          * one
+          * two
+          * three
+          
+          Heart  
+        EOS
+
+        assert_equal(desc, @site.dtext_artist_commentary_desc)
+      end
+    end
+
+    context "The source for a login-only DeviantArt artwork page" do
+      setup do
+        @site = Sources::Site.new("http://noizave.deviantart.com/art/hidden-work-685458369")
+        @site.get
+      end
+
+      should_eventually "get the image url" do
+        assert_equal("http://orig14.deviantart.net/cb25/f/2017/160/1/9/hidden_work_by_noizave-dbc3r29.png", @site.image_url)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes an issue raised in [topic #14125](https://danbooru.donmai.us/forum_topics/14125). Currently we strip HTML from DeviantArt commentaries, but this tends to produce bad results that require manual cleanup.

This instead converts HTML into DText syntax. We recurse through the HTML and map HTML elements to their DText equivalents. For most elements there is a 1-to-1 mapping, except for `<img>` tags, where we just output the tooltip instead.

Test case: http://noizave.deviantart.com/art/test-post-please-ignore-685436408