### PR TITLE
Add additional restrictions on updating deleted pools

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -10,6 +10,9 @@ class PoolsController < ApplicationController
 
   def edit
     @pool = Pool.find(params[:id])
+    if @pool.is_deleted && !@pool.deletable_by?(CurrentUser.user)
+      raise User::PrivilegeError
+    end
     respond_with(@pool)
   end
 

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -8,6 +8,7 @@ class Pool < ApplicationRecord
   validates_inclusion_of :category, :in => %w(series collection)
   validate :updater_can_change_category
   validate :updater_can_remove_posts
+  validate :updater_can_edit_deleted
   belongs_to :creator, :class_name => "User"
   belongs_to :updater, :class_name => "User"
   before_validation :normalize_post_ids
@@ -209,6 +210,15 @@ class Pool < ApplicationRecord
 
   def deletable_by?(user)
     user.is_builder?
+  end
+
+  def updater_can_edit_deleted
+    if is_deleted? && !deletable_by?(CurrentUser.user)
+      errors[:base] << "You cannot update pools that are deleted"
+      false
+    else
+      true
+    end
   end
 
   def create_mod_action_for_delete


### PR DESCRIPTION
This issue was noticed because of the conversation in [topic #5388](http://danbooru.donmai.us/forum_topics/5388).  Basically, a Gold user was able to add a post to a pool by going through the update function.  The following therefore blocks access to the Edit HTML function for those that can't delete a pool (Platinum-).  Additionally, it raises a validation error which handles users coming though the API.

I thought about restricting add access for all users when a pool is deleted, but then that would require a lot more work for little to no benefit.  Plus, those users could always just undelete a pool if the really wanted to add to it.