### PR TITLE
Substitute nonusable period in local storage saves

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -218,7 +218,7 @@
   }
 
   Danbooru.Autocomplete.normal_source = function(term, resp) {
-    var key = "ac-" + term;
+    var key = "ac-" + term.replace(/\./g,'\uFFFF');
     if (this.enable_local_storage) {
       var cached = $.localStorage.get(key);
       if (cached) {


### PR DESCRIPTION
The [jQuery Web Storage API](https://plugins.jquery.com/storageapi/) uses the period '.' as a special character when saving and retrieving data.  It's telling the API that whatever is left of the period is the entry name, and whatever is to the right of it is an attribute of that entry.

So when a user types in '.', the program does a lookup in the "" entry with the "" attribute, which doesn't exist so the program throws an exception.  Basically, anything with a period is currently unstorable.

The following code therefore does a substitution of all periods with the Unicode character \uFFFF which is a [guaranteed non-character](http://www.fileformat.info/info/unicode/char/ffff/index.htm).