### PR TITLE
Migrated tag logic into config file and added fifth tag category meta

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -9,6 +9,7 @@
   Danbooru.Autocomplete.initialize_all = function() {
     if (Danbooru.meta("enable-auto-complete") === "true") {
       Danbooru.Autocomplete.enable_local_storage = this.test_local_storage();
+      this.update_static_metatags();
       this.initialize_tag_autocomplete();
       this.initialize_mention_autocomplete();
       this.prune_local_storage();
@@ -94,7 +95,7 @@
     var $fields_multiple = $('[data-autocomplete="tag-query"], [data-autocomplete="tag-edit"]');
     var $fields_single = $('[data-autocomplete="tag"]');
 
-    var prefixes = "-|~|general:|gen:|artist:|art:|copyright:|copy:|co:|character:|char:|ch:";
+    var prefixes = "-|~|" + $.map(JSON.parse(Danbooru.meta("tag-category-names")), function (category) { return category + ':'}).join('|');
     var metatags = "order|-status|status|-rating|rating|-locked|locked|child|filetype|-filetype|" +
       "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-fav|fav|ordfav|" +
       "-pool|pool|ordpool|favgroup|-search|search";
@@ -326,10 +327,6 @@
       "portrait", "landscape",
       "filesize", "filesize_asc",
       "tagcount", "tagcount_asc",
-      "gentags", "gentags_asc",
-      "arttags", "arttags_asc",
-      "chartags", "chartags_asc",
-      "copytags", "copytags_asc",
       "rank",
       "random"
     ],
@@ -348,6 +345,11 @@
     filetype: [
       "jpg", "png", "gif", "swf", "zip", "webm", "mp4"
     ],
+  }
+
+  //This must be done as a separate function as Danbooru.meta does not exist at program initialization
+  Danbooru.Autocomplete.update_static_metatags = function () {
+    Array.prototype.push.apply(Danbooru.Autocomplete.static_metatags.order,$.map(JSON.parse(Danbooru.meta("short-tag-category-names")), function(shorttag) { return [shorttag + "tags", shorttag + "tags_asc"]}));
   }
 
   Danbooru.Autocomplete.static_metatag_source = function(term, resp, metatag) {

--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -12,10 +12,9 @@
 
   Danbooru.RelatedTag.initialize_buttons = function() {
     this.common_bind("#related-tags-button", "");
-    this.common_bind("#related-general-button", "general");
-    this.common_bind("#related-artists-button", "artist");
-    this.common_bind("#related-characters-button", "character");
-    this.common_bind("#related-copyrights-button", "copyright");
+    $.each(JSON.parse(Danbooru.meta("related-tag-button-list")), function(i,category) {
+      Danbooru.RelatedTag.common_bind("#related-" + category + "-button", category);
+    });
     $("#find-artist-button").click(Danbooru.RelatedTag.find_artist);
   }
 

--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -2,7 +2,7 @@
   Danbooru.RelatedTag = {};
 
   Danbooru.RelatedTag.initialize_all = function() {
-    if ($("#c-posts").length || $("#c-uploads").length) {
+    if ($("#c-posts #a-show").length || $("#c-uploads #a-new").length) {
       this.initialize_buttons();
       $("#related-tags-container").hide();
       $("#artist-tags-container").hide();

--- a/app/assets/stylesheets/specific/posts.scss
+++ b/app/assets/stylesheets/specific/posts.scss
@@ -211,6 +211,14 @@ body[data-user-can-approve-posts="true"] .post-preview {
   }
 }
 
+.category-5 a, a.tag-type-5, .ui-state-focus a.tag-type-5 {
+  color: #F80;
+
+  &:hover {
+    color: #FA6;
+  }
+}
+
 .category-banned a, a.tag-type-banned,, .ui-state-focus a.tag-type-banned {
   color: black;
   background-color: red;

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,7 +118,7 @@ class PostQueryBuilder
     relation = add_range_relation(q[:filesize], "posts.file_size", relation)
     relation = add_range_relation(q[:date], "posts.created_at", relation)
     relation = add_range_relation(q[:age], "posts.created_at", relation)
-    Danbooru.config.full_tag_config_info.each_key do |category|
+    TagCategory.categories.each do |category|
       relation = add_range_relation(q["#{category}_tag_count".to_sym], "posts.tag_count_#{category}", relation)
     end
     relation = add_range_relation(q[:post_tag_count], "posts.tag_count", relation)
@@ -511,11 +511,11 @@ class PostQueryBuilder
     when "tagcount_asc"
       relation = relation.order("posts.tag_count ASC")
 
-    when /(#{Danbooru.config.short_tag_name_mapping.keys.join("|")})tags(?:\Z|_desc)/
-      relation = relation.order("posts.tag_count_#{Danbooru.config.short_tag_name_mapping[$1]} DESC")
+    when /(#{TagCategory.short_name_regex})tags(?:\Z|_desc)/
+      relation = relation.order("posts.tag_count_#{TagCategory.short_name_mapping[$1]} DESC")
 
-    when /(#{Danbooru.config.short_tag_name_mapping.keys.join("|")})tags_asc/
-      relation = relation.order("posts.tag_count_#{Danbooru.config.short_tag_name_mapping[$1]} ASC")
+    when /(#{TagCategory.short_name_regex})tags_asc/
+      relation = relation.order("posts.tag_count_#{TagCategory.short_name_mapping[$1]} ASC")
 
     when "rank"
       relation = relation.order("log(3, posts.score) + (extract(epoch from posts.created_at) - extract(epoch from timestamp '2005-05-24')) / 35000 DESC")

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -118,10 +118,9 @@ class PostQueryBuilder
     relation = add_range_relation(q[:filesize], "posts.file_size", relation)
     relation = add_range_relation(q[:date], "posts.created_at", relation)
     relation = add_range_relation(q[:age], "posts.created_at", relation)
-    relation = add_range_relation(q[:general_tag_count], "posts.tag_count_general", relation)
-    relation = add_range_relation(q[:artist_tag_count], "posts.tag_count_artist", relation)
-    relation = add_range_relation(q[:copyright_tag_count], "posts.tag_count_copyright", relation)
-    relation = add_range_relation(q[:character_tag_count], "posts.tag_count_character", relation)
+    Danbooru.config.full_tag_config_info.each_key do |category|
+      relation = add_range_relation(q["#{category}_tag_count".to_sym], "posts.tag_count_#{category}", relation)
+    end
     relation = add_range_relation(q[:post_tag_count], "posts.tag_count", relation)
     relation = add_range_relation(q[:pixiv_id], "posts.pixiv_id", relation)
 
@@ -512,29 +511,11 @@ class PostQueryBuilder
     when "tagcount_asc"
       relation = relation.order("posts.tag_count ASC")
 
-    when "gentags", "gentags_desc"
-      relation = relation.order("posts.tag_count_general DESC")
+    when /(#{Danbooru.config.short_tag_name_mapping.keys.join("|")})tags(?:\Z|_desc)/
+      relation = relation.order("posts.tag_count_#{Danbooru.config.short_tag_name_mapping[$1]} DESC")
 
-    when "gentags_asc"
-      relation = relation.order("posts.tag_count_general ASC")
-
-    when "arttags", "arttags_desc"
-      relation = relation.order("posts.tag_count_artist DESC")
-
-    when "arttags_asc"
-      relation = relation.order("posts.tag_count_artist ASC")
-
-    when "chartags", "chartags_desc"
-      relation = relation.order("posts.tag_count_character DESC")
-
-    when "chartags_asc"
-      relation = relation.order("posts.tag_count_character ASC")
-
-    when "copytags", "copytags_desc"
-      relation = relation.order("posts.tag_count_copyright DESC")
-
-    when "copytags_asc"
-      relation = relation.order("posts.tag_count_copyright ASC")
+    when /(#{Danbooru.config.short_tag_name_mapping.keys.join("|")})tags_asc/
+      relation = relation.order("posts.tag_count_#{Danbooru.config.short_tag_name_mapping[$1]} ASC")
 
     when "rank"
       relation = relation.order("log(3, posts.score) + (extract(epoch from posts.created_at) - extract(epoch from timestamp '2005-05-24')) / 35000 DESC")

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -1,0 +1,78 @@
+class TagCategory
+  module Mappings
+    # Returns a hash mapping various tag categories to a numerical value.
+    def mapping
+      @@mapping ||= Hash[
+          Danbooru.config.full_tag_config_info.map {|k,v|  v["extra"].map {|y| [y,v["category"]]}}
+          .reduce([],:+)]
+        .update(Hash[Danbooru.config.full_tag_config_info.map {|k,v|  [v["short"],v["category"]]}])
+        .update( Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["category"]]}])
+    end
+
+    # Returns a hash mapping more suited for views
+    def canonical_mapping
+      @@canonical_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k.capitalize,v["category"]]}]
+    end
+
+    # Returns a hash mapping numerical category values to their string equivalent.
+    def reverse_mapping
+      @@reverse_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [v["category"],k]}]
+    end
+
+    # Returns a hash mapping for the short name usage in metatags
+    def short_name_mapping
+      @@short_name_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [v["short"],k]}]
+    end
+
+    # Returns a hash mapping for humanized_essential_tag_string (models/post.rb)
+    def humanized_mapping
+      @@humanized_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["humanized"]]}]
+    end
+
+    # Returns a hash mapping for humanized_essential_tag_string (models/post.rb)
+    def header_mapping
+      @@header_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["header"]]}]
+    end
+
+    # Returns a hash mapping for related tag buttons (javascripts/related_tag.js)
+    def related_button_mapping
+      @@related_button_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["relatedbutton"]]}]
+    end
+  end
+
+  module Lists
+    def categories
+      @@categories ||= Danbooru.config.full_tag_config_info.keys
+    end
+
+    def short_name_list
+      @@short_name_list ||= short_name_mapping.keys
+    end
+
+    def humanized_list
+      Danbooru.config.humanized_tag_category_list
+    end
+
+    def split_header_list
+      Danbooru.config.split_tag_header_list
+    end
+
+    def categorized_list
+      Danbooru.config.categorized_tag_list
+    end
+
+    def related_button_list
+      Danbooru.config.related_tag_button_list
+    end
+  end
+
+  module Regexes
+    def short_name_regex
+      @@short_name_regex ||= short_name_list.join("|")
+    end
+  end
+
+  extend Mappings
+  extend Lists
+  extend Regexes
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -616,30 +616,21 @@ class Post < ApplicationRecord
       Post.expire_cache_for_all([""]) if new_record? || id <= 100_000
     end
 
+    def set_tag_count(category,tagcount)
+      self.send("tag_count_#{category}=",tagcount)
+    end
+
+    def inc_tag_count(category)
+      set_tag_count(category,self.send("tag_count_#{category}") + 1)
+    end
+
     def set_tag_counts
       self.tag_count = 0
-      self.tag_count_general = 0
-      self.tag_count_artist = 0
-      self.tag_count_copyright = 0
-      self.tag_count_character = 0
-
+      Danbooru.config.full_tag_config_info.each_key {|x| set_tag_count(x,0)}
       categories = Tag.categories_for(tag_array, :disable_caching => true)
       categories.each_value do |category|
         self.tag_count += 1
-
-        case category
-        when Tag.categories.general
-          self.tag_count_general += 1
-
-        when Tag.categories.artist
-          self.tag_count_artist += 1
-
-        when Tag.categories.copyright
-          self.tag_count_copyright += 1
-
-        when Tag.categories.character
-          self.tag_count_character += 1
-        end
+        inc_tag_count(Danbooru.config.reverse_tag_category_mapping[category])
       end
     end
 
@@ -918,26 +909,6 @@ class Post < ApplicationRecord
       @tag_categories ||= Tag.categories_for(tag_array)
     end
 
-    def copyright_tags
-      typed_tags("copyright")
-    end
-
-    def character_tags
-      typed_tags("character")
-    end
-
-    def artist_tags
-      typed_tags("artist")
-    end
-
-    def artist_tags_excluding_hidden
-      artist_tags - %w(banned_artist)
-    end
-
-    def general_tags
-      typed_tags("general")
-    end
-
     def typed_tags(name)
       @typed_tags ||= {}
       @typed_tags[name] ||= begin
@@ -955,51 +926,36 @@ class Post < ApplicationRecord
       @humanized_essential_tag_string ||= Cache.get("hets-#{id}", 1.hour.to_i) do
         string = []
 
-        if character_tags.any?
-          chartags = character_tags.slice(0, 5)
-          if character_tags.length > 5
-            chartags << "others"
+        Danbooru.config.humanized_tag_category_list.each do |category|
+          humanizeddata = Danbooru.config.full_tag_config_info[category]["humanized"]
+          typetags = typed_tags(category) - humanizeddata["exclusion"]
+          if humanizeddata["slice"] > 0
+            typetags = typetags.slice(0,humanizeddata["slice"]) + (typetags.length > humanizeddata["slice"] ? ["others"] : [])
           end
-          chartags = chartags.map do |tag|
-            tag.match(/^(.+?)(?:_\(.+\))?$/)[1]
+          if humanizeddata["regexmap"] != //
+            typetags = typetags.map do |tag|
+              tag.match(humanizeddata["regexmap"])[1]
+            end
           end
-          string << chartags.to_sentence
-        end
-
-        if copyright_tags.any?
-          copytags = copyright_tags.slice(0, 5)
-          if copyright_tags.length > 5
-            copytags << "others"
+          if typetags.any?
+            if category != "copyright" || typed_tags("character").any?
+              string << humanizeddata["formatstr"] % typetags.to_sentence
+            else
+              string << typetags.to_sentence
+            end
           end
-          copytags = copytags.to_sentence
-          string << (character_tags.any? ? "(#{copytags})" : copytags)
         end
-
-        if artist_tags_excluding_hidden.any?
-          string << "drawn by"
-          string << artist_tags_excluding_hidden.to_sentence
-        end
-
         string.empty? ? "##{id}" : string.join(" ").tr("_", " ")
       end
     end
 
-    def tag_string_copyright
-      copyright_tags.join(" ")
-    end
-
-    def tag_string_character
-      character_tags.join(" ")
-    end
-
-    def tag_string_artist
-      artist_tags.join(" ")
-    end
-
-    def tag_string_general
-      general_tags.join(" ")
+    Danbooru.config.full_tag_config_info.each_key do |category|
+      define_method("tag_string_#{category}") do
+        typed_tags(category).join(" ")
+      end
     end
   end
+
 
   module FavoriteMethods
     def clean_fav_string?
@@ -1182,15 +1138,10 @@ class Post < ApplicationRecord
   end
 
   module CountMethods
-    def fix_post_counts
+    def fix_post_counts(post)
       post.set_tag_counts
-      post.update_columns(
-        :tag_count => post.tag_count,
-        :tag_count_general => post.tag_count_general,
-        :tag_count_artist => post.tag_count_artist,
-        :tag_count_copyright => post.tag_count_copyright,
-        :tag_count_character => post.tag_count_character
-      )
+      args = Hash[Danbooru.config.full_tag_config_info.keys.map {|x| ["tag_count_#{x}",post.send("tag_count_#{x}")]}].update(:tag_count => post.tag_count)
+      post.update_columns(args)
     end
 
     def get_count_from_cache(tags)
@@ -1572,7 +1523,7 @@ class Post < ApplicationRecord
     end
 
     def method_attributes
-      list = super + [:uploader_name, :has_large, :tag_string_artist, :tag_string_character, :tag_string_copyright, :tag_string_general, :has_visible_children, :children_ids]
+      list = super + [:uploader_name, :has_large, :has_visible_children, :children_ids] + Danbooru.config.full_tag_config_info.keys.map {|x| "tag_string_#{x}".to_sym}
       if visible?
         list += [:file_url, :large_file_url, :preview_file_url]
       end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -317,19 +317,19 @@ class Tag < ApplicationRecord
       when :filesize
         object =~ /\A(\d+(?:\.\d*)?|\d*\.\d+)([kKmM]?)[bB]?\Z/
 
-      	size = $1.to_f
-      	unit = $2
+        size = $1.to_f
+        unit = $2
 
-      	conversion_factor = case unit
-    	  when /m/i
-    	    1024 * 1024
-    	  when /k/i
-    	    1024
-    	  else
-    	    1
-  	    end
+        conversion_factor = case unit
+        when /m/i
+          1024 * 1024
+        when /k/i
+          1024
+        else
+          1
+        end
 
-  	    (size * conversion_factor).to_i
+        (size * conversion_factor).to_i
       end
     end
 
@@ -429,296 +429,298 @@ class Tag < ApplicationRecord
         q[:tag_count] += 1 unless token == "status:deleted" || token =~ /\Alimit:.+\Z/
 
         if token =~ /\A(#{METATAGS}):(.+)\Z/i
-          case $1.downcase
+          g1 = $1.downcase
+          g2 = $2
+          case g1
           when "-user"
             q[:uploader_id_neg] ||= []
-            user_id = User.name_to_id($2)
+            user_id = User.name_to_id(g2)
             q[:uploader_id_neg] << user_id unless user_id.blank?
 
           when "user"
-            user_id = User.name_to_id($2)
+            user_id = User.name_to_id(g2)
             q[:uploader_id] = user_id unless user_id.blank?
 
           when "-approver"
-            if $2 == "none"
+            if g2 == "none"
               q[:approver_id] = "any"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:approver_id] = "none"
             else
               q[:approver_id_neg] ||= []
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:approver_id_neg] << user_id unless user_id.blank?
             end
 
           when "approver"
-            if $2 == "none"
+            if g2 == "none"
               q[:approver_id] = "none"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:approver_id] = "any"
             else
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:approver_id] = user_id unless user_id.blank?
             end
 
           when "flagger"
             q[:flagger_ids] ||= []
 
-            if $2 == "none"
+            if g2 == "none"
               q[:flagger_ids] << "none"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:flagger_ids] << "any"
             else
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:flagger_ids] << user_id unless user_id.blank?
             end
 
           when "-flagger"
-            if $2 == "none"
+            if g2 == "none"
               q[:flagger_ids] ||= []
               q[:flagger_ids] << "any"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:flagger_ids] ||= []
               q[:flagger_ids] << "none"
             else
               q[:flagger_ids_neg] ||= []
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:flagger_ids_neg] << user_id unless user_id.blank?
             end
 
           when "appealer"
             q[:appealer_ids] ||= []
 
-            if $2 == "none"
+            if g2 == "none"
               q[:appealer_ids] << "none"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:appealer_ids] << "any"
             else
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:appealer_ids] << user_id unless user_id.blank?
             end
 
           when "-appealer"
-            if $2 == "none"
+            if g2 == "none"
               q[:appealer_ids] ||= []
               q[:appealer_ids] << "any"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:appealer_ids] ||= []
               q[:appealer_ids] << "none"
             else
               q[:appealer_ids_neg] ||= []
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:appealer_ids_neg] << user_id unless user_id.blank?
             end
 
           when "commenter", "comm"
             q[:commenter_ids] ||= []
 
-            if $2 == "none"
+            if g2 == "none"
               q[:commenter_ids] << "none"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:commenter_ids] << "any"
             else
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:commenter_ids] << user_id unless user_id.blank?
             end
 
           when "noter"
             q[:noter_ids] ||= []
 
-            if $2 == "none"
+            if g2 == "none"
               q[:noter_ids] << "none"
-            elsif $2 == "any"
+            elsif g2 == "any"
               q[:noter_ids] << "any"
             else
-              user_id = User.name_to_id($2)
+              user_id = User.name_to_id(g2)
               q[:noter_ids] << user_id unless user_id.blank?
             end
 
           when "noteupdater"
             q[:note_updater_ids] ||= []
-            user_id = User.name_to_id($2)
+            user_id = User.name_to_id(g2)
             q[:note_updater_ids] << user_id unless user_id.blank?
 
           when "artcomm"
             q[:artcomm_ids] ||= []
-            user_id = User.name_to_id($2)
+            user_id = User.name_to_id(g2)
             q[:artcomm_ids] << user_id unless user_id.blank?
 
           when "-pool"
-            if $2.downcase == "none"
+            if g2.downcase == "none"
               q[:pool] = "any"
-            elsif $2.downcase == "any"
+            elsif g2.downcase == "any"
               q[:pool] = "none"
-            elsif $2.downcase == "series"
+            elsif g2.downcase == "series"
               q[:tags][:exclude] << "pool:series"
-            elsif $2.downcase == "collection"
+            elsif g2.downcase == "collection"
               q[:tags][:exclude] << "pool:collection"
             else
-              q[:tags][:exclude] << "pool:#{Pool.name_to_id($2)}"
+              q[:tags][:exclude] << "pool:#{Pool.name_to_id(g2)}"
             end
 
           when "pool"
-            if $2.downcase == "none"
+            if g2.downcase == "none"
               q[:pool] = "none"
-            elsif $2.downcase == "any"
+            elsif g2.downcase == "any"
               q[:pool] = "any"
-            elsif $2.downcase == "series"
+            elsif g2.downcase == "series"
               q[:tags][:related] << "pool:series"
-            elsif $2.downcase == "collection"
+            elsif g2.downcase == "collection"
               q[:tags][:related] << "pool:collection"
-            elsif $2.include?("*")
-              pools = Pool.name_matches($2).select("id").limit(Danbooru.config.tag_query_limit).order("post_count DESC")
+            elsif g2.include?("*")
+              pools = Pool.name_matches(g2).select("id").limit(Danbooru.config.tag_query_limit).order("post_count DESC")
               q[:tags][:include] += pools.map {|pool| "pool:#{pool.id}"}
             else
-              q[:tags][:related] << "pool:#{Pool.name_to_id($2)}"
+              q[:tags][:related] << "pool:#{Pool.name_to_id(g2)}"
             end
 
           when "ordpool"
-            pool_id = Pool.name_to_id($2)
+            pool_id = Pool.name_to_id(g2)
             q[:tags][:related] << "pool:#{pool_id}"
             q[:ordpool] = pool_id
 
           when "-favgroup"
-            favgroup_id = FavoriteGroup.name_to_id($2)
+            favgroup_id = FavoriteGroup.name_to_id(g2)
             q[:favgroups_neg] ||= []
             q[:favgroups_neg] << favgroup_id
 
           when "favgroup"
-            favgroup_id = FavoriteGroup.name_to_id($2)
+            favgroup_id = FavoriteGroup.name_to_id(g2)
             q[:favgroups] ||= []
             q[:favgroups] << favgroup_id
 
           when "-fav"
-            q[:tags][:exclude] << "fav:#{User.name_to_id($2)}"
+            q[:tags][:exclude] << "fav:#{User.name_to_id(g2)}"
 
           when "fav"
-            q[:tags][:related] << "fav:#{User.name_to_id($2)}"
+            q[:tags][:related] << "fav:#{User.name_to_id(g2)}"
 
           when "ordfav"
-            user_id = User.name_to_id($2)
+            user_id = User.name_to_id(g2)
             q[:tags][:related] << "fav:#{user_id}"
             q[:ordfav] = user_id
 
           when "search"
             q[:saved_searches] ||= []
-            q[:saved_searches] << $2
+            q[:saved_searches] << g2
 
           when "md5"
-            q[:md5] = $2.downcase.split(/,/)
+            q[:md5] = g2.downcase.split(/,/)
 
           when "-rating"
-            q[:rating_negated] = $2.downcase
+            q[:rating_negated] = g2.downcase
 
           when "rating"
-            q[:rating] = $2.downcase
+            q[:rating] = g2.downcase
 
           when "-locked"
-            q[:locked_negated] = $2.downcase
+            q[:locked_negated] = g2.downcase
 
           when "locked"
-            q[:locked] = $2.downcase
+            q[:locked] = g2.downcase
 
           when "id"
-            q[:post_id] = parse_helper($2)
+            q[:post_id] = parse_helper(g2)
 
           when "-id"
-            q[:post_id_negated] = $2.to_i
+            q[:post_id_negated] = g2.to_i
 
           when "width"
-            q[:width] = parse_helper($2)
+            q[:width] = parse_helper(g2)
 
           when "height"
-            q[:height] = parse_helper($2)
+            q[:height] = parse_helper(g2)
 
           when "mpixels"
-            q[:mpixels] = parse_helper_fudged($2, :float)
+            q[:mpixels] = parse_helper_fudged(g2, :float)
 
           when "ratio"
-            q[:ratio] = parse_helper($2, :ratio)
+            q[:ratio] = parse_helper(g2, :ratio)
 
           when "score"
-            q[:score] = parse_helper($2)
+            q[:score] = parse_helper(g2)
 
           when "favcount"
-            q[:fav_count] = parse_helper($2)
+            q[:fav_count] = parse_helper(g2)
 
           when "filesize"
-      	    q[:filesize] = parse_helper_fudged($2, :filesize)
+            q[:filesize] = parse_helper_fudged(g2, :filesize)
 
           when "source"
-            src = $2.gsub(/\A"(.*)"\Z/, '\1')
+            src = g2.gsub(/\A"(.*)"\Z/, '\1')
             q[:source] = (src.to_escaped_for_sql_like + "%").gsub(/%+/, '%')
 
           when "-source"
-            src = $2.gsub(/\A"(.*)"\Z/, '\1')
+            src = g2.gsub(/\A"(.*)"\Z/, '\1')
             q[:source_neg] = (src.to_escaped_for_sql_like + "%").gsub(/%+/, '%')
 
           when "date"
-            q[:date] = parse_helper($2, :date)
+            q[:date] = parse_helper(g2, :date)
 
           when "age"
-            q[:age] = reverse_parse_helper(parse_helper($2, :age))
+            q[:age] = reverse_parse_helper(parse_helper(g2, :age))
 
           when "tagcount"
-            q[:post_tag_count] = parse_helper($2)
+            q[:post_tag_count] = parse_helper(g2)
 
           when "gentags"
-            q[:general_tag_count] = parse_helper($2)
+            q[:general_tag_count] = parse_helper(g2)
 
           when "arttags"
-            q[:artist_tag_count] = parse_helper($2)
+            q[:artist_tag_count] = parse_helper(g2)
 
           when "chartags"
-            q[:character_tag_count] = parse_helper($2)
+            q[:character_tag_count] = parse_helper(g2)
 
           when "copytags"
-            q[:copyright_tag_count] = parse_helper($2)
+            q[:copyright_tag_count] = parse_helper(g2)
 
           when "parent"
-            q[:parent] = $2.downcase
+            q[:parent] = g2.downcase
 
           when "-parent"
-            if $2.downcase == "none"
+            if g2.downcase == "none"
               q[:parent] = "any"
-            elsif $2.downcase == "any"
+            elsif g2.downcase == "any"
               q[:parent] = "none"
             else
               q[:parent_neg_ids] ||= []
-              q[:parent_neg_ids] << $2.downcase
+              q[:parent_neg_ids] << g2.downcase
             end
 
           when "child"
-            q[:child] = $2.downcase
+            q[:child] = g2.downcase
 
           when "order"
-            q[:order] = $2.downcase
+            q[:order] = g2.downcase
 
           when "limit"
             # Do nothing. The controller takes care of it.
 
           when "-status"
-            q[:status_neg] = $2.downcase
+            q[:status_neg] = g2.downcase
 
           when "status"
-            q[:status] = $2.downcase
+            q[:status] = g2.downcase
 
           when "filetype"
-            q[:filetype] = $2.downcase
+            q[:filetype] = g2.downcase
 
           when "-filetype"
-            q[:filetype_neg] = $2.downcase
+            q[:filetype_neg] = g2.downcase
 
           when "pixiv_id", "pixiv"
-            q[:pixiv_id] = parse_helper($2)
+            q[:pixiv_id] = parse_helper(g2)
 
           when "upvote"
             if CurrentUser.user.is_moderator?
-              q[:upvote] = User.name_to_id($2)
+              q[:upvote] = User.name_to_id(g2)
             end
 
           when "downvote"
             if CurrentUser.user.is_moderator?
-              q[:downvote] = User.name_to_id($2)
+              q[:downvote] = User.name_to_id(g2)
             end
 
           end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -27,7 +27,7 @@ class Tag < ApplicationRecord
 
   class CategoryMapping
     Danbooru.config.reverse_tag_category_mapping.each do |value, category|
-      define_method(category.downcase) do
+      define_method(category) do
         value
       end
     end
@@ -124,7 +124,7 @@ class Tag < ApplicationRecord
     end
 
     def category_name
-      Danbooru.config.reverse_tag_category_mapping[category]
+      Danbooru.config.reverse_tag_category_mapping[category].capitalize
     end
 
     def update_category_cache_for_all

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -132,7 +132,7 @@ class PostPresenter < Presenter
   def categorized_tag_groups
     string = []
 
-    Danbooru.config.categorized_tag_list.each do |category|
+    TagCategory.categorized_list.each do |category|
       if @post.typed_tags(category).any?
         string << @post.typed_tags(category).join(" ")
       end

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -129,48 +129,24 @@ class PostPresenter < Presenter
     @post.humanized_essential_tag_string
   end
 
-  def categorized_tag_string
+  def categorized_tag_groups
     string = []
 
-    if @post.copyright_tags.any?
-      string << @post.copyright_tags.join(" ")
+    Danbooru.config.categorized_tag_list.each do |category|
+      if @post.typed_tags(category).any?
+        string << @post.typed_tags(category).join(" ")
+      end
     end
+    
+    string
+  end
 
-    if @post.character_tags.any?
-      string << @post.character_tags.join(" ")
-    end
-
-    if @post.artist_tags.any?
-      string << @post.artist_tags.join(" ")
-    end
-
-    if @post.general_tags.any?
-      string << @post.general_tags.join(" ")
-    end
-
-    string.join(" \n")
+  def categorized_tag_string
+    categorized_tag_groups.join(" \n")
   end
 
   def humanized_categorized_tag_string
-    string = []
-
-    if @post.copyright_tags.any?
-      string << @post.copyright_tags
-    end
-
-    if @post.character_tags.any?
-      string << @post.character_tags
-    end
-
-    if @post.artist_tags.any?
-      string << @post.artist_tags
-    end
-
-    if @post.general_tags.any?
-      string << @post.general_tags
-    end
-
-    string.flatten.slice(0, 25).join(", ").tr("_", " ")
+    categorized_tag_groups.flatten.slice(0, 25).join(", ").tr("_", " ")
   end
 
   def image_html(template)

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -25,40 +25,16 @@ class TagSetPresenter < Presenter
   def split_tag_list_html(template, options = {})
     html = ""
 
-    if copyright_tags.any?
-      html << '<h2>Copyrights</h2>'
-      html << "<ul>"
-      copyright_tags.keys.each do |tag|
-        html << build_list_item(tag, template, options)
+    Danbooru.config.split_tag_header_list.each do |category|
+      typetags = typed_tags(category)
+      if typetags.any?
+        html << Danbooru.config.full_tag_config_info[category]["header"]
+        html << "<ul>"
+        typetags.each do |tag|
+          html << build_list_item(tag, template, options)
+        end
+        html << "</ul>"
       end
-      html << "</ul>"
-    end
-
-    if character_tags.any?
-      html << '<h2>Characters</h2>'
-      html << "<ul>"
-      character_tags.keys.each do |tag|
-        html << build_list_item(tag, template, options)
-      end
-      html << "</ul>"
-    end
-
-    if artist_tags.any?
-      html << '<h2>Artist</h2>'
-      html << "<ul>"
-      artist_tags.keys.each do |tag|
-        html << build_list_item(tag, template, options)
-      end
-      html << "</ul>"
-    end
-
-    if general_tags.any?
-      html << '<h1>Tags</h1>'
-      html << "<ul>"
-      general_tags.keys.each do |tag|
-        html << build_list_item(tag, template, options)
-      end
-      html << "</ul>"
     end
 
     html.html_safe
@@ -76,20 +52,13 @@ class TagSetPresenter < Presenter
   end
 
 private
-  def general_tags
-    @general_tags ||= categories.select {|k, v| v == Tag.categories.general}
-  end
-
-  def copyright_tags
-    @copyright_tags ||= categories.select {|k, v| v == Tag.categories.copyright}
-  end
-
-  def character_tags
-    @character_tags ||= categories.select {|k, v| v == Tag.categories.character}
-  end
-
-  def artist_tags
-    @artist_tags ||= categories.select {|k, v| v == Tag.categories.artist}
+  def typed_tags(name)
+    @typed_tags ||= {}
+    @typed_tags[name] ||= begin
+      @tags.select do |tag|
+        categories[tag] == Danbooru.config.tag_category_mapping[name]
+      end
+    end
   end
 
   def categories

--- a/app/presenters/tag_set_presenter.rb
+++ b/app/presenters/tag_set_presenter.rb
@@ -25,10 +25,10 @@ class TagSetPresenter < Presenter
   def split_tag_list_html(template, options = {})
     html = ""
 
-    Danbooru.config.split_tag_header_list.each do |category|
+    TagCategory.split_header_list.each do |category|
       typetags = typed_tags(category)
       if typetags.any?
-        html << Danbooru.config.full_tag_config_info[category]["header"]
+        html << TagCategory.header_mapping[category]
         html << "<ul>"
         typetags.each do |tag|
           html << build_list_item(tag, template, options)
@@ -56,7 +56,7 @@ private
     @typed_tags ||= {}
     @typed_tags[name] ||= begin
       @tags.select do |tag|
-        categories[tag] == Danbooru.config.tag_category_mapping[name]
+        categories[tag] == TagCategory.mapping[name]
       end
     end
   end

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -8,6 +8,8 @@
   <% unless cookies[:dm] %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
   <% end %>
+  <meta name="tag-category-names" content="<%= Danbooru.config.tag_category_mapping.keys %>">
+  <meta name="short-tag-category-names" content="<%= Danbooru.config.short_tag_name_mapping.keys %>">
   <meta name="current-user-name" content="<%= CurrentUser.name %>">
   <meta name="current-user-id" content="<%= CurrentUser.id %>">
   <meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -8,8 +8,8 @@
   <% unless cookies[:dm] %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
   <% end %>
-  <meta name="tag-category-names" content="<%= Danbooru.config.tag_category_mapping.keys %>">
-  <meta name="short-tag-category-names" content="<%= Danbooru.config.short_tag_name_mapping.keys %>">
+  <meta name="tag-category-names" content="<%= TagCategory.categories %>">
+  <meta name="short-tag-category-names" content="<%= TagCategory.short_name_list %>">
   <meta name="current-user-name" content="<%= CurrentUser.name %>">
   <meta name="current-user-id" content="<%= CurrentUser.id %>">
   <meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -78,8 +78,8 @@
 
     <%= button_tag "Related tags", :id => "related-tags-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
 
-    <% Danbooru.config.related_tag_button_list.each do |category| %>
-      <%= button_tag "#{Danbooru.config.full_tag_config_info[category]["relatedtag"]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+    <% TagCategory.related_button_list.each do |category| %>
+      <%= button_tag "#{TagCategory.related_button_mapping[category]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
     <% end %>
   </div>
 

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -77,10 +77,10 @@
     </div>
 
     <%= button_tag "Related tags", :id => "related-tags-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-    <%= button_tag "General", :id => "related-general-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-    <%= button_tag "Artists", :id => "related-artists-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-    <%= button_tag "Characters", :id => "related-characters-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-    <%= button_tag "Copyrights", :id => "related-copyrights-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+
+    <% Danbooru.config.related_tag_button_list.each do |category| %>
+      <%= button_tag "#{Danbooru.config.full_tag_config_info[category]["relatedtag"]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+    <% end %>
   </div>
 
   <div class="input">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -153,7 +153,7 @@
 <% end %>
 
 <% content_for(:html_header) do %>
-  <meta name="related-tag-button-list" content="<%= Danbooru.config.related_tag_button_list %>">
+  <meta name="related-tag-button-list" content="<%= TagCategory.related_button_list %>">
   <meta name="description" content="<%= @post.presenter.humanized_tag_string %>">
   <meta name="tags" content="<%= @post.tag_string %>">
   <meta name="favorites" content="<%= @post.fav_string %>">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -153,6 +153,7 @@
 <% end %>
 
 <% content_for(:html_header) do %>
+  <meta name="related-tag-button-list" content="<%= Danbooru.config.related_tag_button_list %>">
   <meta name="description" content="<%= @post.presenter.humanized_tag_string %>">
   <meta name="tags" content="<%= @post.tag_string %>">
   <meta name="favorites" content="<%= @post.fav_string %>">

--- a/app/views/related_tags/show.html.erb
+++ b/app/views/related_tags/show.html.erb
@@ -3,7 +3,7 @@
   <section>
     <%= form_tag(related_tag_path, :method => :get) do %>
       <%= text_field_tag "query", params[:query], :data => { :autocomplete => "tag" } %>
-      <%= select_tag "category", options_for_select([""] + Danbooru.config.canonical_tag_category_mapping.map{|x| [x.first, x.first.downcase]}, params[:category]) %>
+      <%= select_tag "category", options_for_select([""] + TagCategory.canonical_mapping.map{|x| [x.first, x.first.downcase]}, params[:category]) %>
       <%= submit_tag "Show"%>
     <% end %>
   </section>

--- a/app/views/tag_aliases/index.html.erb
+++ b/app/views/tag_aliases/index.html.erb
@@ -3,7 +3,7 @@
     <%= simple_form_for(:search, method: :get, url: tag_aliases_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
       <%= f.input :status, label: "Status", collection: ["", "Approved", "Pending"], selected: params[:search][:status] %>
-      <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
+      <%= f.input :category, label: "Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
       <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
       <%= f.submit "Search" %>
     <% end %>

--- a/app/views/tag_implications/index.html.erb
+++ b/app/views/tag_implications/index.html.erb
@@ -3,7 +3,7 @@
     <%= simple_form_for(:search, method: :get, url: tag_implications_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :name_matches, label: "Name", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
       <%= f.input :status, label: "Status", collection: ["", "Approved", "Pending"], selected: params[:search][:status] %>
-      <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
+      <%= f.input :category, label: "Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true, selected: params[:search][:category] %>
       <%= f.input :order, label: "Order", collection: [%w[Status status], %w[Recently\ created created_at], %w[Recently\ updated updated_at], %w[Name name], %w[Tag\ count tag_count]], selected: params[:search][:order] %>
       <%= f.submit "Search" %>
     <% end %>

--- a/app/views/tags/_search.html.erb
+++ b/app/views/tags/_search.html.erb
@@ -1,6 +1,6 @@
 <%= simple_form_for(:search, url: tags_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :name_matches, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name_matches], data: { autocomplete: "tag" } } %>
-  <%= f.input :category, label: "Category", collection: Danbooru.config.canonical_tag_category_mapping.to_a, include_blank: true,selected: params[:search][:category] %>
+  <%= f.input :category, label: "Category", collection: TagCategory.canonical_mapping.to_a, include_blank: true,selected: params[:search][:category] %>
   <%= f.input :order, collection: [%w[Newest date], %w[Count count], %w[Name name]], include_blank: false, selected: params[:search][:order] %>
   <%= f.input :hide_empty, label: "Hide empty?", collection: %w[yes no], selected: params[:search][:hide_empty] %>
   <%= f.input :has_wiki, label: "Has wiki?", collection: %w[yes no], include_blank: true, selected: params[:search][:has_wiki] %>

--- a/app/views/tags/edit.html.erb
+++ b/app/views/tags/edit.html.erb
@@ -6,7 +6,7 @@
       <% if @tag.is_locked? %>
         <p>This tag is category locked</p>
       <% else %>
-        <%= f.input :category, :collection => Danbooru.config.canonical_tag_category_mapping.to_a, :include_blank => false %>
+        <%= f.input :category, :collection => TagCategory.canonical_mapping.to_a, :include_blank => false %>
       <% end %>
 
       <% if CurrentUser.is_moderator? %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -109,10 +109,10 @@
           </div>
 
           <%= button_tag "Related tags", :id => "related-tags-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <%= button_tag "General", :id => "related-general-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <%= button_tag "Artists", :id => "related-artists-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <%= button_tag "Characters", :id => "related-characters-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <%= button_tag "Copyrights", :id => "related-copyrights-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+
+          <% Danbooru.config.related_tag_button_list.each do |category| %>
+            <%= button_tag "#{Danbooru.config.full_tag_config_info[category]["relatedtag"]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+          <% end %>
         </div>
 
         <div class="input">
@@ -139,6 +139,10 @@
 
 <% content_for(:page_title) do %>
   Upload - <%= Danbooru.config.app_name %>
+<% end %>
+
+<% content_for(:html_header) do %>
+  <meta name="related-tag-button-list" content="<%= Danbooru.config.related_tag_button_list %>">
 <% end %>
 
 <%= render "posts/partials/common/secondary_links" %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -110,9 +110,9 @@
 
           <%= button_tag "Related tags", :id => "related-tags-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
 
-          <% Danbooru.config.related_tag_button_list.each do |category| %>
-            <%= button_tag "#{Danbooru.config.full_tag_config_info[category]["relatedtag"]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <% end %>
+        <% TagCategory.related_button_list.each do |category| %>
+          <%= button_tag "#{TagCategory.related_button_mapping[category]}", :id => "related-#{category}-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
+        <% end %>
         </div>
 
         <div class="input">

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -214,31 +214,58 @@ module Danbooru
       "albert"
     end
 
+#TAG CONFIGURATION
+
     #Full tag configuration info for all tags
     def full_tag_config_info
       @full_tag_category_mapping ||= {
         "general" => {
           "category" => 0,
           "short" => "gen",
-          "extra" => []
+          "extra" => [],
+          "header" => "<h1>Tags</h1>",
+          "humanized" => nil
         },
         "character" => {
           "category" => 4,
           "short" => "char",
-          "extra" => ["ch"]
+          "extra" => ["ch"],
+          "header" => "<h2>Characters</h2>",
+          "humanized" => {
+            "slice" => 5,
+            "exclusion" => [],
+            "regexmap" => /^(.+?)(?:_\(.+\))?$/,
+            "formatstr" => "%s"
+          }
         },
         "copyright" => {
           "category" => 3,
           "short" => "copy",
-          "extra" => ["co"]
+          "extra" => ["co"],
+          "header" => "<h2>Copyrights</h2>",
+          "humanized" => {
+            "slice" => 5,
+            "exclusion" => [],
+            "regexmap" => //,
+            "formatstr" => "(%s)"
+          }
         },
         "artist" => {
           "category" => 1,
           "short" => "art",
-          "extra" => []
+          "extra" => [],
+          "header" => "<h2>Artist</h2>",
+          "humanized" => {
+            "slice" => 0,
+            "exclusion" => %w(banned_artist),
+            "regexmap" => //,
+            "formatstr" => "drawn by %s"
+          }
         }
       }
     end
+
+#TAG MAPPINGS
 
     # Returns a hash mapping various tag categories to a numerical value.
     def tag_category_mapping
@@ -258,6 +285,30 @@ module Danbooru
     def reverse_tag_category_mapping
       @reverse_tag_category_mapping ||= Hash[full_tag_config_info.map {|k,v| [v["category"],k]}]
     end
+
+    # Returns a hash mapping for the short name usage in metatags
+    def short_tag_name_mapping
+      @short_tag_name_mapping ||= Hash[full_tag_config_info.map {|k,v| [v["short"],k] }]
+    end
+
+#TAG ORDERS
+
+    #Sets the order of the humanized essential tag string (models/post.rb)
+    def humanized_tag_category_list
+      @humanized_tag_category_list ||= ["character","copyright","artist"]
+    end
+
+    #Sets the order of the split tag header list (presenters/tag_set_presenter.rb)
+    def split_tag_header_list
+      @split_tag_header_list ||= ["copyright","character","artist","general"]
+    end
+
+    #Sets the order of the categorized tag string (presenters/post_presenter.rb)
+    def categorized_tag_list
+      @categorized_tag_list ||= ["copyright","character","artist","general"]
+    end
+
+#END TAG
 
     # If enabled, users must verify their email addresses.
     def enable_email_verification?

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -224,7 +224,8 @@ module Danbooru
           "short" => "gen",
           "extra" => [],
           "header" => "<h1>Tags</h1>",
-          "humanized" => nil
+          "humanized" => nil,
+          "relatedtag" => "General"
         },
         "character" => {
           "category" => 4,
@@ -236,7 +237,8 @@ module Danbooru
             "exclusion" => [],
             "regexmap" => /^(.+?)(?:_\(.+\))?$/,
             "formatstr" => "%s"
-          }
+          },
+          "relatedtag" => "Characters"
         },
         "copyright" => {
           "category" => 3,
@@ -248,7 +250,8 @@ module Danbooru
             "exclusion" => [],
             "regexmap" => //,
             "formatstr" => "(%s)"
-          }
+          },
+          "relatedtag" => "Copyrights"
         },
         "artist" => {
           "category" => 1,
@@ -260,7 +263,8 @@ module Danbooru
             "exclusion" => %w(banned_artist),
             "regexmap" => //,
             "formatstr" => "drawn by %s"
-          }
+          },
+          "relatedtag" => "Artists"
         }
       }
     end
@@ -306,6 +310,11 @@ module Danbooru
     #Sets the order of the categorized tag string (presenters/post_presenter.rb)
     def categorized_tag_list
       @categorized_tag_list ||= ["copyright","character","artist","general"]
+    end
+
+    #Sets the order of the related tag buttons (javascripts/related_tag.js)
+    def related_tag_button_list
+      @related_tag_button_list ||= ["general","artist","character","copyright"]
     end
 
 #END TAG

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -265,6 +265,14 @@ module Danbooru
             "formatstr" => "drawn by %s"
           },
           "relatedtag" => "Artists"
+        },
+        "meta" => {
+          "category" => 5,
+          "short" => "meta",
+          "extra" => [],
+          "header" => "<h2>Meta</h2>",
+          "humanized" => nil,
+          "relatedtag" => nil
         }
       }
     end
@@ -304,12 +312,12 @@ module Danbooru
 
     #Sets the order of the split tag header list (presenters/tag_set_presenter.rb)
     def split_tag_header_list
-      @split_tag_header_list ||= ["copyright","character","artist","general"]
+      @split_tag_header_list ||= ["copyright","character","artist","general","meta"]
     end
 
     #Sets the order of the categorized tag string (presenters/post_presenter.rb)
     def categorized_tag_list
-      @categorized_tag_list ||= ["copyright","character","artist","general"]
+      @categorized_tag_list ||= ["copyright","character","artist","meta","general"]
     end
 
     #Sets the order of the related tag buttons (javascripts/related_tag.js)

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -214,44 +214,49 @@ module Danbooru
       "albert"
     end
 
+    #Full tag configuration info for all tags
+    def full_tag_config_info
+      @full_tag_category_mapping ||= {
+        "general" => {
+          "category" => 0,
+          "short" => "gen",
+          "extra" => []
+        },
+        "character" => {
+          "category" => 4,
+          "short" => "char",
+          "extra" => ["ch"]
+        },
+        "copyright" => {
+          "category" => 3,
+          "short" => "copy",
+          "extra" => ["co"]
+        },
+        "artist" => {
+          "category" => 1,
+          "short" => "art",
+          "extra" => []
+        }
+      }
+    end
+
     # Returns a hash mapping various tag categories to a numerical value.
-    # Be sure to update the reverse_tag_category_mapping also.
     def tag_category_mapping
-      @tag_category_mapping ||= {
-        "general" => 0,
-        "gen" => 0,
-
-        "artist" => 1,
-        "art" => 1,
-
-        "copyright" => 3,
-        "copy" => 3,
-        "co" => 3,
-
-        "character" => 4,
-        "char" => 4,
-        "ch" => 4
-      }
+      @tag_category_mapping ||= Hash[
+          full_tag_config_info.map {|k,v|  v["extra"].map {|y| [y,v["category"]]}}
+          .reduce([],:+)]
+        .update(Hash[full_tag_config_info.map {|k,v|  [v["short"],v["category"]]}])
+        .update( Hash[full_tag_config_info.map {|k,v| [k,v["category"]]}])
     end
 
+    # Returns a hash mapping more suited for views
     def canonical_tag_category_mapping
-      @canonical_tag_category_mapping ||= {
-        "General" => 0,
-        "Artist" => 1,
-        "Copyright" => 3,
-        "Character" => 4
-      }
+      @canonical_tag_category_mapping ||= Hash[full_tag_config_info.map {|k,v| [k.capitalize,v["category"]]}]
     end
 
-    # Returns a hash maping numerical category values to their
-    # string equivalent. Be sure to update the tag_category_mapping also.
+    # Returns a hash mapping numerical category values to their string equivalent.
     def reverse_tag_category_mapping
-      @reverse_tag_category_mapping ||= {
-        0 => "General",
-        1 => "Artist",
-        3 => "Copyright",
-        4 => "Character"
-      }
+      @reverse_tag_category_mapping ||= Hash[full_tag_config_info.map {|k,v| [v["category"],k]}]
     end
 
     # If enabled, users must verify their email addresses.

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -225,7 +225,7 @@ module Danbooru
           "extra" => [],
           "header" => "<h1>Tags</h1>",
           "humanized" => nil,
-          "relatedtag" => "General"
+          "relatedbutton" => "General"
         },
         "character" => {
           "category" => 4,
@@ -238,7 +238,7 @@ module Danbooru
             "regexmap" => /^(.+?)(?:_\(.+\))?$/,
             "formatstr" => "%s"
           },
-          "relatedtag" => "Characters"
+          "relatedbutton" => "Characters"
         },
         "copyright" => {
           "category" => 3,
@@ -251,7 +251,7 @@ module Danbooru
             "regexmap" => //,
             "formatstr" => "(%s)"
           },
-          "relatedtag" => "Copyrights"
+          "relatedbutton" => "Copyrights"
         },
         "artist" => {
           "category" => 1,
@@ -264,7 +264,7 @@ module Danbooru
             "regexmap" => //,
             "formatstr" => "drawn by %s"
           },
-          "relatedtag" => "Artists"
+          "relatedbutton" => "Artists"
         },
         "meta" => {
           "category" => 5,
@@ -272,35 +272,9 @@ module Danbooru
           "extra" => [],
           "header" => "<h2>Meta</h2>",
           "humanized" => nil,
-          "relatedtag" => nil
+          "relatedbutton" => nil
         }
       }
-    end
-
-#TAG MAPPINGS
-
-    # Returns a hash mapping various tag categories to a numerical value.
-    def tag_category_mapping
-      @tag_category_mapping ||= Hash[
-          full_tag_config_info.map {|k,v|  v["extra"].map {|y| [y,v["category"]]}}
-          .reduce([],:+)]
-        .update(Hash[full_tag_config_info.map {|k,v|  [v["short"],v["category"]]}])
-        .update( Hash[full_tag_config_info.map {|k,v| [k,v["category"]]}])
-    end
-
-    # Returns a hash mapping more suited for views
-    def canonical_tag_category_mapping
-      @canonical_tag_category_mapping ||= Hash[full_tag_config_info.map {|k,v| [k.capitalize,v["category"]]}]
-    end
-
-    # Returns a hash mapping numerical category values to their string equivalent.
-    def reverse_tag_category_mapping
-      @reverse_tag_category_mapping ||= Hash[full_tag_config_info.map {|k,v| [v["category"],k]}]
-    end
-
-    # Returns a hash mapping for the short name usage in metatags
-    def short_tag_name_mapping
-      @short_tag_name_mapping ||= Hash[full_tag_config_info.map {|k,v| [v["short"],k] }]
     end
 
 #TAG ORDERS

--- a/db/migrate/20171106075030_add_tag_count_meta_to_posts.rb
+++ b/db/migrate/20171106075030_add_tag_count_meta_to_posts.rb
@@ -1,0 +1,7 @@
+class AddTagCountMetaToPosts < ActiveRecord::Migration
+  def change
+    Post.without_timeout do
+      add_column :posts, :tag_count_meta, :integer, default: 0, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2776,7 +2776,8 @@ CREATE TABLE posts (
     pixiv_id integer,
     last_commented_at timestamp without time zone,
     has_active_children boolean DEFAULT false,
-    bit_flags bigint DEFAULT 0 NOT NULL
+    bit_flags bigint DEFAULT 0 NOT NULL,
+    tag_count_meta integer DEFAULT 0 NOT NULL
 );
 
 
@@ -7517,4 +7518,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170613200356');
 INSERT INTO schema_migrations (version) VALUES ('20170709190409');
 
 INSERT INTO schema_migrations (version) VALUES ('20170914200122');
+
+INSERT INTO schema_migrations (version) VALUES ('20171106075030');
 

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -61,6 +61,7 @@ class TagTest < ActiveSupport::TestCase
       assert_equal(1, Tag.categories.artist)
       assert_equal(3, Tag.categories.copyright)
       assert_equal(4, Tag.categories.character)
+      assert_equal(5, Tag.categories.meta)
     end
 
     should "have a regular expression for matching category names and shortcuts" do
@@ -74,6 +75,7 @@ class TagTest < ActiveSupport::TestCase
       assert_match(regexp, "character")
       assert_match(regexp, "char")
       assert_match(regexp, "ch")
+      assert_match(regexp, "meta")
       assert_no_match(regexp, "c")
       assert_no_match(regexp, "woodle")
     end
@@ -83,6 +85,7 @@ class TagTest < ActiveSupport::TestCase
       assert_equal(0, Tag.categories.value_for("gen"))
       assert_equal(1, Tag.categories.value_for("artist"))
       assert_equal(1, Tag.categories.value_for("art"))
+      assert_equal(5, Tag.categories.value_for("meta"))
       assert_equal(0, Tag.categories.value_for("unknown"))
     end
   end

--- a/test/unit/tag_test.rb
+++ b/test/unit/tag_test.rb
@@ -218,7 +218,7 @@ class TagTest < ActiveSupport::TestCase
       should_not allow_value("café").for(:name).on(:create)
       should_not allow_value("東方").for(:name).on(:create)
 
-      metatags = Tag::METATAGS.split("|") + Tag::SUBQUERY_METATAGS.split("|") + Danbooru.config.tag_category_mapping.keys
+      metatags = Tag::METATAGS.split("|") + Tag::SUBQUERY_METATAGS.split("|") + TagCategory.mapping.keys
       metatags.split("|").each do |metatag|
         should_not allow_value("#{metatag}:foo").for(:name).on(:create)
       end


### PR DESCRIPTION
Fixes #3292.  Most of the configuration logic for the tag categories was first moved out of all of the affected files and into the configuration file.  This will facilitate greater control over tag categories for anyone that uses a Danbooru instance, to include renaming, adding, or removing categories.

Some of the logic was left in still though, such as when one category affected another, or something only affected a single category.

One such case was for the new **meta** tag category.  An additional restriction of Builder+ only was applied to that as per Type-kun's suggestion, but since it only affected that category, it was left in the corresponding model and controller files.  However, it could always be moved out to the configuration file as well if necessary.