### PR TITLE
Fix #3390: Searching certain metatags results in an empty paginator

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1218,14 +1218,14 @@ class Post < ApplicationRecord
     end
 
     def get_count_from_cache(tags)
-      count = Cache.get(count_cache_key(tags)) # this will only have a value for multi-tag searches
-
-      if count.nil? && !tags.include?(" ")
+      if Tag.is_simple_tag?(tags)
         count = select_value_sql("SELECT post_count FROM tags WHERE name = ?", tags.to_s)
-        # set_count_in_cache(tags, count.to_i) if count
+      else
+        # this will only have a value for multi-tag searches or single metatag searches
+        count = Cache.get(count_cache_key(tags))
       end
 
-      count ? count.to_i : nil
+      count.try(:to_i)
     end
 
     def set_count_in_cache(tags, count, expiry = nil)

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -783,6 +783,10 @@ class Tag < ApplicationRecord
   end
 
   module SearchMethods
+    def empty
+      where("tags.post_count <= 0")
+    end
+
     def nonempty
       where("tags.post_count > 0")
     end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -415,6 +415,12 @@ class Tag < ApplicationRecord
       end
     end
 
+    # true if query is a single "simple" tag (not a metatag, negated tag, or wildcard tag).
+    def is_simple_tag?(query)
+      q = parse_query(query)
+      (scan_query(query).size == 1) && (q[:tags][:related].size == 1)
+    end
+
     def parse_query(query, options = {})
       q = {}
 

--- a/script/fixes/051_purge_invalid_tags.rb
+++ b/script/fixes/051_purge_invalid_tags.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment'))
+
+CurrentUser.user = User.system
+CurrentUser.ip_addr = "127.0.0.1"
+
+Tag.transaction do
+  empty_gentags = Tag.empty.where(category: Tag.categories.general)
+  total = empty_gentags.count
+
+  empty_gentags.find_each.with_index do |tag, i|
+    STDERR.puts %{validating "#{tag.name}" (#{i}/#{total})} if i % 1000 == 0
+
+    if tag.invalid?(:create)
+      # puts ({ name: tag.name, id: tag.id }).to_json
+      tag.delete
+    end
+  end
+end


### PR DESCRIPTION
Fixes #3390:

* Adds a fix script to purge tags with invalid names from the tags table. Only empty gentags are purged. This will purge invalid metatags from the tags table, along with a bunch of other invalid unicode tags and typo tags. About ~27k tags will be purged: [invalid-tags.json](https://storage.googleapis.com/evazion/danbooru/invalid-tags.json).

* Fixes `Post#get_count_from_cache` to only lookup the count in the tags table when the search is for a single "simple" tag. Don't attempt to lookup multi-tag searches, metatags (`rating:s`), negated tags (`-touhou`), wildcard tags (`*touhou*`), etc in the tags table.