### PR TITLE
Fix #3262: Add time remaining for upload limits on user profiles

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -942,4 +942,8 @@ class User < ApplicationRecord
     self.enable_sequential_post_navigation = true
     self.enable_auto_complete = true
   end
+
+  def presenter
+    @presenter ||= UserPresenter.new(self)
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -585,6 +585,10 @@ class User < ApplicationRecord
       end
     end
 
+    def next_free_upload_slot
+      (posts.where("created_at >= ?", 24.hours.ago).first.try(:created_at) || 24.hours.ago) + 24.hours
+    end
+
     def tag_query_limit
       if is_platinum?
         Danbooru.config.base_tag_query_limit * 2

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -68,13 +68,14 @@ class UserPresenter
       return "none"
     end
 
-    dcon = [user.deletion_confidence(60), 15].min
-    multiplier = (1 - (dcon / 15.0))
-    max_count = [(user.base_upload_limit * multiplier).ceil, 5].max
-    uploaded_count = Post.for_user(user.id).where("created_at >= ?", 24.hours.ago).count
-    uploaded_comic_count = Post.for_user(user.id).tag_match("comic").where("created_at >= ?", 24.hours.ago).count / 3
+    limit_tooltip = <<-EOS.strip_heredoc
+      Base: #{user.base_upload_limit}
+      Del. Rate: #{"%.2f" % user.adjusted_deletion_confidence}
+      Multiplier: (1 - (#{"%.2f" % user.adjusted_deletion_confidence} / 15)) = #{user.upload_limit_multiplier}
+      Upload Limit: #{user.base_upload_limit} * #{"%.2f" % user.upload_limit_multiplier} = #{user.max_upload_limit}
+    EOS
 
-    "(#{user.base_upload_limit} * #{'%0.2f' % multiplier}) - #{uploaded_count - uploaded_comic_count} = #{user.upload_limit}"
+    %{#{user.used_upload_slots} / <abbr title="#{limit_tooltip}">#{user.upload_limit}</abbr>}.html_safe
   end
 
   def uploads

--- a/app/presenters/user_presenter.rb
+++ b/app/presenters/user_presenter.rb
@@ -63,11 +63,12 @@ class UserPresenter
     end
   end
 
-  def upload_limit
+  def upload_limit(template)
     if user.can_upload_free?
       return "none"
     end
 
+    slots_tooltip = "Next free slot: #{template.time_ago_in_words(user.next_free_upload_slot)}"
     limit_tooltip = <<-EOS.strip_heredoc
       Base: #{user.base_upload_limit}
       Del. Rate: #{"%.2f" % user.adjusted_deletion_confidence}
@@ -75,7 +76,7 @@ class UserPresenter
       Upload Limit: #{user.base_upload_limit} * #{"%.2f" % user.upload_limit_multiplier} = #{user.max_upload_limit}
     EOS
 
-    %{#{user.used_upload_slots} / <abbr title="#{limit_tooltip}">#{user.upload_limit}</abbr>}.html_safe
+    %{<abbr title="#{slots_tooltip}">#{user.used_upload_slots}</abbr> / <abbr title="#{limit_tooltip}">#{user.max_upload_limit}</abbr>}.html_safe
   end
 
   def uploads

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -8,7 +8,7 @@
       </div>
 
       <% unless CurrentUser.can_upload_free? %>
-        <p>You can upload <strong><%= pluralize CurrentUser.upload_limit, "more post" %></strong> today.</p>
+        <p>Upload limit: <strong><%= CurrentUser.user.presenter.upload_limit(self) %></strong>.</p>
       <% end %>
 
       <%= render "image" %>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -31,7 +31,7 @@
 
       <tr>
         <th>Upload Limit</th>
-        <td><%= presenter.upload_limit %> (<%= link_to "help", wiki_pages_path(title: "about:upload_limits") %>)</td>
+        <td><%= presenter.upload_limit(self) %> (<%= link_to "help", wiki_pages_path(title: "about:upload_limits") %>)</td>
       </tr>
 
       <tr>

--- a/app/views/users/_statistics.html.erb
+++ b/app/views/users/_statistics.html.erb
@@ -31,7 +31,7 @@
 
       <tr>
         <th>Upload Limit</th>
-        <td><%= presenter.upload_limit %></td>
+        <td><%= presenter.upload_limit %> (<%= link_to "help", wiki_pages_path(title: "about:upload_limits") %>)</td>
       </tr>
 
       <tr>


### PR DESCRIPTION
Fixes #3262:

* Allow mousing over the upload limit on profile pages to show the full formula for the upload limit calculation. In particular, show how the upload limit multiplier is derived from the deletion confidence.

* Makes it so that you can hover over your used upload slots to see the time remaining until your next available upload.

See screenshots below:

![screenshot 1](https://i.imgur.com/HcaLlKb.png)
![screenshot 2](https://i.imgur.com/CR5axXv.png)