### PR TITLE
Fix #3171: Translate Twitter Hashtags to assist with tagging

### DIFF
--- a/app/logical/sources/strategies/twitter.rb
+++ b/app/logical/sources/strategies/twitter.rb
@@ -12,10 +12,6 @@ module Sources::Strategies
       end
     end
 
-    def tags
-      []
-    end
-
     def site_name
       "Twitter"
     end
@@ -32,6 +28,9 @@ module Sources::Strategies
       @image_url = image_urls.first
       @artist_commentary_title = ""
       @artist_commentary_desc = attrs[:text]
+      @tags = attrs[:entities][:hashtags].map do |text:, indices:|
+        [text, "https://twitter.com/hashtag/#{text}"]
+      end
     end
 
     def image_urls

--- a/test/unit/sources/twitter_test.rb
+++ b/test/unit/sources/twitter_test.rb
@@ -100,6 +100,15 @@ module Sources
         desc = 'test "#foo":[https://twitter.com/hashtag/foo] "#ホワイトデー":[https://twitter.com/hashtag/ホワイトデー] "@noizave":[https://twitter.com/noizave]\'s blah http://www.example.com <>& 😀'
         assert_equal(desc, @site.dtext_artist_commentary_desc)
       end
+
+      should "get the tags" do
+        tags = [
+          %w[foo https://twitter.com/hashtag/foo],
+          %w[ホワイトデー https://twitter.com/hashtag/ホワイトデー],
+        ]
+
+        assert_equal(tags, @site.tags)
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #3171. Fetches translated tags for Twitter.