### PR TITLE
Fix #2344: Negating status metatag breaks deleted post filter.

### DIFF
--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1972,6 +1972,17 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(all - [flagged], "-status:active")
     end
 
+    should "respect the 'Deleted post filter' option when using the status:banned metatag" do
+      deleted = FactoryGirl.create(:post, is_deleted: true, is_banned: true)
+      undeleted = FactoryGirl.create(:post, is_banned: true)
+
+      CurrentUser.hide_deleted_posts = true
+      assert_tag_match([undeleted], "status:banned")
+
+      CurrentUser.hide_deleted_posts = false
+      assert_tag_match([undeleted, deleted], "status:banned")
+    end
+
     should "return posts for the filetype:<ext> metatag" do
       png = FactoryGirl.create(:post, file_ext: "png")
       jpg = FactoryGirl.create(:post, file_ext: "jpg")


### PR DESCRIPTION
Fixes #2344. Fixes searches so that when the `Deleted post filter` option is on, deleted posts are properly filtered from `-status:pending`, `-status:flagged`, `-status:banned`, and `status:banned` searches.