### PR TITLE
Post editing: add warning when creating new tags (#3352)

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -110,6 +110,10 @@ private
   def respond_with_post_after_update(post)
     respond_with(post) do |format|
       format.html do
+        if post.warnings.any?
+          flash[:notice] = post.warnings.full_messages.join(".\n \n")
+        end
+
         if post.errors.any?
           @error_message = post.errors.full_messages.join("; ")
           render :template => "static/error", :status => 500

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -53,7 +53,12 @@ class UploadsController < ApplicationController
 
   def create
     @upload = Upload.create(params[:upload].merge(:server => Socket.gethostname))
-    @upload.process! if @upload.errors.empty?
+
+    if @upload.errors.empty?
+      post = @upload.process!
+      flash[:notice] = post.warnings.full_messages.join(".\n \n") if post.present? && post.warnings.any?
+    end
+
     save_recent_tags
     respond_with(@upload)
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -43,5 +43,9 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
+  def warnings
+    @warnings ||= ActiveModel::Errors.new(self)
+  end
+
   include ApiMethods
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1724,11 +1724,18 @@ class Post < ApplicationRecord
     def added_tags_are_valid
       new_tags = added_tags.select { |t| t.post_count <= 1 }
       new_general_tags = new_tags.select { |t| t.category == Tag.categories.general }
+      new_artist_tags = new_tags.select { |t| t.category == Tag.categories.artist }
 
       if new_general_tags.present?
         n = new_general_tags.size
         tag_wiki_links = new_general_tags.map { |tag| "[[#{tag.name}]]" }
         self.warnings[:base] << "Created #{n} new #{n == 1 ? "tag" : "tags"}: #{tag_wiki_links.join(", ")}"
+      end
+
+      new_artist_tags.each do |tag|
+        if tag.artist.blank?
+          self.warnings[:base] << "Artist [[#{tag.name}]] requires an artist entry. \"Create new artist entry\":[/artists/new?name=#{CGI::escape(tag.name)}]"
+        end
       end
     end
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1761,7 +1761,8 @@ class Post < ApplicationRecord
     def has_artist_tag
       return if !new_record?
       return if source !~ %r!\Ahttps?://!
-      return if has_tag?("artist_request") || tags.any? { |t| t.category == Tag.categories.artist }
+      return if has_tag?("artist_request") || has_tag?("official_art")
+      return if tags.any? { |t| t.category == Tag.categories.artist }
 
       site = Sources::Site.new(source)
       self.warnings[:base] << "Artist tag is required. Create a new tag with [[artist:<artist_name>]]. Ask on the forum if you need naming help"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -19,6 +19,7 @@ class Post < ApplicationRecord
   validates_inclusion_of :rating, in: %w(s q e), message: "rating must be s, q, or e"
   validate :tag_names_are_valid
   validate :added_tags_are_valid
+  validate :has_copyright_tag
   validate :post_is_not_its_own_parent
   validate :updater_can_change_rating
   before_save :update_tag_post_counts
@@ -1737,6 +1738,13 @@ class Post < ApplicationRecord
           self.warnings[:base] << "Artist [[#{tag.name}]] requires an artist entry. \"Create new artist entry\":[/artists/new?name=#{CGI::escape(tag.name)}]"
         end
       end
+    end
+
+    def has_copyright_tag
+      return if !new_record?
+      return if has_tag?("copyright_request") || tags.any? { |t| t.category == Tag.categories.copyright }
+
+      self.warnings[:base] << "Copyright tag is required. Consider adding [[copyright request]] or [[original]]"
     end
   end
   

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -6,6 +6,7 @@ class Tag < ApplicationRecord
   attr_accessible :category, :as => [:moderator, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
   attr_accessible :is_locked, :as => [:moderator, :admin]
   has_one :wiki_page, :foreign_key => "title", :primary_key => "name"
+  has_one :artist, :foreign_key => "name", :primary_key => "name"
   has_one :antecedent_alias, lambda {active}, :class_name => "TagAlias", :foreign_key => "antecedent_name", :primary_key => "name"
   has_many :consequent_aliases, lambda {active}, :class_name => "TagAlias", :foreign_key => "consequent_name", :primary_key => "name"
   has_many :antecedent_implications, lambda {active}, :class_name => "TagImplication", :foreign_key => "antecedent_name", :primary_key => "name"

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -148,6 +148,8 @@ class Upload < ApplicationRecord
       else
         update_attribute(:status, "error: " + post.errors.full_messages.join(", "))
       end
+
+      post
     end
 
     def process!(force = false)
@@ -155,7 +157,7 @@ class Upload < ApplicationRecord
       return if !force && status =~ /processing|completed|error/
 
       process_upload
-      create_post_from_upload
+      post = create_post_from_upload
 
     rescue Timeout::Error, Net::HTTP::Persistent::Error => x
       if @tries > 3
@@ -164,9 +166,11 @@ class Upload < ApplicationRecord
         @tries += 1
         retry
       end
+      nil
 
     rescue Exception => x
       update_attributes(:status => "error: #{x.class} - #{x.message}", :backtrace => x.backtrace.join("\n"))
+      nil
       
     ensure
       delete_temp_file

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -112,7 +112,7 @@
     <% end %>
 
     <div class="ui-corner-all ui-state-highlight" id="notice" style="<%= "display: none;" unless flash[:notice] %>">
-      <span><%= flash[:notice] %></span>
+      <span><%= format_text(flash[:notice], inline: true) %>.</span>
       <a href="#" id="close-notice-link">close</a>
     </div>
 


### PR DESCRIPTION
This is a proof of concept demonstrating how the soft validations from #3352 can be done fully server-side. This adds two type of warnings:

* When new general tags are created, a `Created 2 new tags: <tag1>, <tag2>, ...` notice is displayed. This warns users about typos.
* When an artist tag is created and it doesn't have an artist entry, a `Artist <name> requires an artist entry. Create new artist entry.` notice is displayed. This reminds users to create artist entries.

The approach is to use standard Rails validations to perform these checks during the post saving process, but to store the warnings inside `post.warnings` instead of `post.errors`. This way we can add soft errors that don't prevent the object from saving. Then in the controller we simply set `flash[:notice] = @post.warnings.full_messages.join("; ")`, and Danbooru will display a warning notice after the page reloads.

The downside to this approach is that the user doesn't see the warning until after the edit completes and the page refreshes. The upside is that the implementation is simple and requires no extra Javascript.