### PR TITLE
Fix #3387: Safebooru: Two tag searches fail for members.

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -427,7 +427,7 @@ class Tag < ApplicationRecord
       }
 
       scan_query(query).each do |token|
-        q[:tag_count] += 1 unless token == "status:deleted" || token =~ /\Alimit:.+\Z/
+        q[:tag_count] += 1 unless Danbooru.config.is_unlimited_tag?(token)
 
         if token =~ /\A(#{METATAGS}):(.+)\Z/i
           g1 = $1.downcase

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -169,6 +169,11 @@ module Danbooru
       end
     end
 
+    # Return true if the given tag shouldn't count against the user's tag search limit.
+    def is_unlimited_tag?(tag)
+      !!(tag =~ /\A(-?status:deleted|rating:s.*|limit:.+)\z/i)
+    end
+
     # After this many pages, the paginator will switch to sequential mode.
     def max_numbered_pages
       1_000


### PR DESCRIPTION
Fixes #3387 by making the `rating:s` and `-status:deleted` tags not count against the user's tag limit. These tags are already free when in safe mode or when the `Deleted Post Filter` option is turned on, so they may as well be free always.