### PR TITLE
Use timeout on tag box cursor calculation

### DIFF
--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -261,8 +261,8 @@
       Danbooru.RelatedTag.process_artist(Danbooru.RelatedTag.recent_artist);
     }
 
-    $field.focus();
-    $field.prop('selectionStart', $field.val().length);
+    //The timeout is needed on Chrome since it will clobber the field attribute otherwise
+    setTimeout(function () { $field.prop('selectionStart', $field.val().length);}, 100);
     e.preventDefault();
   }
 


### PR DESCRIPTION
The fix on #3333 does work, however it uses the focus() function to accomplish this which switches focus back to the tag box. This works mostly fine on a large display, however on smaller displays, this causes the user to lose their view on the tags they're attempting to add. For tags on the bottom of the list, this necessitates scrolling back down after each tag add.

After experimenting, I found that setting a timeout on only the portion that updates the cursor value is sufficient to have it survive whatever Chrome is doing to clobber the cursor position normally. Using that instead, the cursor still gets updated however the focus isn't forced back to the tag box each time.