### PR TITLE
Fix window resizing issue in mobile mode

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -27,7 +27,7 @@
       this.initialize_replace_image_dialog();
       this.initialize_gestures();
 
-      if ((Danbooru.meta("always-resize-images") === "true") || ((Danbooru.Cookie.get("dm") != "1") && (window.innerWidth <= 660))) {
+      if ((Danbooru.meta("always-resize-images") === "true") || ((Danbooru.Cookie.get("dm") !== "1") && (window.screen.width <= 660))) {
         $("#image-resize-to-window-link").click();
       }
     }


### PR DESCRIPTION
This issue was first brought up on the [Danbooru forums](http://danbooru.donmai.us/forum_topics/14489).

Basically, the user reported that the images were appearing at their full size instead of being resized for the mobile screen.  I investigated it with my Samsung Galaxy S6 using Chrome and confirmed the above issue.

Using the developer's console for Chrome on my desktop PC using the above mobile layout, I checked the variables and discovered that the culprit was the `window.innerWidth` variable.  It was being set to the window size to include the width of the full-size image.  I then checked Firefox's mobile layout using the same tools and saw that the `window.innerWidth` was being set to the actual screen size as it had previously done for both browsers.  So Chrome might have changed something recently...?

Regardless, the `window.screen.width` variable is still using the actual screen size, which I confirmed for both Firefox and Chrome.