### PR TITLE
Added searchbox link to responsive view

### DIFF
--- a/app/assets/stylesheets/specific/z_responsive.scss
+++ b/app/assets/stylesheets/specific/z_responsive.scss
@@ -4,8 +4,16 @@
   display: none;
 }
 
+#searchbox-redirect-link {
+  display: none;
+}
+
 @media screen and (max-width: 660px) {
   #desktop-version-link {
+    display: inline;
+  }
+
+  #searchbox-redirect-link {
     display: inline;
   }
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,6 +32,8 @@
         <% elsif @post_set.is_single_tag? && !@post_set.is_metatag_search? %>
           <li><%= link_to "Wiki", "#", :id => "show-excerpt-link" %></li>
         <% end %>
+
+        <li id="searchbox-redirect-link"><a href="#search-box">Search&raquo;</a></li>
       </menu>
 
       <%= render "posts/partials/index/edit" %>


### PR DESCRIPTION
I brought up the idea on the [Danbooru forum](http://danbooru.donmai.us/forum_topics/14535) about having an extra search box at the top of the post index due to the necessity to always having to scroll through ~50 rows of images to reach the search box.

@kittey however brought up the useful suggestion to just have a link at the top which redirects to the search box, which is a good compromise and relatively simple to code.

So the following presents a link next to the **Post**, **Wiki**, **Artist**, etc links at the top of the image content when in the responsive view.