### PR TITLE
Convert absolute links in notes to relative links (fix #1911)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "delayed_job_active_record"
 gem "simple_form"
 gem "mechanize"
 gem "whenever", :require => false
-gem "sanitize", "~> 3.1.0"
+gem "sanitize"
 gem 'rmagick'
 gem 'net-sftp'
 gem 'term-ansicolor', :require => "term/ansicolor"
@@ -44,6 +44,7 @@ gem 'memoist'
 gem 'daemons'
 gem 'oauth2'
 gem 'bootsnap'
+gem 'addressable'
 
 # needed for looser jpeg header compat
 gem 'ruby-imagespec', :require => "image_spec", :git => "https://github.com/r888888888/ruby-imagespec.git", :branch => "exif-fixes"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -199,7 +199,7 @@ GEM
     metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (2.99.3)
-    mini_portile2 (2.1.0)
+    mini_portile2 (2.2.0)
     minitest (5.10.1)
     mocha (1.2.1)
       metaclass (~> 0.0.1)
@@ -218,11 +218,11 @@ GEM
     net-ssh (2.9.2)
     netrc (0.10.3)
     newrelic_rpm (3.13.0.299)
-    nokogiri (1.7.0.1)
-      mini_portile2 (~> 2.1.0)
-    nokogiri (1.7.0.1-x64-mingw32)
-      mini_portile2 (~> 2.1.0)
-    nokogumbo (1.2.0)
+    nokogiri (1.8.0)
+      mini_portile2 (~> 2.2.0)
+    nokogiri (1.8.0-x64-mingw32)
+      mini_portile2 (~> 2.2.0)
+    nokogumbo (1.4.13)
       nokogiri
     ntlm-http (0.1.1)
     oauth2 (1.3.0)
@@ -292,10 +292,10 @@ GEM
     rmagick (2.16.0)
     ruby-prof (0.15.8)
     rubyzip (1.1.7)
-    sanitize (3.1.2)
-      crass (~> 1.0.1)
+    sanitize (4.5.0)
+      crass (~> 1.0.2)
       nokogiri (>= 1.4.4)
-      nokogumbo (= 1.2.0)
+      nokogumbo (~> 1.4.1)
     sass (3.4.23)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -387,6 +387,7 @@ PLATFORMS
   x64-mingw32
 
 DEPENDENCIES
+  addressable
   awesome_print
   aws-sdk (~> 2)
   bcrypt-ruby
@@ -429,7 +430,7 @@ DEPENDENCIES
   ruby-imagespec!
   ruby-prof
   rubyzip
-  sanitize (~> 3.1.0)
+  sanitize
   sass-rails
   shoulda-context
   shoulda-matchers

--- a/app/logical/note_sanitizer.rb
+++ b/app/logical/note_sanitizer.rb
@@ -73,7 +73,20 @@ module NoteSanitizer
         at_rules: [],
         protocols: [],
         properties: ALLOWED_PROPERTIES,
-      }
+      },
+      :transformers => method(:relativize_links),
     )
+  end
+
+  def self.relativize_links(node:, **env)
+    return unless node.name == "a" && node.attribute("href")
+
+    href = node.attribute("href")
+    url  = Addressable::URI.parse(href.value).normalize
+
+    if url.authority.in?(Danbooru.config.hostnames)
+      url.site = nil
+      href.value = url.to_s
+    end
   end
 end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -20,9 +20,15 @@ module Danbooru
       "Find good anime art fast"
     end
 
-    # The hostname of the server.
+    # The canonical hostname of the site.
     def hostname
       Socket.gethostname
+    end
+
+    # The list of all domain names this site is accessible under.
+    # Example: %w[danbooru.donmai.us sonohara.donmai.us hijiribe.donmai.us safebooru.donmai.us]
+    def hostnames
+      [hostname]
     end
 
     # Contact email address of the admin.

--- a/test/unit/note_sanitizer_test.rb
+++ b/test/unit/note_sanitizer_test.rb
@@ -21,5 +21,12 @@ class NoteSanitizerTest < ActiveSupport::TestCase
       body = '<a href="http://www.google.com">google</a>'
       assert_equal('<a href="http://www.google.com" rel="nofollow">google</a>', NoteSanitizer.sanitize(body))
     end
+
+    should "rewrite absolute links to relative links" do
+      Danbooru.config.stubs(:hostnames).returns(%w[danbooru.donmai.us sonohara.donmai.us hijiribe.donmai.us])
+
+      body = '<a href="http://sonohara.donmai.us/posts?tags=touhou#dtext-intro">touhou</a>'
+      assert_equal('<a href="/posts?tags=touhou#dtext-intro" rel="nofollow">touhou</a>', NoteSanitizer.sanitize(body))
+    end
   end
 end


### PR DESCRIPTION
Fixes #1911. Converts absolute links in notes (e.g. `http://sonohara.donmai.us/posts/1234`) to relative links (`/posts/1234`). This is so that users stay on the same domain and on HTTPS when following links inside notes.

Doing this required adding a `Danbooru.config.hostnames` config option listing all domain names that the site is known under.