### PR TITLE
Fix #2502: Exclude empty commentary from searches.

### DIFF
--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -23,6 +23,14 @@ class ArtistCommentary < ApplicationRecord
       PostQueryBuilder.new(query).build(self.joins(:post)).reorder("")
     end
 
+    def deleted
+      where(original_title: "", original_description: "", translated_title: "", translated_description: "")
+    end
+
+    def undeleted
+      where("original_title != '' OR original_description != '' OR translated_title != '' OR translated_description != ''")
+    end
+
     def search(params)
       q = where("true")
       params = {} if params.blank?
@@ -50,6 +58,9 @@ class ArtistCommentary < ApplicationRecord
       if params[:post_tags_match].present?
         q = q.post_tags_match(params[:post_tags_match])
       end
+
+      q = q.deleted if params[:is_deleted] == "yes"
+      q = q.undeleted if params[:is_deleted] == "no"
 
       q
     end

--- a/app/views/artist_commentaries/search.html.erb
+++ b/app/views/artist_commentaries/search.html.erb
@@ -5,8 +5,9 @@
     <%= simple_form_for(:search, url: artist_commentaries_path, method: :get, defaults: { required: false }) do |f| %>
       <%= f.input :text_matches, label: "Text" %>
       <%= f.input :post_tags_match, label: "Tags", input_html: { data: { autocomplete: "tag-query" } } %>
-      <%= f.input :original_present, label: "Original present?", collection: ["yes", "no"], include_blank: true %>
-      <%= f.input :translated_present, label: "Translation present?", collection: ["yes", "no"], include_blank: true %>
+      <%= f.input :original_present, label: "Original present?", collection: ["yes", "no"] %>
+      <%= f.input :translated_present, label: "Translation present?", collection: ["yes", "no"] %>
+      <%= f.input :is_deleted, label: "Deleted?", collection: ["yes", "no"] %>
       <%= f.submit "Search" %>
     <% end %>
   </div>


### PR DESCRIPTION
Fixes #2502. Adds a `Deleted?` option to the `/artist_commentaries` search form. Choosing "no" filters empty commentaries out of the results.