### PR TITLE
Fix #3323: Exclude post replacements from Mod Actions 

### DIFF
--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -56,7 +56,6 @@ class PostReplacement < ApplicationRecord
 
       if md5_changed
         post.comments.create!({creator: User.system, body: comment_replacement_message, do_not_bump_post: true}, without_protection: true)
-        ModAction.log(modaction_replacement_message)
       else
         post.queue_backup
       end
@@ -121,10 +120,6 @@ class PostReplacement < ApplicationRecord
   module PresenterMethods
     def comment_replacement_message
       %("#{creator.name}":[/users/#{creator.id}] replaced this post with a new image:\n\n#{replacement_message})
-    end
-
-    def modaction_replacement_message
-      "replaced post ##{post.id}:\n\n#{replacement_message}"
     end
 
     def replacement_message

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -46,7 +46,6 @@ class PostReplacementTest < ActiveSupport::TestCase
         @post.update(source: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png")
         @post.replace!(replacement_url: "https://www.google.com/intl/en_ALL/images/logo.gif", tags: "-tag1 tag2")
         @upload = Upload.last
-        @mod_action = ModAction.last
       end
 
       context "that is then undone" do
@@ -93,10 +92,6 @@ class PostReplacementTest < ActiveSupport::TestCase
         assert_equal("127.0.0.2", @post.uploader_ip_addr.to_s)
         assert_equal(@uploader.id, @post.uploader_id)
         assert_equal(false, @post.is_pending)
-      end
-
-      should "log a mod action" do
-        assert_match(/replaced post ##{@post.id}/, @mod_action.description)
       end
 
       should "leave a system comment" do
@@ -264,7 +259,7 @@ class PostReplacementTest < ActiveSupport::TestCase
 
       should "not queue a deletion or log a comment" do
         upload_file("#{Rails.root}/test/files/test.jpg", "test.jpg") do |file|
-          assert_no_difference(["@post.comments.count", "ModAction.count"]) do
+          assert_no_difference(["@post.comments.count"]) do
             @post.replace!(replacement_file: file, replacement_url: "")
           end
         end

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -246,7 +246,7 @@ class PostReplacementTest < ActiveSupport::TestCase
     context "a post when replaced with a HTML source" do
       should "record the image URL as the replacement URL, not the HTML source" do
         replacement_url = "https://twitter.com/nounproject/status/540944400767922176"
-        image_url = "http://pbs.twimg.com/media/B4HSEP5CUAA4xyu.png:orig"
+        image_url = "https://pbs.twimg.com/media/B4HSEP5CUAA4xyu.png:orig"
         @post.replace!(replacement_url: replacement_url)
 
         assert_equal(image_url, @post.replacements.last.replacement_url)


### PR DESCRIPTION
Fixes #3323.