### PR TITLE
Fix #1908: Allow E shortcut to work on upload page.

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -11,6 +11,7 @@
       $("#image").load(this.initialize_image);
       this.initialize_info_bookmarklet();
       this.initialize_similar();
+      this.initialize_shortcuts();
       $("#related-tags-button").trigger("click");
       $("#find-artist-button").trigger("click");
 
@@ -24,6 +25,13 @@
       this.initialize_iqdb_source();
     }
   }
+
+  Danbooru.Upload.initialize_shortcuts = function() {
+    Danbooru.keydown("e", "edit", function(e) {
+      $("#upload_tag_string").focus();
+      e.preventDefault();
+    });
+  };
 
   Danbooru.Upload.initialize_iqdb_source = function() {
     if (/^https?:\/\//.test($("#normalized_url").val())) {


### PR DESCRIPTION
Fixes #1908. Makes `E` focus the tag edit box on the uploads page.