### PR TITLE
Fix #3263: Remove leading whitespace on pool names

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -36,7 +36,7 @@ class PoolsController < ApplicationController
 
   def create
     @pool = Pool.create(params[:pool])
-    flash[:notice] = "Pool created"
+    flash[:notice] = @pool.valid? ? "Pool created" : @pool.errors.full_messages.join("; ")
     respond_with(@pool)
   end
 

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -387,8 +387,12 @@ class Pool < ApplicationRecord
       errors[:name] << "cannot be any of the following names: any, none, series, collection"
     when /,/
       errors[:name] << "cannot contain commas"
+    when /\*/
+      errors[:name] << "cannot contain asterisks"
     when ""
       errors[:name] << "cannot be blank"
+    when /\A[0-9]+\z/
+      errors[:name] << "cannot contain only digits"
     end
   end
 

--- a/test/factories/pool.rb
+++ b/test/factories/pool.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory(:pool) do
-    name {(rand(1_000_000) + 100).to_s}
+    name {"pool_" + (rand(1_000_000) + 100).to_s}
     association :creator, :factory => :user
     description {FFaker::Lorem.sentences.join(" ")}
   end

--- a/test/unit/pool_test.rb
+++ b/test/unit/pool_test.rb
@@ -249,13 +249,26 @@ class PoolTest < ActiveSupport::TestCase
     end
 
     should "normalize its name" do
-      @pool.update_attributes(:name => "A B")
+      @pool.update(:name => "  A  B  ")
+      assert_equal("A_B", @pool.name)
+
+      @pool.update(:name => "__A__B__")
       assert_equal("A_B", @pool.name)
     end
 
     should "normalize its post ids" do
       @pool.update_attributes(:post_ids => " 1  2 ")
       assert_equal("1 2", @pool.post_ids)
+    end
+
+    context "when validating names" do
+      should_not allow_value("foo,bar").for(:name)
+      should_not allow_value("___").for(:name)
+      should_not allow_value("   ").for(:name)
+
+      %w[any none series collection].each do |type|
+        should_not allow_value(type).for(:name)
+      end
     end
   end
 

--- a/test/unit/pool_test.rb
+++ b/test/unit/pool_test.rb
@@ -263,6 +263,8 @@ class PoolTest < ActiveSupport::TestCase
 
     context "when validating names" do
       should_not allow_value("foo,bar").for(:name)
+      should_not allow_value("foo*bar").for(:name)
+      should_not allow_value("123").for(:name)
       should_not allow_value("___").for(:name)
       should_not allow_value("   ").for(:name)
 


### PR DESCRIPTION
Fixes #3263:

* Strips leading / trailing underscores from pool names.
* Strips consecutive underscores (`___`) inside pool names.
* Disallows blank pool names.
* Disallows asterisks (this conflicts with wildcards in `pool:touhou*` searches).
* Disallows numeric-only names (this is ambiguous in `pool:1234` searches).