### PR TITLE
Fix #3214: Add autocomplete for saved searches.

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -93,7 +93,7 @@
     var prefixes = "-|~|general:|gen:|artist:|art:|copyright:|copy:|co:|character:|char:|ch:";
     var metatags = "order|-status|status|-rating|rating|-locked|locked|child|filetype|-filetype|" +
       "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-fav|fav|ordfav|" +
-      "sub|-pool|pool|ordpool|favgroup";
+      "sub|-pool|pool|ordpool|favgroup|-search|search";
 
     $fields_multiple.autocomplete({
       delay: 100,
@@ -182,6 +182,10 @@
         case "favgroup":
         case "-favgroup":
           Danbooru.Autocomplete.favorite_group_source(term, resp, metatag);
+          break;
+        case "search":
+        case "-search":
+          Danbooru.Autocomplete.saved_search_source(term, resp);
           break;
         default:
           Danbooru.Autocomplete.normal_source(term, resp);
@@ -418,6 +422,17 @@
           };
         }));
       }
+    });
+  }
+
+  Danbooru.Autocomplete.saved_search_source = function(term, resp) {
+    return Danbooru.SavedSearch.labels(term).success(function(labels) {
+      resp(labels.map(function(label) {
+        return {
+          label: label.replace(/_/g, " "),
+          value: "search:" + label,
+        };
+      }));
     });
   }
 })();

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -548,7 +548,6 @@
 
   Danbooru.Post.initialize_saved_searches = function() {
     $("#saved_search_labels").autocomplete({
-      minLength: 2,
       source: function(req, resp) {
         Danbooru.SavedSearch.labels(req.term).success(function(labels) {
           resp(labels.map(function(label) {

--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -550,21 +550,14 @@
     $("#saved_search_labels").autocomplete({
       minLength: 2,
       source: function(req, resp) {
-        $.ajax({
-          url: "/saved_searches/labels.json",
-          data: {
-            label: req.term
-          },
-          method: "get",
-          success: function(data) {
-            resp($.map(data, function(saved_search) {
-              return {
-                label: saved_search.replace(/_/g, " "),
-                value: saved_search
-              };
-            }));
-          }
-        })
+        Danbooru.SavedSearch.labels(req.term).success(function(labels) {
+          resp(labels.map(function(label) {
+            return {
+              label: label.replace(/_/g, " "),
+              value: label
+            };
+          }));
+        });
       }
     });
 

--- a/app/assets/javascripts/saved_searches.js
+++ b/app/assets/javascripts/saved_searches.js
@@ -1,5 +1,16 @@
-$(document).ready(function() {
+Danbooru.SavedSearch = {};
+
+Danbooru.SavedSearch.initialize_all = function() {
   if ($("#c-saved-searches".length)) {
     Danbooru.sorttable($("#c-saved-searches table"));
   }
-});
+}
+
+Danbooru.SavedSearch.labels = function(term) {
+  return $.getJSON("/saved_searches/labels", {
+    "search[label]": term + "*",
+    "limit": 10
+  });
+}
+
+$(Danbooru.SavedSearch.initialize_all);

--- a/app/assets/javascripts/saved_searches.js
+++ b/app/assets/javascripts/saved_searches.js
@@ -1,7 +1,7 @@
 Danbooru.SavedSearch = {};
 
 Danbooru.SavedSearch.initialize_all = function() {
-  if ($("#c-saved-searches".length)) {
+  if ($("#c-saved-searches").length) {
     Danbooru.sorttable($("#c-saved-searches table"));
   }
 }

--- a/app/controllers/saved_searches_controller.rb
+++ b/app/controllers/saved_searches_controller.rb
@@ -17,11 +17,7 @@ class SavedSearchesController < ApplicationController
   end
 
   def labels
-    @labels = SavedSearch.labels_for(CurrentUser.user.id)
-    if params[:label]
-      regexp = Regexp.compile(Regexp.escape(params[:label]))
-      @labels = @labels.grep(regexp)
-    end
+    @labels = SavedSearch.search_labels(CurrentUser.id, params[:search])
     respond_with(@labels)
   end
 

--- a/app/models/saved_search.rb
+++ b/app/models/saved_search.rb
@@ -62,6 +62,19 @@ class SavedSearch < ApplicationRecord
     label.to_s.strip.downcase.gsub(/[[:space:]]/, "_")
   end
 
+  def self.search_labels(user_id, params)
+    labels = labels_for(user_id)
+
+    if params[:label].present?
+      query = Regexp.escape(params[:label]).gsub("\\*", ".*")
+      query = ".*#{query}.*" unless query.include?("*")
+      query = /\A#{query}\z/
+      labels = labels.grep(query)
+    end
+
+    labels
+  end
+
   def self.labels_for(user_id)
     Cache.get(cache_key(user_id)) do
       SavedSearch.where(user_id: user_id).order("label").pluck("distinct unnest(labels) as label")


### PR DESCRIPTION
Fixes #3214:

* Autocomplete the `search:<label>` metatag.

* Make label autocompletion do a prefix match instead of a substring match. Example: `search:ar` matches `artists`, not `characters`. This is how tags and most other things are autocompleted.

* Make the saved search dialog trigger autocomplete after typing the first letter of the label. This threshold was increased to 2 in da06bee0ab19c683a278a787e9c87b78d7ec3993 but I don't see why, the endpoint isn't any slower for one character.