### PR TITLE
Fix #3168: API upload can't handle unset source.

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -393,7 +393,7 @@ class Upload < ApplicationRecord
 
   module DownloaderMethods
     def strip_source
-      source.try(:strip)
+      source.to_s.strip
     end
 
     # Determines whether the source is downloadable

--- a/test/factories/upload.rb
+++ b/test/factories/upload.rb
@@ -16,9 +16,11 @@ FactoryGirl.define do
 
     factory(:jpg_upload) do
       content_type "image/jpeg"
-      file_path do
-        FileUtils.cp("#{Rails.root}/test/files/test.jpg", "#{Rails.root}/tmp")
-        "#{Rails.root}/tmp/test.jpg"
+      file do
+        f = Tempfile.new
+        f.write(File.read("#{Rails.root}/test/files/test.jpg"))
+        f.seek(0)
+        f
       end
     end
 

--- a/test/unit/upload_test.rb
+++ b/test/unit/upload_test.rb
@@ -308,6 +308,14 @@ class UploadTest < ActiveSupport::TestCase
       assert_equal("completed", @upload.status)
     end
 
+    should "process completely for a null source" do
+      @upload = FactoryGirl.create(:jpg_upload, :source => nil)
+
+      assert_difference("Post.count") do
+        assert_nothing_raised {@upload.process!}
+      end
+    end
+
     should "delete the temporary file upon completion" do
       @upload = FactoryGirl.create(:source_upload,
         :rating => "s",


### PR DESCRIPTION
Fixes #3168. Converts nil sources on upload to the empty string.