### PR TITLE
Skip validation of video duration if user is admin

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -101,8 +101,10 @@ class Upload < ApplicationRecord
     end
 
     def validate_video_duration
-      if is_video? && video.duration > 120
-        raise "video must not be longer than 2 minutes"
+      unless uploader.is_admin?
+        if is_video? && video.duration > 120
+          raise "video must not be longer than 2 minutes"
+        end
       end
     end
   end


### PR DESCRIPTION
Following the discussion [in this thread](http://danbooru.donmai.us/forum_topics/14593), this modifies the behavior of the upload validator to permit admins to bypass the length check on video. Because admins tend to be smart, and not stupid, I doubt that this feature will be abused.

This is more of a stop gap measure. @BrokenEagle's [solution](http://danbooru.donmai.us/forum_posts/137906) is far better suited towards a long term system, but I think it's unnecessary until exceptions to the upload limit start becoming a regularly requested thing.

Finally, I'd like to point out that [this comment](http://danbooru.donmai.us/forum_posts/137852) noted that flash animations don't have a length limit.

Edit: It's worth noting this solution really only solves my problem if at least one active admin uploads things, and is willing to upload on behalf of me. Personally, I've thought builders would be suited to this role but the thread consensus seemed to lean towards admin only.