### PR TITLE
Fix #3203: Overly restrictive permissions

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -1,6 +1,6 @@
 class ArtistsController < ApplicationController
   respond_to :html, :xml, :json
-  before_filter :member_only, :except => [:index, :show, :banned]
+  before_filter :member_only, :except => [:index, :show, :show_or_new, :banned]
   before_filter :builder_only, :only => [:destroy]
   before_filter :admin_only, :only => [:ban, :unban]
   before_filter :load_artist, :only => [:ban, :unban, :show, :edit, :update, :destroy, :undelete]
@@ -96,7 +96,9 @@ class ArtistsController < ApplicationController
     if @artist
       redirect_to artist_path(@artist)
     else
-      redirect_to new_artist_path(:name => params[:name])
+      @artist = Artist.new(name: params[:name])
+      @post_set = PostSets::Artist.new(@artist)
+      respond_with(@artist)
     end
   end
 

--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -1,6 +1,6 @@
 class BulkUpdateRequestsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_filter :member_only
+  before_filter :member_only, :except => [:index, :show]
   before_filter :admin_only, :only => [:approve]
   before_filter :load_bulk_update_request, :except => [:new, :create, :index]
 

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -1,6 +1,6 @@
 class DmailsController < ApplicationController
   respond_to :html, :xml, :json
-  before_filter :member_only
+  before_filter :member_only, except: [:index, :show, :destroy, :mark_all_as_read]
 
   def new
     if params[:respond_to_id]

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,5 +1,5 @@
 class FavoritesController < ApplicationController
-  before_filter :member_only
+  before_filter :member_only, except: [:index]
   respond_to :html, :xml, :json
   skip_before_filter :api_check
 

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -1,6 +1,6 @@
 class ForumPostsController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_filter :member_only, :except => [:index, :show]
+  before_filter :member_only, :except => [:index, :show, :search]
   before_filter :load_post, :only => [:edit, :show, :update, :destroy, :undelete]
   before_filter :check_min_level, :only => [:edit, :show, :update, :destroy, :undelete]
   skip_before_filter :api_check

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -1,6 +1,5 @@
 # todo: move this to iqdbs
 class IqdbQueriesController < ApplicationController
-  before_filter :member_only
   respond_to :html, :json, :xml
 
   def index

--- a/app/controllers/maintenance/user/api_keys_controller.rb
+++ b/app/controllers/maintenance/user/api_keys_controller.rb
@@ -1,7 +1,6 @@
 module Maintenance
   module User
     class ApiKeysController < ApplicationController
-      before_filter :member_only
       before_filter :check_privilege
       before_filter :authenticate!, :except => [:show]
       rescue_from ::SessionLoader::AuthenticationFailure, :with => :authentication_failed

--- a/app/controllers/maintenance/user/dmail_filters_controller.rb
+++ b/app/controllers/maintenance/user/dmail_filters_controller.rb
@@ -2,7 +2,6 @@ module Maintenance
   module User
     class DmailFiltersController < ApplicationController
       before_filter :ensure_ownership
-      before_filter :member_only
       respond_to :html, :json, :xml
 
       def edit

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -1,6 +1,6 @@
 class NotesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_filter :member_only, :except => [:index, :show]
+  before_filter :member_only, :except => [:index, :show, :search]
 
   def search
   end

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,5 +1,5 @@
 class ReportsController < ApplicationController
-  before_filter :member_only
+  before_filter :member_only, :except => [:upload_tags]
   before_filter :gold_only, :only => [:similar_users]
   before_filter :moderator_only, :only => [:post_versions, :post_versions_create]
 

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -1,5 +1,4 @@
 class SavedSearchesController < ApplicationController
-  before_filter :member_only
   before_filter :check_availability
   respond_to :html, :xml, :json, :js
   

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,5 +1,5 @@
 class UploadsController < ApplicationController
-  before_filter :member_only
+  before_filter :member_only, except: [:index, :show]
   respond_to :html, :xml, :json, :js
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
   respond_to :html, :xml, :json
-  before_filter :member_only, :only => [:edit, :update]
   skip_before_filter :api_check
 
   def new

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -1,6 +1,6 @@
 class WikiPagesController < ApplicationController
   respond_to :html, :xml, :json, :js
-  before_filter :member_only, :except => [:index, :show, :show_or_new]
+  before_filter :member_only, :except => [:index, :search, :show, :show_or_new]
   before_filter :builder_only, :only => [:destroy]
   before_filter :normalize_search_params, :only => [:index]
   
@@ -30,6 +30,9 @@ class WikiPagesController < ApplicationController
         render :xml => @wiki_pages.to_xml(:root => "wiki-pages")
       end
     end
+  end
+
+  def search
   end
 
   def show

--- a/app/views/artists/_show.html.erb
+++ b/app/views/artists/_show.html.erb
@@ -1,0 +1,28 @@
+<div id="c-artists">
+  <div id="a-show">
+    <h1>Artist: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_name}" %></h1>
+
+    <% if @artist.notes.present? && @artist.visible? %>
+      <div class="prose">
+        <%= format_text(@artist.notes, :ragel => true, :disable_mentions => true) %>
+      </div>
+
+      <p><%= link_to "View wiki page", @artist.wiki_page %></p>
+    <% end %>
+
+    <%= yield %>
+
+    <div class="recent-posts">
+      <h1>Recent Posts</h1>
+      <div style="margin: 1em 0;">
+        <%= @post_set.presenter.post_previews_html(self) %>
+      </div>
+    </div>
+
+    <%= render "secondary_links" %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  Artist - <%= @artist.name %> - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/artists/show.html.erb
+++ b/app/views/artists/show.html.erb
@@ -1,35 +1,9 @@
-<div id="c-artists">
-  <div id="a-show">
-    <h1>Artist: <%= link_to @artist.pretty_name, posts_path(:tags => @artist.name), :class => "tag-type-#{@artist.category_name}" %></h1>
-
-    <% if @artist.notes.present? && @artist.visible? %>
-      <div class="prose">
-        <%= format_text(@artist.notes, :ragel => true, :disable_mentions => true) %>
-      </div>
-
-      <p><%= link_to "View wiki page", @artist.wiki_page %></p>
-    <% end %>
-
-    <% if @artist.visible? %>
-      <div>
-        <%= render "summary", artist: @artist %>
-      </div>
-
-    <% else %>
-      <p>The artist requested removal of this page.</p>
-    <% end %>
-
-    <div class="recent-posts">
-      <h1>Recent Posts</h1>
-      <div style="margin: 1em 0;">
-        <%= @post_set.presenter.post_previews_html(self) %>
-      </div>
+<%= render layout: "show" do %>
+  <% if @artist.visible? %>
+    <div>
+      <%= render "summary", artist: @artist %>
     </div>
-
-    <%= render "secondary_links" %>
-  </div>
-</div>
-
-<% content_for(:page_title) do %>
-  Artist - <%= @artist.name %> - <%= Danbooru.config.app_name %>
+  <% else %>
+    <p>The artist requested removal of this page.</p>
+  <% end %>
 <% end %>

--- a/app/views/artists/show_or_new.html.erb
+++ b/app/views/artists/show_or_new.html.erb
@@ -1,0 +1,5 @@
+<%= render layout: "show" do %>
+  <div>
+    <p>This artist entry does not exist. <%= link_to "Create new artist entry", new_artist_path(name: params[:name]) %>.</p>
+  </div>
+<% end %>

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -42,7 +42,7 @@ class ArtistsControllerTest < ActionController::TestCase
       assert_redirected_to(@masao)
 
       get :show_or_new, { name: "nobody" }, { user_id: @user.id }
-      assert_redirected_to(new_artist_path(name: "nobody"))
+      assert_response :success
     end
 
     should "get the edit page" do

--- a/test/functional/dmails_controller_test.rb
+++ b/test/functional/dmails_controller_test.rb
@@ -62,6 +62,13 @@ class DmailsControllerTest < ActionController::TestCase
         assert_response :success
         assert_equal(0, assigns[:dmails].size)
       end
+
+      should "work for banned users" do
+        ban = FactoryGirl.create(:ban, :user => @user, :banner => FactoryGirl.create(:admin_user))
+        get :index, {:search => {:owner_id => @dmail.owner_id, :folder => "sent"}}, {:user_id => @dmail.owner_id}
+
+        assert_response :success
+      end
     end
 
     context "show action" do

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -124,6 +124,15 @@ class UsersControllerTest < ActionController::TestCase
           assert_equal(20, @user.level)
         end
       end
+
+      context "for a banned user" do
+        should "allow the user to edit their settings" do
+          @user = FactoryGirl.create(:banned_user)
+          post :update, {:id => @user.id, :user => {:favorite_tags => "xyz"}}, {:user_id => @user.id}
+
+          assert_equal("xyz", @user.reload.favorite_tags)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes #3203:

* Adds an `/artists/show_or_new` page that displays a "Artist does not exist. Create new artist entry." message when the artist doesn't exist yet. This makes  `/artists/show_or_new` work the same way that `/wiki_pages/show_or_new` does.
* Allows banned users to edit their account settings, read/delete their dmails, and manage their saved searches, dmail filters, and API key.
* Allows anonymous users to access various other pages; see commits.