### PR TITLE
Add more support for negated existing metatags

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -322,11 +322,19 @@ class PostQueryBuilder
 
     if q[:parent] == "none"
       relation = relation.where("posts.parent_id IS NULL")
-    elsif q[:parent_neg] == "none" || q[:parent] == "any"
+    elsif q[:parent] == "any"
       relation = relation.where("posts.parent_id IS NOT NULL")
     elsif q[:parent]
       relation = relation.where("(posts.id = ? or posts.parent_id = ?)", q[:parent].to_i, q[:parent].to_i)
       has_constraints!
+    end
+
+    if q[:parent_neg_ids]
+      neg_ids = q[:parent_neg_ids].map(&:to_i)
+      neg_ids.delete(0)
+      if neg_ids.present?
+        relation = relation.where("posts.id not in (?) and (posts.parent_id is null or posts.parent_id not in (?))", neg_ids, neg_ids)
+      end
     end
 
     if q[:child] == "none"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -436,9 +436,15 @@ class Tag < ActiveRecord::Base
             q[:uploader_id] = user_id unless user_id.blank?
 
           when "-approver"
-            q[:approver_id_neg] ||= []
-            user_id = User.name_to_id($2)
-            q[:approver_id_neg] << user_id unless user_id.blank?
+            if $2 == "none"
+              q[:approver_id] = "any"
+            elsif $2 == "any"
+              q[:approver_id] = "none"
+            else
+              q[:approver_id_neg] ||= []
+              user_id = User.name_to_id($2)
+              q[:approver_id_neg] << user_id unless user_id.blank?
+            end
 
           when "approver"
             if $2 == "none"
@@ -463,9 +469,17 @@ class Tag < ActiveRecord::Base
             end
 
           when "-flagger"
-            q[:flagger_ids_neg] ||= []
-            user_id = User.name_to_id($2)
-            q[:flagger_ids_neg] << user_id unless user_id.blank?
+            if $2 == "none"
+              q[:flagger_ids] ||= []
+              q[:flagger_ids] << "any"
+            elsif $2 == "any"
+              q[:flagger_ids] ||= []
+              q[:flagger_ids] << "none"
+            else
+              q[:flagger_ids_neg] ||= []
+              user_id = User.name_to_id($2)
+              q[:flagger_ids_neg] << user_id unless user_id.blank?
+            end
 
           when "appealer"
             q[:appealer_ids] ||= []
@@ -480,9 +494,17 @@ class Tag < ActiveRecord::Base
             end
 
           when "-appealer"
-            q[:appealer_ids_neg] ||= []
-            user_id = User.name_to_id($2)
-            q[:appealer_ids_neg] << user_id unless user_id.blank?
+            if $2 == "none"
+              q[:appealer_ids] ||= []
+              q[:appealer_ids] << "any"
+            elsif $2 == "any"
+              q[:appealer_ids] ||= []
+              q[:appealer_ids] << "none"
+            else
+              q[:appealer_ids_neg] ||= []
+              user_id = User.name_to_id($2)
+              q[:appealer_ids_neg] << user_id unless user_id.blank?
+            end
 
           when "commenter", "comm"
             q[:commenter_ids] ||= []
@@ -519,7 +541,11 @@ class Tag < ActiveRecord::Base
             q[:artcomm_ids] << user_id unless user_id.blank?
 
           when "-pool"
-            if $2.downcase == "series"
+            if $2.downcase == "none"
+              q[:pool] = "any"
+            elsif $2.downcase == "any"
+              q[:pool] = "none"
+            elsif $2.downcase == "series"
               q[:tags][:exclude] << "pool:series"
             elsif $2.downcase == "collection"
               q[:tags][:exclude] << "pool:collection"
@@ -648,7 +674,14 @@ class Tag < ActiveRecord::Base
             q[:parent] = $2.downcase
 
           when "-parent"
-            q[:parent_neg] = $2.downcase
+            if $2.downcase == "none"
+              q[:parent] = "any"
+            elsif $2.downcase == "any"
+              q[:parent] = "none"
+            else
+              q[:parent_neg_ids] ||= []
+              q[:parent_neg_ids] << $2.downcase
+            end
 
           when "child"
             q[:child] = $2.downcase


### PR DESCRIPTION
This adds support for the following metatags:

* `-approver:any`
* `-approver:none`
* `-flagger:any`
* `-flagger:none`
* `-appealer:any`
* `-appealer:none`
* `-pool:any`
* `-pool:none`
* `-parent:any` (`-parent:none` was implemented already)
* multiple `-parent:<number>` metatags

I think the support for that has been rejected before, but I don't see any reason to do that; it's a thing that users might try in their search, and currently it will get them confusing results. Also, I'm working on making autocomplete for metatags more intelligent, and having `metatag` and `-metatag` support different sets of values is becoming a pain.
