### PR TITLE
Keep auth_secure cookie from deviantart

### DIFF
--- a/app/logical/sources/strategies/deviant_art.rb
+++ b/app/logical/sources/strategies/deviant_art.rb
@@ -118,7 +118,7 @@ module Sources
       def agent
         @agent ||= begin
           mech = Mechanize.new
-          auth, userinfo = session_cookies(mech)
+          auth, userinfo, auth_secure = session_cookies(mech)
 
           if auth
             # This cookie needs to be set to allow viewing of mature works
@@ -136,6 +136,13 @@ module Sources
             cookie.domain = ".deviantart.com"
             cookie.path = "/"
             mech.cookie_jar.add(cookie)
+            
+            if auth_secure
+              cookie = Mechanize::Cookie.new("auth_secure", auth_secure)
+              cookie.domain = ".deviantart.com"
+              cookie.path = "/"
+              mech.cookie_jar.add(cookie)
+            end
           end
 
           mech
@@ -166,9 +173,10 @@ module Sources
 
           auth = mech.cookies.find { |cookie| cookie.name == "auth" }.try(:value)
           userinfo = mech.cookies.find { |cookie| cookie.name == "userinfo" }.try(:value)
+          auth_secure = mech.cookies.find { |cookie| cookie.name == "auth_secure" }.try(:value)
           mech.cookie_jar.clear
 
-          [auth, userinfo]
+          [auth, userinfo, auth_secure]
         end
       end
     end


### PR DESCRIPTION
This should fix #3260.

Unlike this projects, all other DA scrapers I found ([1][0], [2][1]) require that both
`auth` and `auth_secure` are set.
While the current approach, for some reason, seems to have worked fine in
the past, it has stopped functioning on some systems, sometimes
permanently (apparently sometimes only temporarily).
I don't have the means to find out the reason behind that, since all
configurations I've tried (mobile, VPN, and regular connection +
4 seperate accounts) resulted in me being effectively logged out and
unable to view mature works after deleting the `auth_secure` cookie.
The `if auth_cookie` part might not actually be necessary, its only
purpose is to prevent unintended breakage due to lack of information
on my part.

[0]: https://github.com/4pr0n/ripme/commit/b662b46a44a087af316953b10aee537397f2fa2a#diff-aab4e263d591d1c7f23d015a2e540a32R161
[1]: https://github.com/fake-name/xA-Scraper/commit/cbaecf55071de8ff40d21af514b48e5557c6a838#diff-9f9821e7d744874a2fe42e0a69e4b14aR33