### PR TITLE
Fix #1156: Allow sequential search navigator to work without a search.

### DIFF
--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -189,7 +189,11 @@ class PostPresenter < Presenter
   end
 
   def has_nav_links?(template)
-    (CurrentUser.user.enable_sequential_post_navigation && template.params[:tags].present? && template.params[:tags] !~ /(?:^|\s)(?:order|ordfav|ordpool):/) || @post.pools.undeleted.any? || @post.favorite_groups(active_id=template.params[:favgroup_id]).any?
+    has_sequential_navigation?(template) || @post.pools.undeleted.any? || @post.favorite_groups(active_id=template.params[:favgroup_id]).any?
+  end
+
+  def has_sequential_navigation?(template)
+    CurrentUser.user.enable_sequential_post_navigation && template.params[:tags] !~ /(?:^|\s)(?:order|ordfav|ordpool):/i
   end
 
   def post_footer_for_pool_html(template)

--- a/app/views/posts/partials/show/_nav_links.html.erb
+++ b/app/views/posts/partials/show/_nav_links.html.erb
@@ -1,6 +1,6 @@
 <% if (position == "bottom" && CurrentUser.user.new_post_navigation_layout) || (position == "top" && !CurrentUser.user.new_post_navigation_layout) %>
   <div id="nav-links" class="ui-corner-all nav-notice">
-    <% if CurrentUser.user.enable_sequential_post_navigation && params[:tags].present? && params[:tags] !~ /(?:^|\s)(?:order|ordfav|ordpool):/ %>
+    <% if post.presenter.has_sequential_navigation?(self) %>
       <%= render "posts/partials/show/search_seq", :post => post %>
     <% end %>
 

--- a/app/views/posts/partials/show/_search_seq.html.erb
+++ b/app/views/posts/partials/show/_search_seq.html.erb
@@ -2,7 +2,7 @@
   <ul>
     <li class="active">
       <%= link_to "&lsaquo;&thinsp;prev".html_safe, show_seq_post_path(post, :tags => params[:tags], :seq => "prev"), :rel => "prev nofollow", :class => "prev" %>
-      <span class="search-name">Search: <%= params[:tags] %></span>
+      <span class="search-name">Search: <%= params[:tags].presence || "status:any" %></span>
       <%= link_to "next&thinsp;&rsaquo;".html_safe, show_seq_post_path(post, :tags => params[:tags], :seq => "next"), :rel => "next nofollow", :class => "next" %>
     </li>
   </ul>


### PR DESCRIPTION
Fixes #1156. Makes the sequential post navigator default to a `status:any` search when the search is blank.