### PR TITLE
Post replacements: streamline removing tags; fix replacement url.

### DIFF
--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -535,12 +535,8 @@ div#unapprove-dialog {
   }
 }
 
-.ui-widget #form {
-  font-size: 1em;
-
-  input, select, textarea, button {
-    font-size: 0.9em;
-  }
+textarea[data-autocomplete="tag-edit"] {
+  font-family: monospace;
 }
 
 #add-commentary-dialog {

--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -23,6 +23,6 @@ class PostReplacementsController < ApplicationController
 
 private
   def create_params
-    params.require(:post_replacement).permit(:replacement_url, :replacement_file, :final_source)
+    params.require(:post_replacement).permit(:replacement_url, :replacement_file, :final_source, :tags)
   end
 end

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -4,11 +4,12 @@ class PostReplacement < ApplicationRecord
   belongs_to :post
   belongs_to :creator, class_name: "User"
   before_validation :initialize_fields
-  attr_accessor :replacement_file, :final_source
+  attr_accessor :replacement_file, :final_source, :tags
 
   def initialize_fields
     self.creator = CurrentUser.user
     self.original_url = post.source
+    self.tags = post.tag_string + " " + self.tags.to_s
   end
 
   def undo!
@@ -23,7 +24,7 @@ class PostReplacement < ApplicationRecord
     end
 
     transaction do
-      upload = Upload.create!(file: replacement_file, source: replacement_url, rating: post.rating, tag_string: post.tag_string)
+      upload = Upload.create!(file: replacement_file, source: replacement_url, rating: post.rating, tag_string: self.tags)
       upload.process_upload
       upload.update(status: "completed", post_id: post.id)
 
@@ -154,6 +155,12 @@ class PostReplacement < ApplicationRecord
       else
         truncated_source
       end
+    end
+
+    def suggested_tags_for_removal
+      tags = post.tag_array.select { |tag| Danbooru.config.remove_tag_after_replacement?(tag) }
+      tags = tags.map { |tag| "-#{tag}" }
+      tags.join(" ")
     end
   end
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -27,6 +27,12 @@ class PostReplacement < ApplicationRecord
       upload.process_upload
       upload.update(status: "completed", post_id: post.id)
 
+      if replacement_file.present?
+        update(replacement_url: "file://#{replacement_file.original_filename}")
+      else
+        update(replacement_url: upload.source)
+      end
+
       # queue the deletion *before* updating the post so that we use the old
       # md5/file_ext to delete the old files. if saving the post fails,
       # this is rolled back so the job won't run.
@@ -112,7 +118,7 @@ class PostReplacement < ApplicationRecord
     end
 
     def replacement_message
-      linked_source = linked_source(post.source)
+      linked_source = linked_source(replacement_url)
       linked_source_was = linked_source(post.source_was)
 
       <<-EOS.strip_heredoc

--- a/app/views/post_replacements/_new.html.erb
+++ b/app/views/post_replacements/_new.html.erb
@@ -4,4 +4,5 @@
   <%= f.input :replacement_file, label: "File", as: :file %>
   <%= f.input :replacement_url, label: "Replacement URL", hint: "The source URL to download the replacement from.", as: :string, input_html: { value: post_replacement.post.normalized_source } %>
   <%= f.input :final_source, label: "Final Source", hint: "If present, the source field will be changed to this after replacement.", as: :string, input_html: { value: post_replacement.post.source } %>
+  <%= f.input :tags, label: "Tags", as: :text, input_html: { value: post_replacement.suggested_tags_for_removal, data: { autocomplete: "tag-edit" } } %>
 <% end %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -386,6 +386,11 @@ module Danbooru
       true
     end
 
+    # Should return true if the given tag should be suggested for removal in the post replacement dialog box.
+    def remove_tag_after_replacement?(tag)
+      tag =~ /replaceme|.*_sample|resized|upscaled|downscaled|md5_mismatch|jpeg_artifacts/i
+    end
+
     def shared_dir_path
       "/var/www/danbooru2/shared"
     end

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -26,7 +26,7 @@ class PostReplacementTest < ActiveSupport::TestCase
   context "Replacing" do
     setup do
       CurrentUser.scoped(@uploader, "127.0.0.2") do
-        upload = FactoryGirl.create(:jpg_upload, as_pending: "0")
+        upload = FactoryGirl.create(:jpg_upload, as_pending: "0", tag_string: "lowres tag1")
         upload.process!
         @post = upload.post
       end
@@ -35,7 +35,7 @@ class PostReplacementTest < ActiveSupport::TestCase
     context "a post from a generic source" do
       setup do
         @post.update(source: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png")
-        @post.replace!(replacement_url: "https://www.google.com/intl/en_ALL/images/logo.gif")
+        @post.replace!(replacement_url: "https://www.google.com/intl/en_ALL/images/logo.gif", tags: "-tag1 tag2")
         @upload = Upload.last
         @mod_action = ModAction.last
       end
@@ -52,6 +52,7 @@ class PostReplacementTest < ActiveSupport::TestCase
         end
 
         should "update the attributes" do
+          assert_equal("lowres tag2", @post.tag_string)
           assert_equal(272, @post.image_width)
           assert_equal(92, @post.image_height)
           assert_equal(5969, @post.file_size)

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -134,6 +134,7 @@ class PostReplacementTest < ActiveSupport::TestCase
         assert_equal("4ceadc314938bc27f3574053a3e1459a", @post.md5)
         assert_equal("4ceadc314938bc27f3574053a3e1459a", Digest::MD5.file(@post.file_path).hexdigest)
         assert_equal("https://i.pximg.net/img-original/img/2017/04/04/08/54/15/62247350_p0.png", @post.source)
+        assert_equal("https://i.pximg.net/img-original/img/2017/04/04/08/54/15/62247350_p0.png", @post.replacements.last.replacement_url)
       end
 
       should "delete the old files after three days" do
@@ -196,9 +197,11 @@ class PostReplacementTest < ActiveSupport::TestCase
         Tempfile.open do |file|
           file.write(File.read("#{Rails.root}/test/files/test.png"))
           file.seek(0)
+          uploaded_file = ActionDispatch::Http::UploadedFile.new(tempfile: file, filename: "test.png")
 
-          @post.replace!(replacement_file: file, replacement_url: "")
+          @post.replace!(replacement_file: uploaded_file, replacement_url: "")
           assert_equal(@post.md5, Digest::MD5.file(file).hexdigest)
+          assert_equal("file://test.png", @post.replacements.last.replacement_url)
         end
       end
     end


### PR DESCRIPTION
* Approvers frequently need to remove certain tags (`replaceme`, `image_sample`, `jpeg_artifacts`, etc) after replacing a post. This adds a `Tags` field to the post replacement dialog, prefilled with a list of such tags to be removed from the post.

* When the replacement comes from an uploaded file, record this as `file://#{filename}` in the replacement url.

* When the replacement comes from an URL, record the final URL used by the upload process instead of the initial URL given by the user. These differ if the upload process rewrites the URL from sample to full size.