### PR TITLE
Fixing dependencies for newer releases of Debian (>=9.0)

### DIFF
--- a/INSTALL.debian
+++ b/INSTALL.debian
@@ -33,8 +33,9 @@ export GITHUB_INSTALL_SCRIPTS=https://raw.githubusercontent.com/r888888888/danbo
 
 # Install packages
 echo "* Installing packages..."
+LIBSSL_DEV_PKG=$( verlt `lsb_release -sr` 9.0 && echo libssl-dev || echo libssl1.0-dev )
 apt-get update
-apt-get -y install build-essential automake libssl-dev libxml2-dev libxslt-dev ncurses-dev sudo libreadline-dev flex bison ragel memcached libmemcached-dev git curl libcurl4-openssl-dev imagemagick libmagickcore-dev libmagickwand-dev sendmail-bin sendmail postgresql postgresql-contrib libpq-dev postgresql-server-dev-all nginx ssh coreutils ffmpeg mkvtoolnix
+apt-get -y install build-essential automake $LIBSSL_DEV_PKG libxml2-dev libxslt-dev ncurses-dev sudo libreadline-dev flex bison ragel memcached libmemcached-dev git curl libcurl4-openssl-dev imagemagick libmagickcore-dev libmagickwand-dev sendmail-bin sendmail postgresql postgresql-contrib libpq-dev postgresql-server-dev-all nginx ssh coreutils ffmpeg mkvtoolnix
 
 if [ $? -ne 0 ]; then
   echo "* Error installing packages; aborting"


### PR DESCRIPTION
Starting in Debian 9.0, libssl1.0-dev is required for the install step of building Ruby 2.3.1.