### PR TITLE
Fix #1608: Show wiki page of alias consequent for Related Tags

### DIFF
--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -1,8 +1,8 @@
 class RelatedTagQuery
   attr_reader :query, :category
 
-  def initialize(query, category)
-    @query = query.strip
+  def initialize(query, category = nil)
+    @query = TagAlias.to_aliased(query.strip).join(" ")
     @category = category
   end
 

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -250,7 +250,7 @@ class WikiPage < ActiveRecord::Base
       else
         match
       end
-    end.map {|x| x.mb_chars.downcase.tr(" ", "_").to_s}
+    end.map {|x| x.mb_chars.downcase.tr(" ", "_").to_s}.uniq
   end
 
   def visible?

--- a/test/unit/related_tag_query_test.rb
+++ b/test/unit/related_tag_query_test.rb
@@ -38,6 +38,24 @@ class RelatedTagQueryTest < ActiveSupport::TestCase
       end
     end
 
+    context "for an aliased tag" do
+      setup do
+        @ta = FactoryGirl.create(:tag_alias, antecedent_name: "xyz", consequent_name: "aaa")
+        @wp = FactoryGirl.create(:wiki_page, title: "aaa", body: "blah [[foo|blah]] [[FOO]] [[bar]] blah")
+        @query = RelatedTagQuery.new("xyz", "")
+
+        Tag.named("aaa").first.update_related
+      end
+
+      should "take wiki tags from the consequent's wiki" do
+        assert_equal(%w[foo bar], @query.wiki_page_tags)
+      end
+
+      should "take related tags from the consequent tag" do
+        assert_equal(%w[aaa bbb ccc], @query.tags)
+      end
+    end
+
     context "for a pattern search" do
       setup do
         @query = RelatedTagQuery.new("a*", "")


### PR DESCRIPTION
Fixes #1608. The bug was that when using the `Related tags` button on an aliased tag, `/hm -> hatsune_miku` for example, we pulled wiki tags from the nonexistent `/hm` wiki instead of from the `hatsune_miku` wiki.