### PR TITLE
Fixed issue with pruning calculation in Firefox

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -28,9 +28,9 @@
   Danbooru.Autocomplete.prune_local_storage = function() {
     if (this.enable_local_storage) {
       var cached_autocomplete_version = $.localStorage.get("danbooru-autocomplete-version");
-      var current_cache_size = $.localStorage.keys().reduce( function(total, key) { return total + localStorage[key].length; }, 0);
+      var current_cache_size = Object.keys(localStorage).reduce( function(total, key) { return total + localStorage[key].length; }, 0);
       if (cached_autocomplete_version !== this.AUTOCOMPLETE_VERSION || current_cache_size > this.MAX_STORAGE_SIZE) {
-        $.each($.localStorage.keys(), function(i, key) {
+        $.each(Object.keys(localStorage), function(i, key) {
           if (key.substr(0, 3) === "ac-") {
             $.localStorage.remove(key);
           }


### PR DESCRIPTION
This issue was reported on Discord.  Basically, on Firefox, the jQuery webstorage API, $.localStorage, would return non-keys when the keys function was called.  This included **setItem**, **getItem**, **removeItem**, **key**, **clear** and **length**.  This would cause errors, as when the reduce function was processing, it would encounter length, and try to find localStorage.length.length, which would be _undefined_, which caused the whole thing to return **NaN**.  This would cause the pruning to never take place, as **NaN** is never greater than any number.

All of the $.localStorage.keys() have therefore been replaced with Object.keys(localStorage), which doesn't have this issue.  Admittedly, it's not as much of an issue in the second case, but was replaced for consistency.