### PR TITLE
Fix #3229: Post expungement bugs

### DIFF
--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -239,11 +239,10 @@ class Pool < ApplicationRecord
   def remove!(post)
     return unless contains?(post.id)
     return unless CurrentUser.user.can_remove_from_pools?
-    return if is_deleted?
 
     with_lock do
       update_attributes(:post_ids => remove_number_from_string(post.id, post_ids), :post_count => post_count - 1)
-      post.remove_pool!(self, true)
+      post.remove_pool!(self)
       clear_post_id_array
     end
   end
@@ -284,7 +283,7 @@ class Pool < ApplicationRecord
 
     removed.each do |post_id|
       post = Post.find(post_id)
-      post.remove_pool!(self, true)
+      post.remove_pool!(self)
     end
 
     normalize_post_ids

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1079,10 +1079,9 @@ class Post < ApplicationRecord
       end
     end
 
-    def remove_pool!(pool, force = false)
+    def remove_pool!(pool)
       return unless belongs_to_pool?(pool)
       return unless CurrentUser.user.can_remove_from_pools?
-      return if pool.is_deleted? && !force
 
       with_lock do
         self.pool_string = pool_string.gsub(/(?:\A| )pool:#{pool.id}(?:\Z| )/, " ").strip

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1051,12 +1051,12 @@ class Post < ApplicationRecord
       @pools ||= begin
         return Pool.none if pool_string.blank?
         pool_ids = pool_string.scan(/\d+/)
-        Pool.undeleted.where(id: pool_ids).series_first
+        Pool.where(id: pool_ids).series_first
       end
     end
 
     def has_active_pools?
-      pools.length > 0
+      pools.undeleted.length > 0
     end
 
     def belongs_to_pool?(pool)
@@ -1101,7 +1101,7 @@ class Post < ApplicationRecord
     def set_pool_category_pseudo_tags
       self.pool_string = (pool_string.scan(/\S+/) - ["pool:series", "pool:collection"]).join(" ")
 
-      pool_categories = pools.select("category").map(&:category)
+      pool_categories = pools.undeleted.pluck(:category)
       if pool_categories.include?("series")
         self.pool_string = "#{pool_string} pool:series".strip
       end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -50,7 +50,7 @@ class Post < ApplicationRecord
   has_many :approvals, :class_name => "PostApproval", :dependent => :destroy
   has_many :disapprovals, :class_name => "PostDisapproval", :dependent => :destroy
   has_many :favorites
-  has_many :replacements, class_name: "PostReplacement"
+  has_many :replacements, class_name: "PostReplacement", :dependent => :destroy
 
   if PostArchive.enabled?
     has_many :versions, lambda {order("post_versions.updated_at ASC")}, :class_name => "PostArchive", :dependent => :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1314,17 +1314,14 @@ class Post < ApplicationRecord
     end
 
     def update_children_on_destroy
-      if children.size == 0
-        # do nothing
-      elsif children.size == 1
-        children.first.update_column(:parent_id, nil)
-      else
-        cached_children = children
-        eldest = cached_children[0]
-        siblings = cached_children[1..-1]
-        eldest.update_column(:parent_id, nil)
-        Post.where(:id => siblings.map(&:id)).update_all(:parent_id => eldest.id)
-      end
+      return unless children.present?
+
+      eldest = children[0]
+      siblings = children[1..-1]
+
+      eldest.update(parent_id: nil)
+      Post.where(id: siblings).find_each { |p| p.update(parent_id: eldest.id) }
+      # Post.where(id: siblings).update(parent_id: eldest.id) # XXX rails 5
     end
 
     def update_parent_on_save

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1379,17 +1379,20 @@ class Post < ApplicationRecord
         return false
       end
 
-      ModAction.log("permanently deleted post ##{id}")
-      delete!("Permanently deleted post ##{id}", :without_mod_action => true)
-      Post.without_timeout do
-        give_favorites_to_parent
-        update_children_on_destroy
-        decrement_tag_post_counts
-        remove_from_all_pools
-        remove_from_fav_groups
-        remove_from_favorites
-        destroy
-        update_parent_on_destroy
+      transaction do
+        Post.without_timeout do
+          ModAction.log("permanently deleted post ##{id}")
+          delete!("Permanently deleted post ##{id}", :without_mod_action => true)
+
+          give_favorites_to_parent
+          update_children_on_destroy
+          decrement_tag_post_counts
+          remove_from_all_pools
+          remove_from_fav_groups
+          remove_from_favorites
+          destroy
+          update_parent_on_destroy
+        end
       end
     end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -189,7 +189,7 @@ class PostPresenter < Presenter
   end
 
   def has_nav_links?(template)
-    (CurrentUser.user.enable_sequential_post_navigation && template.params[:tags].present? && template.params[:tags] !~ /(?:^|\s)(?:order|ordfav|ordpool):/) || @post.pools.any? || @post.favorite_groups(active_id=template.params[:favgroup_id]).any?
+    (CurrentUser.user.enable_sequential_post_navigation && template.params[:tags].present? && template.params[:tags] !~ /(?:^|\s)(?:order|ordfav|ordpool):/) || @post.pools.undeleted.any? || @post.favorite_groups(active_id=template.params[:favgroup_id]).any?
   end
 
   def post_footer_for_pool_html(template)
@@ -211,13 +211,13 @@ class PostPresenter < Presenter
       return if pool.nil?
       html += pool_link_html(template, pool, :include_rel => true)
 
-      other_pools = @post.pools.where("id <> ?", template.params[:pool_id]).series_first
+      other_pools = @post.pools.undeleted.where("id <> ?", template.params[:pool_id]).series_first
       other_pools.each do |other_pool|
         html += pool_link_html(template, other_pool)
       end
     else
       first = true
-      pools = @post.pools.series_first
+      pools = @post.pools.undeleted
       pools.each do |pool|
         if first && template.params[:tags].blank? && template.params[:favgroup_id].blank?
           html += pool_link_html(template, pool, :include_rel => true)

--- a/app/views/moderator/post/queues/_post.html.erb
+++ b/app/views/moderator/post/queues/_post.html.erb
@@ -35,7 +35,7 @@
       </li>
       <li><strong>Source</strong>: <%= post.source %></li>
       <% if post.has_active_pools? %>
-        <li><strong>Pools</strong>: <%= render "pools/inline_list", pools: post.pools %></li>
+        <li><strong>Pools</strong>: <%= render "pools/inline_list", pools: post.pools.undeleted %></li>
       <% end %>
       <li><strong>Tags</strong>: <%= post.presenter.inline_tag_list_html(self) %></li>
     </ul>

--- a/app/views/posts/partials/show/_nav_links.html.erb
+++ b/app/views/posts/partials/show/_nav_links.html.erb
@@ -4,7 +4,7 @@
       <%= render "posts/partials/show/search_seq", :post => post %>
     <% end %>
 
-    <% if post.pools.any? %>
+    <% if post.pools.undeleted.any? %>
       <%= render "posts/partials/show/pools", :post => post %>
     <% end %>
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -86,13 +86,22 @@ class PostTest < ActiveSupport::TestCase
           SqsService.any_instance.stubs(:send_message)
           @pool = FactoryGirl.create(:pool)
           @pool.add!(@post)
-          @post.reload
+
+          @deleted_pool = FactoryGirl.create(:pool)
+          @deleted_pool.add!(@post)
+          @deleted_pool.update_columns(is_deleted: true)
+
           @post.expunge!
+          @pool.reload
+          @deleted_pool.reload
         end
 
         should "remove the post from all pools" do
-          @pool.reload
           assert_equal("", @pool.post_ids)
+        end
+
+        should "remove the post from deleted pools" do
+          assert_equal("", @deleted_pool.post_ids)
         end
 
         should "destroy the record" do


### PR DESCRIPTION
Fixes #3229:

* Wrap `expunge!` in a transaction.
* Destroy post replacement records on expunge.
* Fix `Post#pools` to include deleted pools so that `Post#remove_from_all_pools` truly does remove posts from all pools. Fix `Post#remove_pool!` as well so that posts can be removed from deleted pools (cf #1109).
* Fix `update_children_on_destroy` to properly run callbacks when reparenting children. This ensures that the `has_children` flag is set on the new parent and new post versions are recorded for reparented posts.
* Try to simplify the `update_has_children_flag` logic while we're at it.