### PR TITLE
Fix #3138: Support DeviantArt login-only works.

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -359,6 +359,14 @@ module Danbooru
       nil
     end
 
+    def deviantart_login
+      nil
+    end
+
+    def deviantart_password
+      nil
+    end
+
     def enable_dimension_autotagging
       true
     end

--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -71,7 +71,7 @@ module Sources
         @site.get
       end
 
-      should_eventually "get the image url" do
+      should "get the image url" do
         assert_equal("http://orig14.deviantart.net/cb25/f/2017/160/1/9/hidden_work_by_noizave-dbc3r29.png", @site.image_url)
       end
     end


### PR DESCRIPTION
Fixes #3138. Logs in to DeviantArt so that we're able to fetch login-only images. This is the login flow:

* `GET https://www.deviantart.com/users/login` - get the CSRF tokens, `validate_key` and `validate_token`.
* `POST https://www.deviantart.com/users/login` - post the `username`, `password`, `validate_key`, and `validate_token`.
* Save the session cookies, `auth` and `userinfo`. There is a third cookie, `auth_secure`, but it doesn't seem to be needed. Login works without it.