### PR TITLE
Redirect back to settings page after saving account settings.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,7 +62,7 @@ class UsersController < ApplicationController
     else
       flash[:notice] = "Settings updated"
     end
-    respond_with(@user)
+    respond_with(@user, location: edit_user_path(@user))
   end
 
   def cache


### PR DESCRIPTION
Currently after saving your account settings you are redirected back to your profile page. This is annoying when you're working on custom CSS and you have to go back to the settings page every time you make a change. This would instead keep you on the settings page after saving your settings.