### PR TITLE
Fix #3139: XSS in Related Tags javascript.

### DIFF
--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -227,14 +227,10 @@
         if (text.match(/^ http/)) {
           text = text.substring(1, 1000);
           var $url = $("<a/>");
-          $url.text("open");
+          $url.text(text);
           $url.attr("href", text);
           $url.attr("target", "_blank");
-          var $li = $("<li/>");
-          $li.append(text + " [");
-          $li.append($url);
-          $li.append("]");
-          $ul.append($li);
+          $ul.append($("<li/>").html($url));
         } else {
           $ul.append($("<li/>").text(text));
         }


### PR DESCRIPTION
Fixes #3139. Removes the `[open]` link to the right of the artist URL. Makes the URL itself into a link instead.