### PR TITLE
Fix #3156: Expunging posts is broken

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,4 +74,5 @@ group :test do
   gem "simplecov", :require => false
   gem "timecop"
   gem "fakeweb"
+  gem "test_after_commit" # XXX remove me after upgrading to rails 5.
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -337,6 +337,8 @@ GEM
       rest-client (~> 1.4)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
+    test_after_commit (1.1.0)
+      activerecord (>= 3.2)
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
@@ -433,6 +435,7 @@ DEPENDENCIES
   streamio-ffmpeg
   stripe
   term-ansicolor
+  test_after_commit
   therubyracer
   timecop
   twitter
@@ -443,4 +446,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.14.5
+   1.14.6

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -65,11 +65,13 @@ class Post < ActiveRecord::Base
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def delete_files(post_id, file_path, large_file_path, preview_file_path)
-        post = Post.find(post_id)
+      def delete_files(post_id, file_path, large_file_path, preview_file_path, force: false)
+        unless force
+          post = Post.find(post_id)
 
-        if post.file_path == file_path || post.large_file_path == large_file_path || post.preview_file_path == preview_file_path
-          raise DeletionError.new("Files still in use; skipping deletion.")
+          if post.file_path == file_path || post.large_file_path == large_file_path || post.preview_file_path == preview_file_path
+            raise DeletionError.new("Files still in use; skipping deletion.")
+          end
         end
 
         # the large file and the preview don't necessarily exist. if so errors will be ignored.
@@ -84,7 +86,7 @@ class Post < ActiveRecord::Base
     end
 
     def delete_files
-      Post.delete_files(id, file_path, large_file_path, preview_file_path)
+      Post.delete_files(id, file_path, large_file_path, preview_file_path, force: true)
     end
 
     def distribute_files

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -29,8 +29,8 @@ class Post < ActiveRecord::Base
   after_save :update_parent_on_save
   after_save :apply_post_metatags
   after_save :expire_essential_tag_string_cache
-  after_destroy :remove_iqdb_async
-  after_destroy :delete_files
+  after_commit :delete_files, :on => :destroy
+  after_commit :remove_iqdb_async, :on => :destroy
   after_commit :update_iqdb_async, :on => :create
   after_commit :notify_pubsub
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1715,12 +1715,6 @@ class Post < ActiveRecord::Base
     def remove_iqdb_async
       Post.remove_iqdb(id)
     end
-
-    def update_iqdb
-      if Post.iqdb_enabled? && Post.iqdb_enabled?
-        Post.iqdb_sqs_service.send_message("update\n#{id}\n#{complete_preview_file_url}")
-      end
-    end
   end
 
   module ValidationMethods

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1713,9 +1713,7 @@ class Post < ActiveRecord::Base
     end
 
     def remove_iqdb_async
-      if File.exists?(preview_file_path) && Post.iqdb_enabled?
-        Post.iqdb_sqs_service.send_message("remove\n#{id}")
-      end
+      Post.remove_iqdb(id)
     end
 
     def update_iqdb

--- a/test/helpers/iqdb_test_helper.rb
+++ b/test/helpers/iqdb_test_helper.rb
@@ -16,6 +16,7 @@ module IqdbTestHelper
 
     service = mock_sqs_service.new
     Post.stubs(:iqdb_sqs_service).returns(service)
+    Post.stubs(:iqdb_enabled?).returns(true)
 
     Danbooru.config.stubs(:iqdbs_auth_key).returns("hunter2")
     Danbooru.config.stubs(:iqdbs_server).returns("http://localhost:3004")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -48,6 +48,7 @@ class ActionController::TestCase
 end
 
 Delayed::Worker.delay_jobs = false
+TestAfterCommit.enabled = false
 
 require "helpers/reportbooru_helper"
 class ActiveSupport::TestCase

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -52,6 +52,15 @@ class PostTest < ActiveSupport::TestCase
         assert_equal(false, File.exists?(@post.file_path))
       end
 
+      should "remove the post from iqdb" do
+        mock_iqdb_service!
+        Post.iqdb_sqs_service.expects(:send_message).with("remove\n#{@post.id}")
+
+        TestAfterCommit.with_commits(true) do
+          @post.expunge!
+        end
+      end
+
       context "that is status locked" do
         setup do
           @post.update_attributes({:is_status_locked => true}, :as => :admin)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -33,7 +33,23 @@ class PostTest < ActiveSupport::TestCase
   context "Deletion:" do
     context "Expunging a post" do
       setup do
-        @post = FactoryGirl.create(:post)
+        @upload = FactoryGirl.create(:jpg_upload)
+        @upload.process!
+        @post = @upload.post
+      end
+
+      should "delete the files" do
+        assert_equal(true, File.exists?(@post.preview_file_path))
+        assert_equal(true, File.exists?(@post.large_file_path))
+        assert_equal(true, File.exists?(@post.file_path))
+
+        TestAfterCommit.with_commits(true) do
+          @post.expunge!
+        end
+
+        assert_equal(false, File.exists?(@post.preview_file_path))
+        assert_equal(false, File.exists?(@post.large_file_path))
+        assert_equal(false, File.exists?(@post.file_path))
       end
 
       context "that is status locked" do


### PR DESCRIPTION
Fixes #3156, plus a couple more bugs with expunging posts:

* Fixes `Post.delete_files` to skip the check that the files are still in use. We don't want this when the post is being expunged.

* Fixes the `delete_files` / `remove_iqdb_async` callbacks to run only after the transaction successfully commits. Testing this required adding the [test_after_commit](https://github.com/grosser/test_after_commit) gem to fix an issue with `after_commit` hooks not firing during testing.

* Fixes expunging posts not removing images from iqdb. There was a `File.exists?(preview_file_path)` check that always failed because the files were already deleted by this point. I don't know what the purpose of this check was, but it doesn't seem necessary.

Also removes an unused `update_iqdb` method.