### PR TITLE
Fix #2062: Update user _count fields when expunging posts/wikis

### DIFF
--- a/app/models/favorite.rb
+++ b/app/models/favorite.rb
@@ -4,19 +4,6 @@ class Favorite < ApplicationRecord
   scope :for_user, lambda {|user_id| where("user_id % 100 = #{user_id.to_i % 100} and user_id = #{user_id.to_i}")}
   attr_accessible :user_id, :post_id
 
-  # this is necessary because there's no trigger for deleting favorites
-  def self.destroy_all(user_id: nil, post_id: nil)
-    if user_id && post_id
-      connection.execute("delete from favorites_#{user_id % 100} where user_id = #{user_id} and post_id = #{post_id}")
-    elsif user_id
-      connection.execute("delete from favorites_#{user_id % 100} where user_id = #{user_id}")
-    elsif post_id
-      0.upto(99) do |uid|
-        connection.execute("delete from favorites_#{uid} where post_id = #{post_id}")
-      end
-    end
-  end
-
   def self.add(post:, user:)
     Favorite.transaction do
       User.where(:id => user.id).select("id").lock("FOR UPDATE NOWAIT").first
@@ -40,7 +27,7 @@ class Favorite < ApplicationRecord
       User.where(:id => user.id).select("id").lock("FOR UPDATE NOWAIT").first
 
       return unless Favorite.for_user(user.id).where(:user_id => user.id, :post_id => post_id).exists?
-      Favorite.destroy_all(user_id: user.id, post_id: post_id)
+      Favorite.for_user(user.id).delete_all(post_id: post_id)
       Post.where(:id => post_id).update_all("fav_count = fav_count - 1")
       post.delete_user_from_fav_string(user.id) if post
       User.where(:id => user.id).update_all("favorite_count = favorite_count - 1")

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -147,8 +147,6 @@ class Note < ApplicationRecord
 
   def create_version
     return unless versioned_attributes_changed?
-    User.where(id: CurrentUser.id).update_all("note_update_count = note_update_count + 1")
-    CurrentUser.reload
 
     if merge_version?
       merge_version

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -1,6 +1,6 @@
 class NoteVersion < ApplicationRecord
   before_validation :initialize_updater
-  belongs_to :updater, :class_name => "User"
+  belongs_to :updater, :class_name => "User", :counter_cache => "note_update_count"
   scope :for_user, lambda {|user_id| where("updater_id = ?", user_id)}
   attr_accessible :note_id, :x, :y, :width, :height, :body, :updater_id, :updater_ip_addr, :is_active, :post_id, :html_id, :version
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -36,7 +36,7 @@ class Post < ApplicationRecord
 
   belongs_to :updater, :class_name => "User"
   belongs_to :approver, :class_name => "User"
-  belongs_to :uploader, :class_name => "User"
+  belongs_to :uploader, :class_name => "User", :counter_cache => "post_upload_count"
   belongs_to :parent, :class_name => "Post"
   has_one :upload, :dependent => :destroy
   has_one :artist_commentary, :dependent => :destroy

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1025,7 +1025,9 @@ class Post < ApplicationRecord
     end
 
     def remove_from_favorites
-      Favorite.destroy_all(post_id: self.id)
+      favorites.find_each do |fav|
+        remove_favorite!(fav.user)
+      end
     end
 
     def remove_from_fav_groups

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -2,7 +2,7 @@ class PostArchive < ApplicationRecord
   extend Memoist
 
   belongs_to :post
-  belongs_to :updater, class_name: "User"
+  belongs_to :updater, class_name: "User", counter_cache: "post_update_count"
 
   def self.enabled?
     Danbooru.config.aws_sqs_archives_url.present?

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -139,7 +139,6 @@ class Upload < ApplicationRecord
       post = convert_to_post
       post.distribute_files
       if post.save
-        User.where(id: CurrentUser.id).update_all("post_upload_count = post_upload_count + 1")
         create_artist_commentary(post) if include_artist_commentary?
         ugoira_service.save_frame_data(post) if is_ugoira?
         update_attributes(:status => "completed", :post_id => post.id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -280,17 +280,8 @@ class User < ApplicationRecord
       Favorite.where("user_id % 100 = #{id % 100} and user_id = #{id}").order("id desc")
     end
 
-    def clean_favorite_count?
-      favorite_count < 0 || Kernel.rand(100) < [Math.log(favorite_count, 2), 5].min
-    end
-
-    def clean_favorite_count!
-      update_column(:favorite_count, Favorite.for_user(id).count)
-    end
-
     def add_favorite!(post)
       Favorite.add(post: post, user: self)
-      clean_favorite_count! if clean_favorite_count?
     end
 
     def remove_favorite!(post)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -61,6 +61,25 @@ class PostTest < ActiveSupport::TestCase
         assert_equal(0, Favorite.for_user(@user.id).where("post_id = ?", @post.id).count)
       end
 
+      should "decrement the uploader's upload count" do
+        assert_difference("@post.uploader.reload.post_upload_count", -1) do
+          @post.expunge!
+        end
+      end
+
+      should "decrement the user's note update count" do
+        FactoryGirl.create(:note, post: @post)
+        assert_difference(["@post.uploader.reload.note_update_count"], -1) do
+          @post.expunge!
+        end
+      end
+
+      should "decrement the user's post update count" do
+        assert_difference(["@post.uploader.reload.post_update_count"], -1) do
+          @post.expunge!
+        end
+      end
+
       should "remove the post from iqdb" do
         mock_iqdb_service!
         Post.iqdb_sqs_service.expects(:send_message).with("remove\n#{@post.id}")
@@ -1162,11 +1181,13 @@ class PostTest < ActiveSupport::TestCase
         should "increment the updater's post_update_count" do
           PostArchive.sqs_service.stubs(:merge?).returns(false)
           post = FactoryGirl.create(:post, :tag_string => "aaa bbb ccc")
-          CurrentUser.reload
 
-          assert_difference("CurrentUser.post_update_count", 1) do
+          # XXX in the test environment the update count gets bumped twice: and
+          # once by Post#post_update_count, and once by the counter cache. in
+          # production the counter cache doesn't bump the count, because
+          # versions are created on a separate server.
+          assert_difference("CurrentUser.user.reload.post_update_count", 2) do
             post.update_attributes(:tag_string => "zzz")
-            CurrentUser.reload
           end
         end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -80,6 +80,13 @@ class PostTest < ActiveSupport::TestCase
         end
       end
 
+      should "decrement the user's favorite count" do
+        @post.add_favorite!(@post.uploader)
+        assert_difference(["@post.uploader.reload.favorite_count"], -1) do
+          @post.expunge!
+        end
+      end
+
       should "remove the post from iqdb" do
         mock_iqdb_service!
         Post.iqdb_sqs_service.expects(:send_message).with("remove\n#{@post.id}")

--- a/test/unit/user_test.rb
+++ b/test/unit/user_test.rb
@@ -38,19 +38,6 @@ class UserTest < ActiveSupport::TestCase
       end
     end
 
-    context "favoriting a post" do
-      setup do
-        @user.update_column(:favorite_count, 999)
-        @user.stubs(:clean_favorite_count?).returns(true)
-        @post = FactoryGirl.create(:post)
-      end
-
-      should "periodically clean the favorite_count" do
-        @user.add_favorite!(@post)
-        assert_equal(1, @user.favorite_count)
-      end
-    end
-
     context "that has been invited by a mod" do
       setup do
         @mod = FactoryGirl.create(:moderator_user)


### PR DESCRIPTION
Fixes #2062: 

* Updates the `post_upload_count`, `post_update_count`, `note_update_count`, and `favorite_count` fields when a post is expunged.

* Removes `Favorite.destroy_all`. AFAICT the comment is inaccurate, deleting favorites from the child table by hand is not necessary.

* Removes some code related to cleaning favorite counts. This was a workaround for #1210 that I think is no longer necessary.