### PR TITLE
Fix #2346: Artist URLs: auto add 'http', remove non-links

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -62,6 +62,7 @@ class ArtistsController < ApplicationController
 
   def update
     @artist.update(params[:artist], :as => CurrentUser.role)
+    flash[:notice] = @artist.valid? ? "Artist updated" : @artist.errors.full_messages.join("; ")
     respond_with(@artist)
   end
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -10,6 +10,7 @@ class Artist < ApplicationRecord
   validates_uniqueness_of :name
   validate :validate_name
   validate :validate_wiki, :on => :create
+  after_validation :merge_validation_errors
   belongs_to :creator, :class_name => "User"
   has_many :members, :class_name => "Artist", :foreign_key => "group_name", :primary_key => "name"
   has_many :urls, :dependent => :destroy, :class_name => "ArtistUrl"
@@ -534,6 +535,13 @@ class Artist < ApplicationRecord
   include BanMethods
   extend SearchMethods
   include ApiMethods
+
+  def merge_validation_errors
+    errors[:urls].clear
+    urls.select(&:invalid?).each do |url|
+      errors[:url] << url.errors.full_messages.join("; ")
+    end
+  end
 
   def status
     if is_banned? && is_active?

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -2,6 +2,7 @@ class ArtistUrl < ApplicationRecord
   before_save :initialize_normalized_url, on: [ :create ]
   before_save :normalize
   validates_presence_of :url
+  validate :validate_url_format
   belongs_to :artist, :touch => true
   attr_accessible :url, :artist_id, :normalized_url
 
@@ -64,5 +65,12 @@ class ArtistUrl < ApplicationRecord
 
   def to_s
     url
+  end
+
+  def validate_url_format
+    uri = Addressable::URI.parse(url)
+    errors[:base] << "'#{url}' must begin with http:// or https://" if !uri.scheme.in?(%w[http https])
+  rescue Addressable::URI::InvalidURIError => error
+    errors[:base] << "'#{url}' is malformed: #{error}"
   end
 end

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -134,6 +134,13 @@ class ArtistTest < ActiveSupport::TestCase
       assert_equal(["http://aaa.com", "http://rembrandt.com/test.jpg"], artist.urls.map(&:to_s).sort)
     end
 
+    should "not allow invalid urls" do
+      artist = FactoryGirl.build(:artist, :url_string => "blah")
+
+      assert_equal(false, artist.valid?)
+      assert_equal(["'blah' must begin with http:// or https://"], artist.errors[:url])
+    end
+
     should "make sure old urls are deleted" do
       artist = FactoryGirl.create(:artist, :name => "rembrandt", :url_string => "http://rembrandt.com/test.jpg")
       artist.url_string = "http://not.rembrandt.com/test.jpg"


### PR DESCRIPTION
Fixes #2346. Validates that URLs in artist entries are well-formed. This doesn't attempt to automatically fix bad URLs as suggested in #2346. Instead it just returns a validation error and leaves it up to the user to fix their mistake.