### PR TITLE
Post replacements: Add view; allow replacing from uploaded file.

### DIFF
--- a/app/assets/stylesheets/common/simple_form.scss
+++ b/app/assets/stylesheets/common/simple_form.scss
@@ -66,3 +66,12 @@ form.inline-form {
     }
   }
 }
+
+div.ui-dialog {
+  div.input {
+    input[type="text"] {
+      width: 100%;
+      max-width: 100%;
+    }
+  }
+}

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -23,6 +23,6 @@ class PostReplacementsController < ApplicationController
 
 private
   def create_params
-    params.require(:post_replacement).permit(:replacement_url)
+    params.require(:post_replacement).permit(:replacement_url, :final_source)
   end
 end

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -23,6 +23,6 @@ class PostReplacementsController < ApplicationController
 
 private
   def create_params
-    params.require(:post_replacement).permit(:replacement_url, :final_source)
+    params.require(:post_replacement).permit(:replacement_url, :replacement_file, :final_source)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -101,6 +101,14 @@ module ApplicationHelper
     time_tag(time.strftime("%Y-%m-%d %H:%M"), time)
   end
 
+  def external_link_to(url)
+    if url =~ %r!\Ahttps?://!i
+      link_to url, {}, {rel: :nofollow}
+    else
+      url
+    end
+  end
+
   def link_to_ip(ip)
     link_to ip, moderator_ip_addrs_path(:search => {:ip_addr => ip})
   end

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -4,7 +4,8 @@ class PostReplacement < ApplicationRecord
   belongs_to :post
   belongs_to :creator, class_name: "User"
   before_validation :initialize_fields
-  attr_accessible :replacement_url
+  attr_accessible :replacement_url, :final_source
+  attr_accessor :final_source
 
   def initialize_fields
     self.creator = CurrentUser.user
@@ -37,7 +38,7 @@ class PostReplacement < ApplicationRecord
       post.image_width = upload.image_width
       post.image_height = upload.image_height
       post.file_size = upload.file_size
-      post.source = upload.source
+      post.source = final_source.presence || upload.source
       post.tag_string = upload.tag_string
       rescale_notes
       update_ugoira_frame_data(upload)

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -77,7 +77,7 @@ class PostReplacement < ApplicationRecord
       end
 
       if params[:creator_name].present?
-        q = q.where(creator_name: User.name_to_id(params[:creator_name]))
+        q = q.where(creator_id: User.name_to_id(params[:creator_name]))
       end
 
       if params[:id].present?

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -4,8 +4,7 @@ class PostReplacement < ApplicationRecord
   belongs_to :post
   belongs_to :creator, class_name: "User"
   before_validation :initialize_fields
-  attr_accessible :replacement_url, :final_source
-  attr_accessor :final_source
+  attr_accessor :replacement_file, :final_source
 
   def initialize_fields
     self.creator = CurrentUser.user
@@ -24,7 +23,7 @@ class PostReplacement < ApplicationRecord
     end
 
     transaction do
-      upload = Upload.create!(source: replacement_url, rating: post.rating, tag_string: post.tag_string)
+      upload = Upload.create!(file: replacement_file, source: replacement_url, rating: post.rating, tag_string: post.tag_string)
       upload.process_upload
       upload.update(status: "completed", post_id: post.id)
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -69,6 +69,10 @@ class PostReplacement < ApplicationRecord
   end
 
   module SearchMethods
+    def post_tags_match(query)
+      PostQueryBuilder.new(query).build(self.joins(:post))
+    end
+
     def search(params = {})
       q = all
 
@@ -86,6 +90,10 @@ class PostReplacement < ApplicationRecord
 
       if params[:post_id].present?
         q = q.where(post_id: params[:post_id].split(",").map(&:to_i))
+      end
+
+      if params[:post_tags_match].present?
+        q = q.post_tags_match(params[:post_tags_match])
       end
 
       q = q.order("created_at DESC")

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -1,6 +1,7 @@
 <%= format_text(WikiPage.titled(Danbooru.config.replacement_notice_wiki_page).first.try(&:body), ragel: true) %>
 
 <%= simple_form_for(post_replacement, url: post_replacements_path(post_id: post_replacement.post_id), method: :post) do |f| %>
+  <%= f.input :replacement_file, label: "File", as: :file %>
   <%= f.input :replacement_url, label: "Replacement URL", hint: "The source URL to download the replacement from.", as: :string, input_html: { value: post_replacement.post.normalized_source } %>
   <%= f.input :final_source, label: "Final Source", hint: "If present, the source field will be changed to this after replacement.", as: :string, input_html: { value: post_replacement.post.source } %>
 <% end %>

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -1,5 +1,6 @@
 <%= format_text(WikiPage.titled(Danbooru.config.replacement_notice_wiki_page).first.try(&:body), ragel: true) %>
 
 <%= simple_form_for(post_replacement, url: post_replacements_path(post_id: post_replacement.post_id), method: :post) do |f| %>
-  <%= f.input :replacement_url, label: "New Source", input_html: { value: "" } %>
+  <%= f.input :replacement_url, label: "Replacement URL", hint: "The source URL to download the replacement from.", as: :string, input_html: { value: post_replacement.post.normalized_source } %>
+  <%= f.input :final_source, label: "Final Source", hint: "If present, the source field will be changed to this after replacement.", as: :string, input_html: { value: post_replacement.post.source } %>
 <% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -1,0 +1,54 @@
+<div id="c-post-replacements">
+  <div id="a-index">
+    <h1>Post Replacements</h1>
+
+    <%= render "posts/partials/common/inline_blacklist" %>
+
+    <%= simple_form_for(:search, url: post_replacements_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+      <%= f.input :creator_name, label: "Replacer", input_html: { value: params[:search][:creator_name] } %>
+      <%= f.submit "Search" %>
+    <% end %>
+
+    <table width="100%" class="striped autofit">
+      <thead>
+        <tr>
+          <th width="1%">Post</th>
+          <th>Source</th>
+          <th>Replacer</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @post_replacements.each do |post_replacement| %>
+          <tr>
+            <td><%= PostPresenter.preview(post_replacement.post) %></td>
+            <td>
+              <dl>
+                <dt>Original Source</dt>
+                <dd><%= external_link_to post_replacement.original_url %></dd>
+                <dt>Replacement Source</dt>
+                <dd>
+                  <% if post_replacement.replacement_url.present? %>
+                    <%= external_link_to post_replacement.replacement_url %>
+                  <% else %>
+                    <em>file</em>
+                  <% end %>
+                </dd>
+              </dl>
+            </td>
+            <td>
+              <%= compact_time post_replacement.created_at %>
+              <br> by <%= link_to_user post_replacement.creator %>
+              <%= link_to "»", post_replacements_path(search: params[:search].merge(creator_name: post_replacement.creator.name)) %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= numbered_paginator(@post_replacements) %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  Post Replacements - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -6,6 +6,7 @@
 
     <%= simple_form_for(:search, url: post_replacements_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :creator_name, label: "Replacer", input_html: { value: params[:search][:creator_name] } %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
       <%= f.submit "Search" %>
     <% end %>
 

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -27,6 +27,7 @@
             <li><%= fast_link_to "Notes", note_versions_path(:search => {:post_id => @post.id}) %></li>
             <li><%= fast_link_to "Flags & Appeals", post_events_path(@post.id) %></li>
             <li><%= fast_link_to "Commentary", artist_commentary_versions_path(:search => {:post_id => @post.id}) %></li>
+            <li><%= fast_link_to "Replacements", post_replacements_path(:search => {:post_id => @post.id}) %></li>
           </ul>
         </section>
 

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -11,6 +11,7 @@
         <li><%= link_to("Upload Listing", uploads_path) %></li>
         <li><%= link_to("Appeals", post_appeals_path) %></li>
         <li><%= link_to("Flags", post_flags_path) %></li>
+        <li><%= link_to("Replacements", post_replacements_path) %></li>
         <% if CurrentUser.can_approve_posts? %>
           <li><%= link_to("Moderate", moderator_post_queue_path) %></li>
         <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -196,6 +196,7 @@ Rails.application.routes.draw do
       get :diff
     end
   end
+  resources :post_replacements, :only => [:index, :new, :create]
   resources :posts do
     resources :events, :only => [:index], :controller => "post_events"
     resources :replacements, :only => [:index, :new, :create], :controller => "post_replacements"
@@ -217,7 +218,6 @@ Rails.application.routes.draw do
   end
   resources :post_appeals
   resources :post_flags
-  resources :post_replacements, :only => [:index, :new, :create]
   resources :post_versions, :only => [:index, :search] do
     member do
       put :undo

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -190,5 +190,15 @@ class PostReplacementTest < ActiveSupport::TestCase
         assert(File.exists?(@post.large_file_path))
       end
     end
+
+    context "a post when given a final_source" do
+      should "change the source to the final_source" do
+        replacement_url = "http://data.tumblr.com/afed9f5b3c33c39dc8c967e262955de2/tumblr_orwwptNBCE1wsfqepo1_raw.png"
+        final_source = "https://noizave.tumblr.com/post/162094447052"
+        @post.replace!(replacement_url: replacement_url, final_source: final_source)
+
+        assert_equal(final_source, @post.source)
+      end
+    end
   end
 end

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -191,6 +191,18 @@ class PostReplacementTest < ActiveSupport::TestCase
       end
     end
 
+    context "a post with an uploaded file" do
+      should "work" do
+        Tempfile.open do |file|
+          file.write(File.read("#{Rails.root}/test/files/test.png"))
+          file.seek(0)
+
+          @post.replace!(replacement_file: file, replacement_url: "")
+          assert_equal(@post.md5, Digest::MD5.file(file).hexdigest)
+        end
+      end
+    end
+
     context "a post when given a final_source" do
       should "change the source to the final_source" do
         replacement_url = "http://data.tumblr.com/afed9f5b3c33c39dc8c967e262955de2/tumblr_orwwptNBCE1wsfqepo1_raw.png"


### PR DESCRIPTION
A few improvements for post replacements:

* Adds a basic `/post_replacements` view.
* Adds ability to upload a replacement as a file from your computer.
* Adds a `Final Source` option to the replacement dialog. If present, the post's source field will be set to this value after replacement. This makes changing the source field back to the HTML page after replacement easier.
* Fixes a bug with `/post_replacements?search[creator_name]` not working.
* Fixes the awkward size of the source field in the replacement dialog (and incidentally fixes the size of the reason field in the flag dialog).