### PR TITLE
Disallow a user from seeing flagger's name on own uploads

### DIFF
--- a/app/helpers/post_flags_helper.rb
+++ b/app/helpers/post_flags_helper.rb
@@ -7,7 +7,7 @@ module PostFlagsHelper
       html << '<li>'
       html << format_text(flag.reason, inline: true)
 
-      if CurrentUser.can_view_flagger?(flag.creator_id)
+      if CurrentUser.can_view_flagger_on_post?(flag)
         html << " - #{link_to_user(flag.creator)}"
         if CurrentUser.is_moderator?
            html << " (#{link_to_ip(flag.creator_ip_addr)})"

--- a/app/logical/anonymous_user.rb
+++ b/app/logical/anonymous_user.rb
@@ -120,6 +120,10 @@ class AnonymousUser
     false
   end
 
+  def can_view_flagger_on_post?(flag)
+    false
+  end
+
   def can_approve_posts?
     false
   end

--- a/app/models/post_event.rb
+++ b/app/models/post_event.rb
@@ -30,7 +30,7 @@ class PostEvent
       true
     when PostFlag
       flag = event
-      user.can_view_flagger?(flag.creator_id)
+      user.can_view_flagger_on_post?(flag)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -557,6 +557,10 @@ class User < ApplicationRecord
       is_moderator? || flagger_id == id
     end
 
+    def can_view_flagger_on_post?(flag)
+      (is_moderator? && flag.not_uploaded_by?(id)) || flag.creator_id == id
+    end
+
     def upload_limit
       @upload_limit ||= [max_upload_limit - used_upload_slots, 0].max
     end

--- a/app/views/post_flags/index.html.erb
+++ b/app/views/post_flags/index.html.erb
@@ -39,7 +39,7 @@
             </td>
             <td>
               <%= compact_time post_flag.created_at %>
-              <% if CurrentUser.can_view_flagger?(post_flag.creator_id) %>
+              <% if CurrentUser.can_view_flagger_on_post?(post_flag) %>
                 <br> by <%= link_to_user post_flag.creator %>
                 <%= link_to "»", post_flags_path(search: params[:search].merge(creator_name: post_flag.creator.name)) %>
               <% end %>


### PR DESCRIPTION
Fixes #3349.  It shows all flags to a user, but removes the Creator ID unless you are the flag creator or a moderator that isn't the post uploader.  Similarly the entire flag is hidden if searching by ``creator_id`` or ``creator_name`` (or ``flagger:username`` on posts).  That will prevent users from seeing flags on their own uploads when searching this way, and therefore being able to determine in a roundabout way who flagged their upload.