### PR TITLE
Fix #3154: Inherit models from ApplicationRecord

### DIFF
--- a/app/models/amazon_backup.rb
+++ b/app/models/amazon_backup.rb
@@ -1,7 +1,7 @@
 require 'base64'
 require 'digest/md5'
 
-class AmazonBackup < ActiveRecord::Base
+class AmazonBackup < ApplicationRecord
   attr_accessible :last_id
   
   def self.last_id

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,4 +1,4 @@
-class ApiKey < ActiveRecord::Base
+class ApiKey < ApplicationRecord
   belongs_to :user
   validates_uniqueness_of :user_id
   validates_uniqueness_of :key

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,47 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  module ApiMethods
+    extend ActiveSupport::Concern
+
+    def as_json(options = {})
+      options ||= {}
+      options[:except] ||= []
+      options[:except] += hidden_attributes
+
+      options[:methods] ||= []
+      options[:methods] += method_attributes
+
+      super(options)
+    end
+
+    def to_xml(options = {}, &block)
+      options ||= {}
+
+      options[:except] ||= []
+      options[:except] += hidden_attributes
+
+      options[:methods] ||= []
+      options[:methods] += method_attributes
+
+      super(options, &block)
+    end
+
+    def serializable_hash(*args)
+      hash = super(*args)
+      hash.transform_keys { |key| key.delete("?") }
+    end
+
+    protected
+
+    def hidden_attributes
+      [:uploader_ip_addr, :updater_ip_addr, :creator_ip_addr, :ip_addr]
+    end
+
+    def method_attributes
+      []
+    end
+  end
+
+  include ApiMethods
 end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,4 +1,4 @@
-class Artist < ActiveRecord::Base
+class Artist < ApplicationRecord
   extend Memoist
   class RevertError < Exception ; end
 

--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -1,4 +1,4 @@
-class ArtistCommentary < ActiveRecord::Base
+class ArtistCommentary < ApplicationRecord
   class RevertError < Exception ; end
 
   attr_accessor :remove_commentary_tag, :remove_commentary_request_tag, :remove_commentary_check_tag

--- a/app/models/artist_commentary_version.rb
+++ b/app/models/artist_commentary_version.rb
@@ -1,4 +1,4 @@
-class ArtistCommentaryVersion < ActiveRecord::Base
+class ArtistCommentaryVersion < ApplicationRecord
   before_validation :initialize_updater
   belongs_to :updater, :class_name => "User"
   scope :for_user, lambda {|user_id| where("updater_id = ?", user_id)}

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -1,4 +1,4 @@
-class ArtistUrl < ActiveRecord::Base
+class ArtistUrl < ApplicationRecord
   before_save :initialize_normalized_url, on: [ :create ]
   before_save :normalize
   validates_presence_of :url

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -1,4 +1,4 @@
-class ArtistVersion < ActiveRecord::Base
+class ArtistVersion < ApplicationRecord
   belongs_to :updater, :class_name => "User"
   belongs_to :artist
   attr_accessible :artist_id, :name, :is_active, :other_names, :group_name, :url_string, :is_banned, :updater_id, :updater_ip_addr

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -1,4 +1,4 @@
-class Ban < ActiveRecord::Base
+class Ban < ApplicationRecord
   after_create :update_feedback
   after_create :update_user_on_create
   after_create :create_mod_action

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -1,4 +1,4 @@
-class BulkUpdateRequest < ActiveRecord::Base
+class BulkUpdateRequest < ApplicationRecord
   attr_accessor :reason, :skip_secondary_validations
 
   belongs_to :user

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,4 @@
-class Comment < ActiveRecord::Base
+class Comment < ApplicationRecord
   include Mentionable
 
   validate :validate_post_exists, :on => :create

--- a/app/models/comment_vote.rb
+++ b/app/models/comment_vote.rb
@@ -1,4 +1,4 @@
-class CommentVote < ActiveRecord::Base
+class CommentVote < ApplicationRecord
   class Error < Exception ; end
 
   belongs_to :comment

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -1,6 +1,6 @@
 require 'digest/sha1'
 
-class Dmail < ActiveRecord::Base
+class Dmail < ApplicationRecord
   with_options on: :create do
     validates_presence_of :to_id
     validates_presence_of :from_id

--- a/app/models/dmail_filter.rb
+++ b/app/models/dmail_filter.rb
@@ -1,4 +1,4 @@
-class DmailFilter < ActiveRecord::Base
+class DmailFilter < ApplicationRecord
   belongs_to :user
   attr_accessible :words, :as => [:moderator, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
   validates_presence_of :user

--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -1,4 +1,4 @@
-class Favorite < ActiveRecord::Base
+class Favorite < ApplicationRecord
   belongs_to :post
   belongs_to :user
   scope :for_user, lambda {|user_id| where("user_id % 100 = #{user_id.to_i % 100} and user_id = #{user_id.to_i}")}

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -1,6 +1,6 @@
 require 'ostruct'
 
-class FavoriteGroup < ActiveRecord::Base
+class FavoriteGroup < ApplicationRecord
   validates_uniqueness_of :name, :case_sensitive => false, :scope => :creator_id
   validates_format_of :name, :with => /\A[^,]+\Z/, :message => "cannot have commas"
   belongs_to :creator, :class_name => "User"

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -1,4 +1,4 @@
-class ForumPost < ActiveRecord::Base
+class ForumPost < ApplicationRecord
   include Mentionable
 
   attr_accessible :body, :topic_id, :as => [:member, :builder, :gold, :platinum, :admin, :moderator, :default]

--- a/app/models/forum_subscription.rb
+++ b/app/models/forum_subscription.rb
@@ -1,4 +1,4 @@
-class ForumSubscription < ActiveRecord::Base
+class ForumSubscription < ApplicationRecord
   belongs_to :user
   belongs_to :forum_topic
   attr_accessible :user, :forum_topic, :user_id, :forum_topic_id, :last_read_at, :delete_key

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -1,4 +1,4 @@
-class ForumTopic < ActiveRecord::Base
+class ForumTopic < ApplicationRecord
   CATEGORIES = {
     0 => "General",
     1 => "Tags",

--- a/app/models/forum_topic_visit.rb
+++ b/app/models/forum_topic_visit.rb
@@ -1,4 +1,4 @@
-class ForumTopicVisit < ActiveRecord::Base
+class ForumTopicVisit < ApplicationRecord
   belongs_to :user
   belongs_to :forum_topic
   attr_accessible :user_id, :user, :forum_topic_id, :forum_topic, :last_read_at

--- a/app/models/ip_ban.rb
+++ b/app/models/ip_ban.rb
@@ -1,4 +1,4 @@
-class IpBan < ActiveRecord::Base
+class IpBan < ApplicationRecord
   IP_ADDR_REGEX = /\A(?:[0-9]{1,3}\.){3}[0-9]{1,3}\Z/
   belongs_to :creator, :class_name => "User"
   before_validation :initialize_creator, :on => :create

--- a/app/models/janitor_trial.rb
+++ b/app/models/janitor_trial.rb
@@ -1,4 +1,4 @@
-class JanitorTrial < ActiveRecord::Base
+class JanitorTrial < ApplicationRecord
   belongs_to :user
   after_create :send_dmail
   after_create :promote_user

--- a/app/models/key_value.rb
+++ b/app/models/key_value.rb
@@ -1,4 +1,4 @@
-class KeyValue < ActiveRecord::Base
+class KeyValue < ApplicationRecord
   validates_uniqueness_of :key
   attr_accessible :key, :value
 end

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -1,4 +1,4 @@
-class ModAction < ActiveRecord::Base
+class ModAction < ApplicationRecord
   belongs_to :creator, :class_name => "User"
   before_validation :initialize_creator, :on => :create
   validates_presence_of :creator_id

--- a/app/models/news_update.rb
+++ b/app/models/news_update.rb
@@ -1,4 +1,4 @@
-class NewsUpdate < ActiveRecord::Base
+class NewsUpdate < ApplicationRecord
   belongs_to :creator, :class_name => "User"
   belongs_to :updater, :class_name => "User"
   scope :recent, lambda {where("created_at >= ?", 2.weeks.ago).order("created_at desc").limit(5)}

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -1,4 +1,4 @@
-class Note < ActiveRecord::Base
+class Note < ApplicationRecord
   class RevertError < Exception ; end
 
   attr_accessor :updater_id, :updater_ip_addr, :html_id

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -1,4 +1,4 @@
-class NoteVersion < ActiveRecord::Base
+class NoteVersion < ApplicationRecord
   before_validation :initialize_updater
   belongs_to :updater, :class_name => "User"
   scope :for_user, lambda {|user_id| where("updater_id = ?", user_id)}

--- a/app/models/pixiv_ugoira_frame_data.rb
+++ b/app/models/pixiv_ugoira_frame_data.rb
@@ -1,4 +1,4 @@
-class PixivUgoiraFrameData < ActiveRecord::Base
+class PixivUgoiraFrameData < ApplicationRecord
   attr_accessible :post_id, :data, :content_type
   serialize :data
 end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -1,6 +1,6 @@
 require 'ostruct'
 
-class Pool < ActiveRecord::Base
+class Pool < ApplicationRecord
   class RevertError < Exception ; end
 
   validates_uniqueness_of :name, :case_sensitive => false

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -1,4 +1,4 @@
-class PoolArchive < ActiveRecord::Base
+class PoolArchive < ApplicationRecord
 
   belongs_to :updater, :class_name => "User"
 

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -1,4 +1,4 @@
-class PoolVersion < ActiveRecord::Base
+class PoolVersion < ApplicationRecord
   class Error < Exception ; end
 
   validates_presence_of :updater_id, :updater_ip_addr

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,7 +1,7 @@
 require 'danbooru/has_bit_flags'
 require 'google/apis/pubsub_v1'
 
-class Post < ActiveRecord::Base
+class Post < ApplicationRecord
   class ApprovalError < Exception ; end
   class DisapprovalError < Exception ; end
   class RevertError < Exception ; end

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -1,4 +1,4 @@
-class PostAppeal < ActiveRecord::Base
+class PostAppeal < ApplicationRecord
   class Error < Exception ; end
 
   belongs_to :creator, :class_name => "User"

--- a/app/models/post_approval.rb
+++ b/app/models/post_approval.rb
@@ -1,4 +1,4 @@
-class PostApproval < ActiveRecord::Base
+class PostApproval < ApplicationRecord
   belongs_to :user
   belongs_to :post, inverse_of: :approvals
 

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -1,4 +1,4 @@
-class PostArchive < ActiveRecord::Base
+class PostArchive < ApplicationRecord
   extend Memoist
 
   belongs_to :post

--- a/app/models/post_disapproval.rb
+++ b/app/models/post_disapproval.rb
@@ -1,4 +1,4 @@
-class PostDisapproval < ActiveRecord::Base
+class PostDisapproval < ApplicationRecord
   DELETION_THRESHOLD = 1.month
 
   belongs_to :post

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -1,4 +1,4 @@
-class PostFlag < ActiveRecord::Base
+class PostFlag < ApplicationRecord
   class Error < Exception ; end
 
   module Reasons

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -1,4 +1,4 @@
-class PostReplacement < ActiveRecord::Base
+class PostReplacement < ApplicationRecord
   DELETION_GRACE_PERIOD = 30.days
 
   belongs_to :post

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -1,4 +1,4 @@
-class PostVersion < ActiveRecord::Base
+class PostVersion < ApplicationRecord
   belongs_to :post
   belongs_to :updater, :class_name => "User"
   before_validation :initialize_updater

--- a/app/models/post_vote.rb
+++ b/app/models/post_vote.rb
@@ -1,4 +1,4 @@
-class PostVote < ActiveRecord::Base
+class PostVote < ApplicationRecord
   class Error < Exception ; end
 
   belongs_to :post

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -1,4 +1,4 @@
-class SavedSearch < ActiveRecord::Base
+class SavedSearch < ApplicationRecord
   module ListbooruMethods
     extend ActiveSupport::Concern
 

--- a/app/models/super_voter.rb
+++ b/app/models/super_voter.rb
@@ -1,4 +1,4 @@
-class SuperVoter < ActiveRecord::Base
+class SuperVoter < ApplicationRecord
   MAGNITUDE = 3
   DURATION = 1.week
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,4 +1,4 @@
-class Tag < ActiveRecord::Base
+class Tag < ApplicationRecord
   COSINE_SIMILARITY_RELATED_TAG_THRESHOLD = 1000
   METATAGS = "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-pool|pool|ordpool|-favgroup|favgroup|-fav|fav|ordfav|sub|md5|-rating|rating|-locked|locked|width|height|mpixels|ratio|score|favcount|filesize|source|-source|id|-id|date|age|order|limit|-status|status|tagcount|gentags|arttags|chartags|copytags|parent|-parent|child|pixiv_id|pixiv|search|upvote|downvote|filetype|-filetype|flagger|-flagger|appealer|-appealer"
   SUBQUERY_METATAGS = "commenter|comm|noter|noteupdater|artcomm|flagger|-flagger|appealer|-appealer"

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -1,4 +1,4 @@
-class TagAlias < ActiveRecord::Base
+class TagAlias < ApplicationRecord
   attr_accessor :skip_secondary_validations
 
   before_save :ensure_tags_exist

--- a/app/models/tag_implication.rb
+++ b/app/models/tag_implication.rb
@@ -1,4 +1,4 @@
-class TagImplication < ActiveRecord::Base
+class TagImplication < ApplicationRecord
   attr_accessor :skip_secondary_validations
 
   before_save :update_descendant_names

--- a/app/models/tag_subscription.rb
+++ b/app/models/tag_subscription.rb
@@ -1,4 +1,4 @@
-class TagSubscription < ActiveRecord::Base
+class TagSubscription < ApplicationRecord
   belongs_to :creator, :class_name => "User"
   before_validation :initialize_creator, :on => :create
   before_validation :initialize_post_ids, :on => :create

--- a/app/models/token_bucket.rb
+++ b/app/models/token_bucket.rb
@@ -1,4 +1,4 @@
-class TokenBucket < ActiveRecord::Base
+class TokenBucket < ApplicationRecord
   self.primary_key = "user_id"
   belongs_to :user
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -1,7 +1,7 @@
 require "danbooru_image_resizer/danbooru_image_resizer"
 require "tmpdir"
 
-class Upload < ActiveRecord::Base
+class Upload < ApplicationRecord
   class Error < Exception ; end
 
   attr_accessor :file, :image_width, :image_height, :file_ext, :md5, 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 require 'digest/sha1'
 require 'danbooru/has_bit_flags'
 
-class User < ActiveRecord::Base
+class User < ApplicationRecord
   class Error < Exception ; end
   class PrivilegeError < Exception ; end
 

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -1,4 +1,4 @@
-class UserFeedback < ActiveRecord::Base
+class UserFeedback < ApplicationRecord
   self.table_name = "user_feedback"
   belongs_to :user
   belongs_to :creator, :class_name => "User"

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -1,4 +1,4 @@
-class UserNameChangeRequest < ActiveRecord::Base
+class UserNameChangeRequest < ApplicationRecord
   validates_presence_of :user_id, :original_name, :desired_name
   validates_inclusion_of :status, :in => %w(pending approved rejected)
   belongs_to :user

--- a/app/models/user_password_reset_nonce.rb
+++ b/app/models/user_password_reset_nonce.rb
@@ -1,4 +1,4 @@
-class UserPasswordResetNonce < ActiveRecord::Base
+class UserPasswordResetNonce < ApplicationRecord
   validates_presence_of :email, :key
   validate :validate_existence_of_email
   before_validation :initialize_key, :on => :create

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -1,4 +1,4 @@
-class WikiPage < ActiveRecord::Base
+class WikiPage < ApplicationRecord
   class RevertError < Exception ; end
 
   before_save :normalize_title

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -1,4 +1,4 @@
-class WikiPageVersion < ActiveRecord::Base
+class WikiPageVersion < ApplicationRecord
   belongs_to :wiki_page
   belongs_to :updater, :class_name => "User"
   belongs_to :artist

--- a/config/initializers/active_record_api_extensions.rb
+++ b/config/initializers/active_record_api_extensions.rb
@@ -1,54 +1,5 @@
-module Danbooru
-  module Extensions
-    module ActiveRecordApi
-      extend ActiveSupport::Concern
-
-      def as_json(options = {})
-        options ||= {}
-        options[:except] ||= []
-        options[:except] += hidden_attributes
-
-        options[:methods] ||= []
-        options[:methods] += method_attributes
-
-        super(options)
-      end
-
-      def to_xml(options = {}, &block)
-        options ||= {}
-
-        options[:except] ||= []
-        options[:except] += hidden_attributes
-
-        options[:methods] ||= []
-        options[:methods] += method_attributes
-
-        super(options, &block)
-      end
-
-      def serializable_hash(*args)
-        hash = super(*args)
-        hash.transform_keys { |key| key.delete("?") }
-      end
-
-    protected
-      def hidden_attributes
-        [:uploader_ip_addr, :updater_ip_addr, :creator_ip_addr, :ip_addr]
-      end
-
-      def method_attributes
-        []
-      end
-    end
-  end
-end
-
 class Delayed::Job
   def hidden_attributes
     [:handler]
   end
-end
-
-class ActiveRecord::Base
-  include Danbooru::Extensions::ActiveRecordApi
 end


### PR DESCRIPTION
Fixes #3154. Inherits everything from `ApplicationRecord`. Moves API extension methods (`as_json`, `to_xml`, etc) from an initializer to `ApplicationRecord`.