### PR TITLE
Use current local storage size for pruning calculations

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -3,6 +3,9 @@
 
   Danbooru.Autocomplete.AUTOCOMPLETE_VERSION = 1;
 
+  //Just under 5MB of 16-bit characters
+  Danbooru.Autocomplete.MAX_STORAGE_SIZE = 2500000;
+
   Danbooru.Autocomplete.initialize_all = function() {
     if (Danbooru.meta("enable-auto-complete") === "true") {
       Danbooru.Autocomplete.enable_local_storage = this.test_local_storage();
@@ -25,7 +28,8 @@
   Danbooru.Autocomplete.prune_local_storage = function() {
     if (this.enable_local_storage) {
       var cached_autocomplete_version = $.localStorage.get("danbooru-autocomplete-version");
-      if (cached_autocomplete_version !== this.AUTOCOMPLETE_VERSION || $.localStorage.keys().length > 4000) {
+      var current_cache_size = $.localStorage.keys().reduce( function(total, key) { return total + localStorage[key].length; }, 0);
+      if (cached_autocomplete_version !== this.AUTOCOMPLETE_VERSION || current_cache_size > this.MAX_STORAGE_SIZE) {
         $.each($.localStorage.keys(), function(i, key) {
           if (key.substr(0, 3) === "ac-") {
             $.localStorage.remove(key);


### PR DESCRIPTION
This issue was brought to light as a result from the userscript I developed in [topic #14474](http://danbooru.donmai.us/forum_topics/14474).  Basically, the number of keys in local storage is not a good metric to measure how full the current storage is.

A userscript could store thousands of smaller values, which would trip an unnecessary pruning.  My userscript falls into this category, however at 4000 entries, it only entails around 210K characters being stored at around 50 characters per item.

Conversely, a userscript could store one massive value in local storage, but would not trip necessary pruning which could break the autocomplete.

The average Danbooru autocomplete stored item was observed to be around 600 characters (sampling around 1750 stored items).  With the current item limit of 4000, that turns out to be 2.4M character limit, which jives with what I observed from lowest common denominator Safari with a character limit of around 2.6M characters (checked at https://arty.name/localstorage.html).  Since characters are 16-bit, this turns to be around 5MB of storage, an often quoted limit for local storage.

The following code therefore sets the max number of characters at 2.5M, which is 100K short of the limit and should give enough leeway.  The *current_cache_size* calculation was observed to take around 200-400 ms on a slow machine, and 50-75 ms on a fast machine, but if this is an issue, the pruning function could always be offloaded to a later time via a **setTimeout** function.