### PR TITLE
Fix #3225: Exception in NoteSanitizer#relativize_links.

### DIFF
--- a/app/logical/note_sanitizer.rb
+++ b/app/logical/note_sanitizer.rb
@@ -79,14 +79,15 @@ module NoteSanitizer
   end
 
   def self.relativize_links(node:, **env)
-    return unless node.name == "a" && node.attribute("href")
+    return unless node.name == "a" && node["href"].present?
 
-    href = node.attribute("href")
-    url  = Addressable::URI.parse(href.value).normalize
+    url = Addressable::URI.heuristic_parse(node["href"]).normalize
 
     if url.authority.in?(Danbooru.config.hostnames)
       url.site = nil
-      href.value = url.to_s
+      node["href"] = url.to_s
     end
+  rescue Addressable::URI::InvalidURIError
+    # do nothing for invalid urls
   end
 end

--- a/test/unit/note_sanitizer_test.rb
+++ b/test/unit/note_sanitizer_test.rb
@@ -28,5 +28,10 @@ class NoteSanitizerTest < ActiveSupport::TestCase
       body = '<a href="http://sonohara.donmai.us/posts?tags=touhou#dtext-intro">touhou</a>'
       assert_equal('<a href="/posts?tags=touhou#dtext-intro" rel="nofollow">touhou</a>', NoteSanitizer.sanitize(body))
     end
+
+    should "not fail when rewriting bad links" do
+      body = %{<a href ="\nhttp!://www.google.com:12x3">google</a>}
+      assert_equal(%{<a rel="nofollow">google</a>}, NoteSanitizer.sanitize(body))
+    end
   end
 end


### PR DESCRIPTION
Fixes #3225. Swallows the `InvalidURIError` exception that Addressable raises when it parses a malformed url.