### PR TITLE
Fix #2633: Search for status:active at tag_aliases and tag_implications

### DIFF
--- a/app/controllers/tag_aliases_controller.rb
+++ b/app/controllers/tag_aliases_controller.rb
@@ -22,8 +22,7 @@ class TagAliasesController < ApplicationController
   end
 
   def index
-    @search = TagAlias.search(params[:search])
-    @tag_aliases = @search.order("(case status when 'pending' then 1 when 'queued' then 2 when 'active' then 3 else 0 end), antecedent_name, consequent_name").paginate(params[:page], :limit => params[:limit])
+    @tag_aliases = TagAlias.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@tag_aliases) do |format|
       format.xml do
         render :xml => @tag_aliases.to_xml(:root => "tag-aliases")

--- a/app/controllers/tag_implications_controller.rb
+++ b/app/controllers/tag_implications_controller.rb
@@ -22,8 +22,7 @@ class TagImplicationsController < ApplicationController
   end
 
   def index
-    @search = TagImplication.search(params[:search])
-    @tag_implications = @search.order("(case status when 'pending' then 1 when 'queued' then 2 when 'active' then 3 else 0 end), antecedent_name, consequent_name").paginate(params[:page], :limit => params[:limit])
+    @tag_implications = TagImplication.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@tag_implications) do |format|
       format.xml do
         render :xml => @tag_implications.to_xml(:root => "tag-implications")

--- a/app/models/tag_alias.rb
+++ b/app/models/tag_alias.rb
@@ -1,17 +1,8 @@
-class TagAlias < ApplicationRecord
-  attr_accessor :skip_secondary_validations
-
+class TagAlias < TagRelationship
   before_save :ensure_tags_exist
   after_save :clear_all_cache
   after_destroy :clear_all_cache
   after_save :create_mod_action
-  before_validation :initialize_creator, :on => :create
-  before_validation :normalize_names
-  validates_format_of :status, :with => /\A(active|deleted|pending|processing|queued|error: .*)\Z/
-  validates_presence_of :creator_id, :antecedent_name, :consequent_name
-  validates :creator, presence: { message: "must exist" }, if: lambda { creator_id.present? }
-  validates :approver, presence: { message: "must exist" }, if: lambda { approver_id.present? }
-  validates :forum_topic, presence: { message: "must exist" }, if: lambda { forum_topic_id.present? }
   validates_uniqueness_of :antecedent_name
   validate :absence_of_transitive_relation
   validate :antecedent_and_consequent_are_different
@@ -23,40 +14,6 @@ class TagAlias < ApplicationRecord
   belongs_to :forum_post
   attr_accessible :antecedent_name, :consequent_name, :forum_topic_id, :skip_secondary_validations
   attr_accessible :status, :approver_id, :as => [:admin]
-
-  module SearchMethods
-    def name_matches(name)
-      where("(antecedent_name like ? escape E'\\\\' or consequent_name like ? escape E'\\\\')", name.mb_chars.downcase.to_escaped_for_sql_like, name.downcase.to_escaped_for_sql_like)
-    end
-    
-    def active
-      where("status IN (?)", ["active", "processing"])
-    end
-
-    def search(params)
-      q = where("true")
-      return q if params.blank?
-
-      if params[:name_matches].present?
-        q = q.name_matches(params[:name_matches])
-      end
-
-      if params[:antecedent_name].present?
-        q = q.where("antecedent_name = ?", params[:antecedent_name])
-      end
-
-      if params[:id].present?
-        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
-      end
-
-      case params[:order]
-      when "created_at"
-        q = q.order("created_at desc")
-      end
-
-      q
-    end
-  end
 
   module CacheMethods
     extend ActiveSupport::Concern
@@ -124,7 +81,6 @@ class TagAlias < ApplicationRecord
     end
   end
 
-  extend SearchMethods
   include CacheMethods
   include ApprovalMethods
   include ForumMethods
@@ -170,32 +126,6 @@ class TagAlias < ApplicationRecord
         NewRelic::Agent.notice_error(e, :custom_params => {:tag_alias_id => id, :antecedent_name => antecedent_name, :consequent_name => consequent_name})
       end
     end
-  end
-
-  def is_pending?
-    status == "pending"
-  end
-
-  def is_active?
-    status == "active"
-  end
-  
-  def normalize_names
-    self.antecedent_name = antecedent_name.mb_chars.downcase.tr(" ", "_")
-    self.consequent_name = consequent_name.downcase.tr(" ", "_")
-  end
-
-  def initialize_creator
-    self.creator_id ||= CurrentUser.user.id
-    self.creator_ip_addr ||= CurrentUser.ip_addr
-  end
-
-  def antecedent_tag
-    Tag.find_or_create_by_name(antecedent_name)
-  end
-
-  def consequent_tag
-    Tag.find_or_create_by_name(consequent_name)
   end
 
   def absence_of_transitive_relation
@@ -308,17 +238,6 @@ class TagAlias < ApplicationRecord
         end
       end
     end
-  end
-
-  def deletable_by?(user)
-    return true if user.is_admin?
-    return true if is_pending? && user.is_builder?
-    return true if is_pending? && user.id == creator_id
-    return false
-  end
-
-  def editable_by?(user)
-    deletable_by?(user)
   end
 
   def reject!

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -1,0 +1,91 @@
+class TagRelationship < ApplicationRecord
+  self.abstract_class = true
+
+  attr_accessor :skip_secondary_validations
+  attr_accessible :antecedent_name, :consequent_name, :forum_topic_id, :skip_secondary_validations
+  attr_accessible :status, :approver_id, :as => [:admin]
+
+  belongs_to :creator, :class_name => "User"
+  belongs_to :approver, :class_name => "User"
+  belongs_to :forum_post
+  belongs_to :forum_topic
+  has_one :antecedent_tag, :class_name => "Tag", :foreign_key => "name", :primary_key => "antecedent_name"
+  has_one :consequent_tag, :class_name => "Tag", :foreign_key => "name", :primary_key => "consequent_name"
+
+  before_validation :initialize_creator, :on => :create
+  before_validation :normalize_names
+  validates_format_of :status, :with => /\A(active|deleted|pending|processing|queued|error: .*)\Z/
+  validates_presence_of :creator_id, :antecedent_name, :consequent_name
+  validates :creator, presence: { message: "must exist" }, if: lambda { creator_id.present? }
+  validates :approver, presence: { message: "must exist" }, if: lambda { approver_id.present? }
+  validates :forum_topic, presence: { message: "must exist" }, if: lambda { forum_topic_id.present? }
+
+  def initialize_creator
+    self.creator_id = CurrentUser.user.id
+    self.creator_ip_addr = CurrentUser.ip_addr
+  end
+
+  def normalize_names
+    self.antecedent_name = antecedent_name.mb_chars.downcase.tr(" ", "_")
+    self.consequent_name = consequent_name.mb_chars.downcase.tr(" ", "_")
+  end
+
+  def is_pending?
+    status == "pending"
+  end
+
+  def is_active?
+    status == "active"
+  end
+
+  def deletable_by?(user)
+    return true if user.is_admin?
+    return true if is_pending? && user.is_builder?
+    return true if is_pending? && user.id == creator_id
+    return false
+  end
+
+  def editable_by?(user)
+    deletable_by?(user)
+  end
+
+  module SearchMethods
+    def name_matches(name)
+      where("(antecedent_name like ? escape E'\\\\' or consequent_name like ? escape E'\\\\')", name.mb_chars.downcase.to_escaped_for_sql_like, name.mb_chars.downcase.to_escaped_for_sql_like)
+    end
+
+    def active
+      where(status: %w[active processing queued])
+    end
+
+    def search(params)
+      q = where("true")
+      return q if params.blank?
+
+      if params[:id].present?
+        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
+      end
+
+      if params[:name_matches].present?
+        q = q.name_matches(params[:name_matches])
+      end
+
+      if params[:antecedent_name].present?
+        q = q.where("antecedent_name = ?", params[:antecedent_name])
+      end
+
+      if params[:consequent_name].present?
+        q = q.where("consequent_name = ?", params[:consequent_name])
+      end
+
+      case params[:order]
+      when "created_at"
+        q = q.order("created_at desc")
+      end
+
+      q
+    end
+  end
+
+  extend SearchMethods
+end

--- a/app/views/tag_aliases/_listing.html.erb
+++ b/app/views/tag_aliases/_listing.html.erb
@@ -12,7 +12,7 @@
   <tbody>
     <% tag_aliases.each do |tag_alias| %>
       <tr id="tag-alias-<%= tag_alias.id %>">
-        <td class="category-<%= tag_alias.antecedent_tag.category %>"><%= link_to tag_alias.antecedent_name, posts_path(:tags => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></td>
+        <td class="category-<%= tag_alias.antecedent_tag.try(:category) %>"><%= link_to tag_alias.antecedent_name, posts_path(:tags => tag_alias.antecedent_name) %> <span class="count"><%= tag_alias.antecedent_tag.post_count rescue 0 %></span></td>
         <td class="category-<%= tag_alias.consequent_tag.try(:category) %>"><%= link_to tag_alias.consequent_name, posts_path(:tags => tag_alias.consequent_name) %> <span class="count"><%= tag_alias.consequent_tag.post_count rescue 0 %></span></td>
         <td>
           <% if tag_alias.forum_topic_id %>

--- a/app/views/tag_aliases/index.html.erb
+++ b/app/views/tag_aliases/index.html.erb
@@ -1,7 +1,10 @@
 <div id="c-tag-aliases">
   <div id="a-index">
-    <%= simple_form_for(:search, method: :get, url: tag_aliases_path, defaults: { required: false }) do |f| %>
+    <%= simple_form_for(:search, method: :get, url: tag_aliases_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
+      <%= f.input :status, label: "Status", collection: ["", "Approved", "Pending"], selected: params[:search][:status] %>
+      <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
+      <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
       <%= f.submit "Search" %>
     <% end %>
 
@@ -16,4 +19,3 @@
 <% content_for(:page_title) do %>
   Tag Aliases - <%= Danbooru.config.app_name %>
 <% end %>
-

--- a/app/views/tag_implications/index.html.erb
+++ b/app/views/tag_implications/index.html.erb
@@ -1,7 +1,10 @@
 <div id="c-tag-implications">
   <div id="a-index">
-    <%= simple_form_for(:search, method: :get, url: tag_implications_path, defaults: { required: false }) do |f| %>
+    <%= simple_form_for(:search, method: :get, url: tag_implications_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
+      <%= f.input :status, label: "Status", collection: ["", "Approved", "Pending"], selected: params[:search][:status] %>
+      <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
+      <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
       <%= f.submit "Search" %>
     <% end %>
 


### PR DESCRIPTION
Fixes #2633. Adds options for filtering `/tag_aliases` and `/tag_implications` by status and by tag type, and for ordering results.

The code for searching aliases and implications is the same, so this factors it out (along with some other shared code) into a `TagRelationship` superclass that aliases and implications both inherit from.