### PR TITLE
Fix #3392: Add safe mode account setting.

### DIFF
--- a/app/logical/anonymous_user.rb
+++ b/app/logical/anonymous_user.rb
@@ -265,6 +265,10 @@ class AnonymousUser
     false
   end
 
+  def enable_safe_mode?
+    false
+  end
+
   User::Roles.reject {|r| r == :anonymous}.each do |name|
     define_method("is_#{name}?") do
       false

--- a/app/logical/current_user.rb
+++ b/app/logical/current_user.rb
@@ -74,11 +74,7 @@ class CurrentUser
   end
 
   def self.set_safe_mode(req)
-    if req.host =~ /safe/ || req.params[:safe_mode]
-      Thread.current[:safe_mode] = true
-    else
-      Thread.current[:safe_mode] = false
-    end
+    Thread.current[:safe_mode] = Danbooru.config.enable_safe_mode?(req, CurrentUser.user)
   end
 
   def self.method_missing(method, *params, &block)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -56,13 +56,14 @@ class User < ApplicationRecord
     enable_recent_searches
     disable_cropped_thumbnails
     disable_mobile_gestures
+    enable_safe_mode
   )
 
   include Danbooru::HasBitFlags
   has_bit_flags BOOLEAN_ATTRIBUTES, :field => "bit_prefs"
 
   attr_accessor :password, :old_password
-  attr_accessible :dmail_filter_attributes, :enable_privacy_mode, :enable_post_navigation, :new_post_navigation_layout, :password, :old_password, :password_confirmation, :password_hash, :email, :last_logged_in_at, :last_forum_read_at, :has_mail, :receive_email_notifications, :comment_threshold, :always_resize_images, :favorite_tags, :blacklisted_tags, :name, :ip_addr, :time_zone, :default_image_size, :enable_sequential_post_navigation, :per_page, :hide_deleted_posts, :style_usernames, :enable_auto_complete, :custom_style, :show_deleted_children, :disable_categorized_saved_searches, :disable_tagged_filenames, :enable_recent_searches, :disable_cropped_thumbnails, :disable_mobile_gestures, :as => [:moderator, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
+  attr_accessible :dmail_filter_attributes, :enable_privacy_mode, :enable_post_navigation, :new_post_navigation_layout, :password, :old_password, :password_confirmation, :password_hash, :email, :last_logged_in_at, :last_forum_read_at, :has_mail, :receive_email_notifications, :comment_threshold, :always_resize_images, :favorite_tags, :blacklisted_tags, :name, :ip_addr, :time_zone, :default_image_size, :enable_sequential_post_navigation, :per_page, :hide_deleted_posts, :style_usernames, :enable_auto_complete, :custom_style, :show_deleted_children, :disable_categorized_saved_searches, :disable_tagged_filenames, :enable_recent_searches, :disable_cropped_thumbnails, :disable_mobile_gestures, :enable_safe_mode, :as => [:moderator, :gold, :platinum, :member, :anonymous, :default, :builder, :admin]
   attr_accessible :level, :as => :admin
 
   validates :name, user_name: true, on: :create

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -47,6 +47,8 @@
         <% if CurrentUser.user.is_gold? %>
           <%= f.input :per_page, :label => "Posts per page", :as => :select, :collection => (1..100), :include_blank => false %>
         <% end %>
+
+        <%= f.input :enable_safe_mode, :label => "Safe mode", :hint => "Show only safe images. Hide questionable and explicit images.", :as => :select, :include_blank => false, :collection => [["Yes", "true"], ["No", "false"]] %>
         
         <%= f.input :blacklisted_tags, :hint => "Put any tag combinations you never want to see here. Each combination should go on a separate line. <a href='/wiki_pages/help:blacklists'>View help.</a>".html_safe, :input_html => {:size => "40x5", :data => {:autocomplete => "tag-query"}} %>
       </fieldset>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -151,6 +151,11 @@ module Danbooru
       2
     end
 
+    # Whether safe mode should be enabled. Safe mode hides all non-rating:safe posts from view.
+    def enable_safe_mode?(request, user)
+      !!(request.host =~ /safe/ || request.params[:safe_mode] || user.enable_safe_mode?)
+    end
+
     # Determines who can see ads.
     def can_see_ads?(user)
       !user.is_gold?

--- a/test/unit/current_user_test.rb
+++ b/test/unit/current_user_test.rb
@@ -23,8 +23,20 @@ class CurrentUserTest < ActiveSupport::TestCase
       req = mock()
       req.stubs(:host).returns("danbooru")
       req.stubs(:params).returns({})
+      CurrentUser.user = FactoryGirl.create(:user)
       CurrentUser.set_safe_mode(req)
       assert_equal(false, CurrentUser.safe_mode?)
+    end
+
+    should "return true if the user has enabled the safe mode account setting" do
+      req = mock
+      req.stubs(:host).returns("danbooru")
+      req.stubs(:params).returns({})
+
+      CurrentUser.user = FactoryGirl.create(:user, enable_safe_mode: true)
+      CurrentUser.set_safe_mode(req)
+
+      assert_equal(true, CurrentUser.safe_mode?)
     end
   end 
 


### PR DESCRIPTION
Fixes #3392. Adds an `enable_safe_mode` account setting.