### PR TITLE
#3194: Display thumbnails on batch upload page

### DIFF
--- a/app/assets/stylesheets/specific/uploads.scss
+++ b/app/assets/stylesheets/specific/uploads.scss
@@ -47,4 +47,28 @@ div#c-uploads {
       display: inline;
     }
   }
+
+  div.upload-preview {
+    display: inline-block;
+
+    > a {
+      width: 154px;
+      height: 154px;
+      margin: 0 10px 10px 0;
+      display: inline-block;
+
+      img {
+        margin: auto;
+        border: 2px solid transparent;
+
+        max-width: 154px;
+        max-height: 154px;
+      }
+    }
+
+    .caption-top {
+      font-size: 0.8em;
+      margin-bottom: 0;
+    }
+  }
 }

--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -2,11 +2,19 @@
   <div id="a-new">
     <h1>Batch Upload</h1>
 
-    <ul id="links">
+    <section>
       <% @urls.each.with_index do |url, i| %>
-        <li><%= link_to "Image ##{i}", new_upload_path(:url => url, :ref => params[:url]), :target => "_blank" %></li>
+        <div class="upload-preview">
+          <p class="caption-top">
+            <%= link_to "Image ##{i}", new_upload_path(url: url, ref: params[:url]), target: "_blank" %>
+          </p>
+
+          <%= link_to new_upload_path(url: url, ref: params[:url]), target: "_blank" do %>
+            <%= image_tag url %>
+          <% end %>
+        </div>
       <% end %>
-    </ul>
+    </section>
 
     <p><%= link_to "Open all links in new windows", "#", :id => "link" %></p>
   </div>
@@ -20,7 +28,7 @@
   <script type="text/javascript">
     $(function() {
       $("#link").click(function() {
-        $("#links a").each(function(i, v) {
+        $(".upload-preview > a").each(function(i, v) {
           window.open(v.href);
         });
       });

--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -10,7 +10,11 @@
           </p>
 
           <%= link_to new_upload_path(url: url, ref: params[:url]), target: "_blank" do %>
-            <%= image_tag url %>
+            <% if ImageProxy.needs_proxy?(url) %>
+              <%= image_tag(image_proxy_uploads_path(url: url)) %>
+            <% else %>
+              <%= image_tag url %>
+            <% end %>
           <% end %>
         </div>
       <% end %>


### PR DESCRIPTION
Attempt at #3194. As mentioned in #3194, this loads the full image, which will be slow if the gallery contains many large images.

Screenshot:

![Screenshot](https://i.imgur.com/r8idcz1.png)