### PR TITLE
Fix upload batch view and related tag script (#3366)

### DIFF
--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -12,7 +12,13 @@
 
   Danbooru.RelatedTag.initialize_buttons = function() {
     this.common_bind("#related-tags-button", "");
-    $.each(JSON.parse(Danbooru.meta("related-tag-button-list")), function(i,category) {
+    var related_buttons;
+    try {
+      related_buttons = JSON.parse(Danbooru.meta("related-tag-button-list"));
+    } catch (e) {
+      related_buttons = [];
+    }
+    $.each(related_buttons, function(i,category) {
       Danbooru.RelatedTag.common_bind("#related-" + category + "-button", category);
     });
     $("#find-artist-button").click(Danbooru.RelatedTag.find_artist);

--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -1,5 +1,5 @@
 <div id="c-uploads">
-  <div id="a-new">
+  <div id="a-batch">
     <h1>Batch Upload</h1>
 
     <section>


### PR DESCRIPTION
Fixes #3366, which was caused because the batch view unknowingly had the incorrect value of `#c-uploads #a-new`, which caused it to run the related tag Javascript when it shouldn't.

This therefore fixes two problems present:

1. Renames batch view to the correct ID of `#c-uploads #a-batch`
2. Wraps the JSON parse in related tags with a try/catch for all other unknown cases

As a side note, this bears going through the remaining views and checking that they have the correct IDs as well, though I didn't want to do that as part of an urgent fix request.