### PR TITLE
Fix censored post exposures in data attributes / legacy API (#3237)

### DIFF
--- a/app/controllers/legacy_controller.rb
+++ b/app/controllers/legacy_controller.rb
@@ -1,9 +1,21 @@
 class LegacyController < ApplicationController
   before_filter :member_only, :only => [:create_post]
+  respond_to :json, :xml
 
   def posts
     @post_set = PostSets::Post.new(tag_query, params[:page], params[:limit], format: "json")
-    @posts = @post_set.posts
+    @posts = @post_set.posts.map(&:legacy_attributes)
+
+    respond_with(@posts) do |format|
+      format.xml do
+        xml = Builder::XmlMarkup.new(indent: 2)
+        xml.instruct!
+        xml.posts do
+          @posts.each { |attrs| xml.post(attrs) }
+        end
+        render xml: xml.target!
+      end
+    end
   end
 
   def create_post

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1548,7 +1548,7 @@ class Post < ApplicationRecord
       super(options)
     end
 
-    def to_legacy_json
+    def legacy_attributes
       hash = {
         "has_comments" => last_commented_at.present?,
         "parent_id" => parent_id,
@@ -1574,7 +1574,7 @@ class Post < ApplicationRecord
         hash["md5"] = md5
       end
 
-      hash.to_json
+      hash
     end
 
     def status

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -66,7 +66,7 @@ class PostPresenter < Presenter
   end
 
   def self.data_attributes(post)
-    %{
+    attributes = %{
       data-id="#{post.id}"
       data-has-sound="#{post.has_tag?('video_with_sound|flash_with_sound')}"
       data-tags="#{h(post.tag_string)}"
@@ -83,15 +83,22 @@ class PostPresenter < Presenter
       data-views="#{post.view_count}"
       data-fav-count="#{post.fav_count}"
       data-pixiv-id="#{post.pixiv_id}"
-      data-md5="#{post.md5}"
       data-file-ext="#{post.file_ext}"
-      data-file-url="#{post.file_url}"
-      data-large-file-url="#{post.large_file_url}"
-      data-preview-file-url="#{post.preview_file_url}"
       data-source="#{h(post.source)}"
       data-normalized-source="#{h(post.normalized_source)}"
       data-is-favorited="#{post.favorited_by?(CurrentUser.user.id)}"
-    }.html_safe
+    }
+
+    if post.visible?
+      attributes += %{
+        data-md5="#{post.md5}"
+        data-file-url="#{post.file_url}"
+        data-large-file-url="#{post.large_file_url}"
+        data-preview-file-url="#{post.preview_file_url}"
+      }
+    end
+
+    attributes.html_safe
   end
 
   def initialize(post)

--- a/app/views/legacy/posts.json.erb
+++ b/app/views/legacy/posts.json.erb
@@ -1,1 +1,0 @@
-[<%= @posts.map {|x| x.to_legacy_json}.join(", ").html_safe %>]

--- a/app/views/legacy/posts.xml.erb
+++ b/app/views/legacy/posts.xml.erb
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<posts>
-  <% @posts.each do |post| %>
-	  <post preview_url="<%= post.preview_file_url %>" file_size="<%= post.file_size %>" status="<%= post.status %>" score="<%= post.score %>" file_url="<%= post.file_url %>" height="<%= post.image_height %>" has_comments="<%= post.last_commented_at.present? %>" tags="<%= post.tag_string %>" source="<%= post.source %>" parent_id="<%= post.parent_id %>" created_at="<%= post.created_at.to_formatted_s(:db) %>" rating="<%= post.rating %>" has_notes="<%= post.last_noted_at.present? %>" id="<%= post.id %>" md5="<%= post.md5 %>" has_children="<%= post.has_children? %>" creator_id="<%= post.uploader_id %>" author="<%= post.uploader_name %>" width="<%= post.image_width %>"/>
-	<% end %>
-</posts>


### PR DESCRIPTION
Related to #3237. Fixes hidden attributes being exposed in the data attributes of the `#image-container` element, and in the `/post/index.xml` legacy API.

The Better Better Booru userscript exploits these loopholes to make censored posts visible to unprivileged users.