### PR TITLE
Fix #3377: Batch bookmarklet doesn't fetch artist/tags from twitter

### DIFF
--- a/app/logical/downloads/file.rb
+++ b/app/logical/downloads/file.rb
@@ -125,7 +125,7 @@ module Downloads
 
     def set_source_to_referer(src, referer)
       if Sources::Strategies::Nijie.url_match?(src) ||
-         Sources::Strategies::Twitter.url_match?(src) ||
+         Sources::Strategies::Twitter.url_match?(src) || Sources::Strategies::Twitter.url_match?(referer)
          Sources::Strategies::Pawoo.url_match?(src) ||
          Sources::Strategies::Tumblr.url_match?(src) || Sources::Strategies::Tumblr.url_match?(referer)
          Sources::Strategies::ArtStation.url_match?(src) || Sources::Strategies::ArtStation.url_match?(referer)

--- a/test/functional/sources_controller_test.rb
+++ b/test/functional/sources_controller_test.rb
@@ -3,8 +3,18 @@ require 'test_helper'
 class SourcesControllerTest < ActionController::TestCase
   context "The sources controller" do
     context "show action" do
-      should "work" do
+      should "work for a pixiv URL" do
         get :show, { url: "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=14901720", format: "json" }
+        assert_response :success
+      end
+
+      should "work for a direct twitter URL with referer" do
+        get :show, {
+          url: "https://pbs.twimg.com/media/B4HSEP5CUAA4xyu.png:large",
+          ref: "https://twitter.com/nounproject/status/540944400767922176",
+          format: "json"
+        }
+
         assert_response :success
       end
     end

--- a/test/unit/sources/twitter_test.rb
+++ b/test/unit/sources/twitter_test.rb
@@ -123,6 +123,21 @@ module Sources
       end
     end
 
+    context "The source site for a direct image and a referer" do
+      setup do
+        @site = Sources::Site.new("https://pbs.twimg.com/media/B4HSEP5CUAA4xyu.png:large", referer_url: "https://twitter.com/nounproject/status/540944400767922176")
+        @site.get
+      end
+
+      should "get the artist name" do
+        assert_equal("Noun Project", @site.artist_name)
+      end
+
+      should "get the image url" do
+        assert_equal("https://pbs.twimg.com/media/B4HSEP5CUAA4xyu.png:orig", @site.image_url)
+      end
+    end
+
     context "A tweet" do
       setup do
         @site = Sources::Site.new("https://twitter.com/noizave/status/875768175136317440")


### PR DESCRIPTION
Fixes #3377. Broken in #3368; the twitter source strategy didn't know how to parse the status ID when it was only present in the referrer URL.