### PR TITLE
Moved input existence validations to client (#3352)

### DIFF
--- a/app/assets/javascripts/uploads.js
+++ b/app/assets/javascripts/uploads.js
@@ -12,6 +12,7 @@
       this.initialize_info_bookmarklet();
       this.initialize_similar();
       this.initialize_shortcuts();
+      this.initialize_submit();
       $("#related-tags-button").trigger("click");
       $("#find-artist-button").trigger("click");
 
@@ -24,6 +25,28 @@
     if ($("#iqdb-similar").length) {
       this.initialize_iqdb_source();
     }
+  }
+
+  Danbooru.Upload.initialize_submit = function() {
+    $("#form").submit(function(e) {
+      var error_messages = [];
+      if (($("#upload_file").val() === "") && ($("#upload_source").val() === "")) {
+        error_messages.push("Must choose file or specify source");
+      }
+      if (!$("#upload_rating_s")[0].checked && !$("#upload_rating_q")[0].checked && !$("#upload_rating_e")[0].checked &&
+          ($("#upload_tag_string").val().search(/\brating:[sqe]/) < 0)) {
+        error_messages.push("Must specify a rating");
+      }
+      if (error_messages.length === 0) {
+        $("#submit-button")[0].setAttribute("disabled","true");
+        $("#submit-button")[0].setAttribute("value","Submitting...");
+        $("#client-errors").hide();
+      } else {
+        $("#client-errors")[0].innerHTML = "<strong>Error</strong>: " + error_messages.join(", ");
+        $("#client-errors").show();
+        e.preventDefault();
+      }
+    });
   }
 
   Danbooru.Upload.initialize_shortcuts = function() {

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -15,7 +15,7 @@
       <%= render "post", :post => @post %>
       <%= render "sources/info", :source => @source %>
 
-      <%= error_messages_for "upload" %>
+      <div id="client-errors" class="error-messages ui-state-error ui-corner-all" style="display:none"></div>
 
       <%= form_for(@upload, :html => {:multipart => true, :class => "simple_form", :id => "form"}) do |f| %>
         <%= hidden_field_tag :url, params[:url] %>
@@ -116,7 +116,7 @@
         </div>
 
         <div class="input">
-          <%= submit_tag "Submit", :class => "large", :data => { :disable_with => "Submitting..." }, :class => "ui-button ui-widget ui-corner-all gradient" %>
+          <%= submit_tag "Submit", :id => "submit-button", :class => "large", :class => "ui-button ui-widget ui-corner-all gradient" %>
         </div>
 
         <div id="artist-tags-container">


### PR DESCRIPTION
This adds in the third validation from #3352.  As explained on that issue, doing it this way is quicker and more responsive to the user as all the information is already available at the client.  

I took out the `error_messages_for` since the view ERB and Javascript code will cover all of those cases, but I left the original validation error pushes in the uploads model because the user will get those if they try to upload from the API.  The button is left as an `<input>` with a `value="Submit"` to take advantage of existing CSS that styles that button.  The `name="commit"` was left out as it's not sent anyways as a result of using the _trigger_ action with "submit", which is done for the **Return** key anyways so there shouldn't be an issue.