### PR TITLE
update nginx config

### DIFF
--- a/script/install/nginx.danbooru.conf
+++ b/script/install/nginx.danbooru.conf
@@ -49,8 +49,7 @@ server {
     proxy_cache STATIC;
     proxy_ignore_headers Set-Cookie Cache-Control X-Accel-Expires Expires;
     proxy_cache_valid 200 48h;
-    proxy_cache_use_stale error timeout invalid_header updating http_500 http_5\
-02 http_503 http_504;
+    proxy_cache_use_stale error timeout invalid_header updating http_500 http_502 http_503 http_504;
     proxy_cache_key "$uri";
     proxy_cache_min_uses 2;
     add_header X-Cache-Status $upstream_cache_status;


### PR DESCRIPTION
On Ubuntu 16.04 LTS, the break in the config causes nginx to fail to restart