### PR TITLE
Fix wordbreaks in tags on /post_versions

### DIFF
--- a/app/helpers/post_versions_helper.rb
+++ b/app/helpers/post_versions_helper.rb
@@ -6,10 +6,12 @@ module PostVersionsHelper
     diff[:added_tags].each do |tag|
       prefix = diff[:obsolete_added_tags].include?(tag) ? '+<ins class="obsolete">' : '<ins>+'
       html << prefix + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</ins>'
+      html << " "
     end
     diff[:removed_tags].each do |tag|
       prefix = diff[:obsolete_removed_tags].include?(tag) ? '-<del class="obsolete">' : '<del>-'
       html << prefix + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</del>'
+      html << " "
     end
     diff[:unchanged_tags].each do |tag|
       html << '<span>' + link_to(wordbreakify(tag), posts_path(:tags => tag)) + '</span>'


### PR DESCRIPTION
Fixes this issue from https://danbooru.donmai.us/forum_topics/9127?page=188#forum_post_132424:

> In post changes history, added tags have line breaks in random places.
> See an example: http://i.imgur.com/1Ko9EpR.png

9bf85ee2b3aaeea071f6b2428c8b9017065bfb1f removed whitespace that was between the `<ins>`/`<del>` elements, but it turns out this whitespace is significant, as tags wordbreak differently without it.