### PR TITLE
Tumblr: convert artist commentaries from HTML to DText (#3184)

### DIFF
--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -369,6 +369,53 @@ class DText
     s
   end
 
+  def self.from_html(text, &block)
+    html = Nokogiri::HTML.fragment(text)
+
+    dtext = html.children.map do |element|
+      block.call(element) if block.present?
+
+      case element.name
+      when "text"
+        element.content
+      when "br"
+        "\n"
+      when "p"
+        from_html(element.inner_html, &block) + "\n\n"
+      when "blockquote"
+        "[quote]#{from_html(element.inner_html, &block)}[/quote]" if element.inner_html.present?
+      when "small", "sub"
+        "[tn]#{from_html(element.inner_html, &block)}[/tn]" if element.inner_html.present?
+      when "b", "strong"
+        "[b]#{from_html(element.inner_html, &block)}[/b]" if element.inner_html.present?
+      when "i", "em"
+        "[i]#{from_html(element.inner_html, &block)}[/i]" if element.inner_html.present?
+      when "u"
+        "[u]#{from_html(element.inner_html, &block)}[/u]" if element.inner_html.present?
+      when "s", "strike"
+        "[s]#{from_html(element.inner_html, &block)}[/s]" if element.inner_html.present?
+      when "li"
+        "* #{from_html(element.inner_html, &block)}" if element.inner_html.present?
+      when "h1", "h2", "h3", "h4", "h5", "h6"
+        hN = element.name
+        title = from_html(element.inner_html, &block)
+        "#{hN}. #{title}\n"
+      when "a"
+        title = from_html(element.inner_html, &block)
+        url = element["href"]
+        %("#{title}":[#{url}]) if title.present? && url.present?
+      when "img"
+        element.attributes["title"] || element.attributes["alt"] || ""
+      when "comment"
+        # ignored
+      else
+        from_html(element.inner_html, &block)
+      end
+    end.join
+
+    dtext
+  end
+
   # extract the first paragraph `needle` occurs in.
   def self.excerpt(dtext, needle)
     dtext = dtext.gsub(/\r\n|\r|\n/, "\n")

--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -377,13 +377,13 @@ class DText
 
       case element.name
       when "text"
-        element.content
+        element.content.gsub(/(?:\r|\n)+$/, "")
       when "br"
         "\n"
-      when "p"
-        from_html(element.inner_html, &block) + "\n\n"
+      when "p", "ul", "ol"
+        from_html(element.inner_html, &block).strip + "\n\n"
       when "blockquote"
-        "[quote]#{from_html(element.inner_html, &block)}[/quote]" if element.inner_html.present?
+        "[quote]#{from_html(element.inner_html, &block).strip}[/quote]\n\n" if element.inner_html.present?
       when "small", "sub"
         "[tn]#{from_html(element.inner_html, &block)}[/tn]" if element.inner_html.present?
       when "b", "strong"
@@ -395,13 +395,13 @@ class DText
       when "s", "strike"
         "[s]#{from_html(element.inner_html, &block)}[/s]" if element.inner_html.present?
       when "li"
-        "* #{from_html(element.inner_html, &block)}" if element.inner_html.present?
+        "* #{from_html(element.inner_html, &block)}\n" if element.inner_html.present?
       when "h1", "h2", "h3", "h4", "h5", "h6"
         hN = element.name
         title = from_html(element.inner_html, &block)
-        "#{hN}. #{title}\n"
+        "#{hN}. #{title}\n\n"
       when "a"
-        title = from_html(element.inner_html, &block)
+        title = from_html(element.inner_html, &block).strip
         url = element["href"]
         %("#{title}":[#{url}]) if title.present? && url.present?
       when "img"

--- a/app/logical/sources/strategies/deviant_art.rb
+++ b/app/logical/sources/strategies/deviant_art.rb
@@ -36,47 +36,11 @@ module Sources
       end
 
       def self.to_dtext(text)
-        html = Nokogiri::HTML.fragment(text)
-
-        dtext = html.children.map do |element|
-          case element.name
-          when "text"
-            element.content
-          when "br"
-            "\n"
-          when "blockquote"
-            "[quote]#{to_dtext(element.inner_html)}[/quote]" if element.inner_html.present?
-          when "small", "sub"
-            "[tn]#{to_dtext(element.inner_html)}[/tn]" if element.inner_html.present?
-          when "b"
-            "[b]#{to_dtext(element.inner_html)}[/b]" if element.inner_html.present?
-          when "i"
-            "[i]#{to_dtext(element.inner_html)}[/i]" if element.inner_html.present?
-          when "u"
-            "[u]#{to_dtext(element.inner_html)}[/u]" if element.inner_html.present?
-          when "strike"
-            "[s]#{to_dtext(element.inner_html)}[/s]" if element.inner_html.present?
-          when "li"
-            "* #{to_dtext(element.inner_html)}" if element.inner_html.present?
-          when "h1", "h2", "h3", "h4", "h5", "h6"
-            hN = element.name
-            title = to_dtext(element.inner_html)
-            "#{hN}. #{title}\n"
-          when "a"
-            title = to_dtext(element.inner_html)
-            url = element.attributes["href"].value
-            url = url.gsub(%r!\Ahttps?://www\.deviantart\.com/users/outgoing\?!i, "")
-            %("#{title}":[#{url}]) if title.present?
-          when "img"
-            element.attributes["title"] || element.attributes["alt"] || ""
-          when "comment"
-            # ignored
-          else
-            to_dtext(element.inner_html)
+        DText.from_html(text) do |element|
+          if element.name == "a" && element["href"].present?
+            element["href"] = element["href"].gsub(%r!\Ahttps?://www\.deviantart\.com/users/outgoing\?!i, "")
           end
-        end.join
-
-        dtext
+        end
       end
 
     protected

--- a/app/logical/sources/strategies/nijie.rb
+++ b/app/logical/sources/strategies/nijie.rb
@@ -50,26 +50,9 @@ module Sources
 
     protected
 
-      # XXX: duplicated from strategies/deviant_art.rb.
       def self.to_dtext(text)
-        html = Nokogiri::HTML.fragment(text)
-
-        dtext = html.children.map do |element|
-          case element.name
-          when "text"
-            element.content
-          when "strong"
-            "[b]#{to_dtext(element.inner_html)}[/b]" if element.inner_html.present?
-          when "i"
-            "[i]#{to_dtext(element.inner_html)}[/i]" if element.inner_html.present?
-          when "s"
-            "[s]#{to_dtext(element.inner_html)}[/s]" if element.inner_html.present?
-          else
-            to_dtext(element.inner_html)
-          end
-        end.join
-
-        dtext
+        text = text.gsub(/\r\n|\r/, "<br>")
+        DText.from_html(text).strip
       end
 
       def get_commentary_from_page(page)

--- a/app/logical/sources/strategies/tumblr.rb
+++ b/app/logical/sources/strategies/tumblr.rb
@@ -53,6 +53,10 @@ module Sources::Strategies
       end
     end
 
+    def dtext_artist_commentary_desc
+      DText.from_html(artist_commentary_desc).strip
+    end
+
     def image_url
       image_urls.first
     end

--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -35,14 +35,11 @@ module Sources
       should "get the dtext-ified commentary" do
         desc = <<-EOS.strip_heredoc.chomp
           blah blah
-          
           "test link":[http://www.google.com]
-          
-
 
           h1. lol
 
-          
+
 
           [b]blah[/b] [i]blah[/i] [u]blah[/u] [s]blah[/s]
           herp derp
@@ -52,7 +49,6 @@ module Sources
           * one
           * two
           * three
-          
           
           * one
           * two

--- a/test/unit/sources/nijie_test.rb
+++ b/test/unit/sources/nijie_test.rb
@@ -92,8 +92,8 @@ module Sources
 
       should "get the dtext-ified commentary" do
         desc = <<-EOS.strip_heredoc.chomp
-          foo [b]bold[/b] [i]italics[/i] [s]strike[/s] red\r
-          \r
+          foo [b]bold[/b] [i]italics[/i] [s]strike[/s] red
+
           http://nijie.info/view.php?id=218944
         EOS
 

--- a/test/unit/sources/tumblr_test.rb
+++ b/test/unit/sources/tumblr_test.rb
@@ -42,6 +42,26 @@ module Sources
         assert_equal(desc, @site.artist_commentary_desc)
       end
 
+      should "get the dtext-ified commentary" do
+        desc = <<-EOS.strip_heredoc.chomp
+          h2. header
+
+          plain [b]bold[/b] [i]italics[/i] [s]strike[/s]
+
+          * one
+          * two
+
+          * one
+          * two
+
+          [quote]quote[/quote]
+
+          "link":[http://www.google.com]
+        EOS
+
+        assert_equal(desc, @site.dtext_artist_commentary_desc)
+      end
+
       should "get the image url" do
         assert_equal("http://data.tumblr.com/3bbfcbf075ddf969c996641b264086fd/tumblr_os2buiIOt51wsfqepo1_raw.png", @site.image_url)
       end


### PR DESCRIPTION
 #3184:

* Factors out the HTML-to-DText conversion code from the Pawoo/Nijie/DeviantArt strategies to `DText.from_html`.
* Adjusts some minor whitespace issues along the way (strips extraneous whitespace, adds newlines between block elements).
* Finally converts Tumblr artist commentaries to DText.