### PR TITLE
Convert Pixiv commentaries to DText (fix #2458)

### DIFF
--- a/app/logical/pixiv_api_client.rb
+++ b/app/logical/pixiv_api_client.rb
@@ -94,8 +94,8 @@ class PixivApiClient
       @user_id = json["user"]["id"]
       @moniker = json["user"]["account"]
       @page_count = json["page_count"].to_i
-      @artist_commentary_title = json["title"]
-      @artist_commentary_desc = json["caption"]
+      @artist_commentary_title = json["title"].to_s
+      @artist_commentary_desc = json["caption"].to_s
       @tags = [json["tags"], json["tools"]].flatten.compact.reject {|x| x =~ /^http:/}
 
       if page_count > 1

--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -107,6 +107,23 @@ module Sources
         @metadata.pages
       end
 
+      def self.to_dtext(text)
+        text = text.gsub(%r!https?://www\.pixiv\.net/member_illust\.php\?mode=medium&illust_id=([0-9]+)!i) do |match|
+          pixiv_id = $1
+          %(pixiv ##{pixiv_id} "»":[/posts?tags=pixiv:#{pixiv_id}])
+        end
+
+        text = text.gsub(%r!https?://www\.pixiv\.net/member\.php\?id=([0-9]+)!i) do |match|
+          member_id = $1
+          profile_url = "https://www.pixiv.net/member.php?id=#{member_id}"
+          search_params = {"search[url_matches]" => profile_url}.to_param
+
+          %("user/#{member_id}":[#{profile_url}] "»":[/artists?#{search_params}])
+        end
+
+        text
+      end
+
       def illust_id_from_url
         if sample_image? || full_image? || work_page?
           illust_id_from_url!

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -117,13 +117,18 @@ module Sources
       end
 
       context "fetching the commentary" do
-        setup do
-          get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=46337015")
-        end
-
         should "work when the description is blank" do
+          get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=46337015")
+
           assert_equal("Illustration (PNG) - foo & bar", @site.dtext_artist_commentary_title)
           assert_equal("", @site.dtext_artist_commentary_desc)
+        end
+
+        should "convert illust links and member links to dtext" do
+          get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=63421642")
+
+          dtext_desc = %(foo 【pixiv #46337015 "»":[/posts?tags=pixiv:46337015]】bar 【pixiv #14901720 "»":[/posts?tags=pixiv:14901720]】\r\n\r\nbaz【"user/83739":[https://www.pixiv.net/member.php?id=83739] "»":[/artists?search%5Burl_matches%5D=https%3A%2F%2Fwww.pixiv.net%2Fmember.php%3Fid%3D83739]】)
+          assert_equal(dtext_desc, @site.dtext_artist_commentary_desc)
         end
       end
     end


### PR DESCRIPTION
Fixes #2458. Converts links inside Pixiv commentaries to DText in this manner:

* https://www.pixiv.net/member_illust.php?mode=medium&illust_id=1234
  => [pixiv #1234](https://www.pixiv.net/member_illust.php?mode=medium&illust_id=1234) [»](https://danbooru.donmai.us/posts?tags=pixiv:1234)
  => `pixiv #1234 "»":[/posts?tags=pixiv:1234]`

* https://www.pixiv.net/member.php?id=1234
  => [user/1234](https://www.pixiv.net/member.php?id=1234) [»](https://danbooru.donmai.us/artists?search[url_matches]=https://www.pixiv.net/member.php?id=1234)
  => `"user/1234":[https://www.pixiv.net/member.php?id=1234] "»":[/artists?search[url_matches]=https://www.pixiv.net/member.php?id=1234]`

That is, it links to the post or user on Pixiv, as well as to a post or artist search on Danbooru.