### PR TITLE
Fix #3187: DText is not enabled on certain views 

### DIFF
--- a/app/models/artist_commentary_version.rb
+++ b/app/models/artist_commentary_version.rb
@@ -1,5 +1,6 @@
 class ArtistCommentaryVersion < ApplicationRecord
   before_validation :initialize_updater
+  belongs_to :post
   belongs_to :updater, :class_name => "User"
   scope :for_user, lambda {|user_id| where("updater_id = ?", user_id)}
   attr_accessible :post_id, :original_title, :original_description, :translated_title, :translated_description

--- a/app/views/artist_commentary_versions/index.html.erb
+++ b/app/views/artist_commentary_versions/index.html.erb
@@ -32,11 +32,15 @@
             </td>
             <td>
               <h3><%= h(commentary_version.original_title) %></h3>
-              <%= h(commentary_version.original_description) %>
+              <div class="prose">
+                <%= format_text(commentary_version.original_description) %>
+              </div>
             </td>
             <td>
               <h3><%= h(commentary_version.translated_title) %></h3>
-              <%= h(commentary_version.translated_description) %>
+              <div class="prose">
+                <%= format_text(commentary_version.translated_description) %>
+              </div>
             </td>
             <% if CurrentUser.is_moderator? %>
               <td>

--- a/app/views/artist_commentary_versions/index.html.erb
+++ b/app/views/artist_commentary_versions/index.html.erb
@@ -2,6 +2,8 @@
   <div id="a-index">
     <h1>Artist Commentary Changes</h1>
 
+    <%= render "posts/partials/common/inline_blacklist" %>
+
     <table width="100%" class="striped">
       <thead>
         <tr>
@@ -21,7 +23,13 @@
       <tbody>
         <% @commentary_versions.each do |commentary_version| %>
           <tr>
-            <td><%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %></td>
+            <td>
+              <% if params.dig(:search, :post_id).present? %>
+                <%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %>
+              <% else %>
+                <%= PostPresenter.preview(commentary_version.post, :tags => "status:any") %>
+              <% end %>
+            </td>
             <td>
               <h3><%= h(commentary_version.original_title) %></h3>
               <%= h(commentary_version.original_description) %>


### PR DESCRIPTION
Fixes #3187 for `/artist_commentary_versions`:

* Formats commentaries in `/artist_commentary_versions` as DText.
* Also adds post thumbnails to `/artist_commentary_versions`. Thumbnails aren't shown when viewing the history of a single post, as that would be redundant.