### PR TITLE
Fix #2736: Comment mention dmail didn't go through

### DIFF
--- a/app/logical/d_text.rb
+++ b/app/logical/d_text.rb
@@ -9,6 +9,16 @@ class DText
     "[quote]\n#{creator_name} said:\n\n#{stripped_body}\n[/quote]\n\n"
   end
 
+  def self.parse_mentions(text)
+    text = strip_blocks(text.to_s, "quote")
+
+    names = text.scan(MENTION_REGEXP).map do |mention|
+      mention.gsub(/(?:^\s*@)|(?:[:;,.!?\)\]<>]$)/, "")
+    end
+
+    names.uniq
+  end
+
   def self.strip_blocks(string, tag)
     n = 0
     stripped = ""
@@ -91,4 +101,3 @@ class DText
     excerpt
   end
 end
-

--- a/app/logical/mentionable.rb
+++ b/app/logical/mentionable.rb
@@ -8,7 +8,8 @@ module Mentionable
     def mentionable(options = {})
       @mentionable_options = options
 
-      after_create :queue_mention_messages
+      message_field = mentionable_option(:message_field)
+      after_save :queue_mention_messages, if: :"#{message_field}_changed?"
     end
 
     def mentionable_option(key)
@@ -17,8 +18,11 @@ module Mentionable
   end
 
   def queue_mention_messages
-    text = read_attribute(self.class.mentionable_option(:message_field))
-    names = DText.parse_mentions(text)
+    message_field = self.class.mentionable_option(:message_field)
+    text = send(message_field)
+    text_was = send("#{message_field}_was")
+
+    names = DText.parse_mentions(text) - DText.parse_mentions(text_was)
 
     names.uniq.each do |name|
       body  = self.instance_exec(name, &self.class.mentionable_option(:body))

--- a/app/logical/mentionable.rb
+++ b/app/logical/mentionable.rb
@@ -17,13 +17,8 @@ module Mentionable
   end
 
   def queue_mention_messages
-    from_id = read_attribute(self.class.mentionable_option(:user_field))
     text = read_attribute(self.class.mentionable_option(:message_field))
-    text = DText.strip_blocks(text, "quote")
-
-    names = text.scan(DText::MENTION_REGEXP).map do |mention|
-      mention.gsub!(/(?:^\s*@)|(?:[:;,.!?\)\]<>]$)/, "")
-    end
+    names = DText.parse_mentions(text)
 
     names.uniq.each do |name|
       body  = self.instance_exec(name, &self.class.mentionable_option(:body))

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,7 +22,6 @@ class Comment < ApplicationRecord
   attr_accessible :is_sticky, :as => [:moderator, :admin]
   mentionable(
     :message_field => :body, 
-    :user_field => :creator_id, 
     :title => lambda {|user_name| "#{creator_name} mentioned you in a comment on post ##{post_id}"},
     :body => lambda {|user_name| "@#{creator_name} mentioned you in a \"comment\":/posts/#{post_id}#comment-#{id} on post ##{post_id}:\n\n[quote]\n#{DText.excerpt(body, "@"+user_name)}\n[/quote]\n"},
   )

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -27,7 +27,6 @@ class ForumPost < ApplicationRecord
   end
   mentionable(
     :message_field => :body, 
-    :user_field => :creator_id, 
     :title => lambda {|user_name| %{#{creator_name} mentioned you in topic ##{topic_id} (#{topic.title})}},
     :body => lambda {|user_name| %{@#{creator_name} mentioned you in topic ##{topic_id} ("#{topic.title}":[/forum_topics/#{topic_id}?page=#{forum_topic_page}]):\n\n[quote]\n#{DText.excerpt(body, "@"+user_name)}\n[/quote]\n}},
   )

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -20,6 +20,21 @@ class CommentTest < ActiveSupport::TestCase
         Danbooru.config.stubs(:member_comment_time_threshold).returns(1.week.from_now)
       end
 
+      context "added in an edit" do
+        should "dmail the added user" do
+          @user1 = FactoryGirl.create(:user)
+          @user2 = FactoryGirl.create(:user)
+          @comment = FactoryGirl.create(:comment, :post_id => @post.id, :body => "@#{@user1.name}")
+
+          assert_no_difference("@user1.dmails.count") do
+            assert_difference("@user2.dmails.count") do
+              @comment.body = "@#{@user1.name} @#{@user2.name}"
+              @comment.save
+            end
+          end
+        end
+      end
+
       context "in a quote block" do
         setup do
           @user2 = FactoryGirl.create(:user, :created_at => 2.weeks.ago)


### PR DESCRIPTION
Fixes #2736. The bug was that mentions weren't processed when added during an edit. This fixes it so that mentions added by an edit will get processed.