### PR TITLE
Fix #3395: Bookmarklet on pixiv url with deleted post page returns failbooru, and trying to upload it returns an error 

### DIFF
--- a/app/logical/downloads/rewrite_strategies/pixiv.rb
+++ b/app/logical/downloads/rewrite_strategies/pixiv.rb
@@ -28,6 +28,8 @@ module Downloads
         end
 
         return [url, headers, data]
+      rescue PixivApiClient::BadIDError
+        return [url, headers, data]
       end
 
     protected

--- a/app/logical/pixiv_api_client.rb
+++ b/app/logical/pixiv_api_client.rb
@@ -141,12 +141,13 @@ class PixivApiClient
 
     url = "https://public-api.secure.pixiv.net/v#{API_VERSION}/works/#{illust_id.to_i}.json"
     resp = HTTParty.get(url, Danbooru.config.httparty_options.deep_merge(query: params, headers: headers))
+    body = resp.body.force_encoding("utf-8")
 
     if resp.success?
-      json = parse_api_json(resp.body)
+      json = parse_api_json(body)
       WorksResponse.new(json["response"][0])
     else
-      raise Error.new("Pixiv API call failed (status=#{resp.code} body=#{resp.body})")
+      raise Error.new("Pixiv API call failed (status=#{resp.code} body=#{body})")
     end
   end
 
@@ -177,11 +178,13 @@ private
       url = "https://oauth.secure.pixiv.net/auth/token"
 
       resp = HTTParty.post(url, Danbooru.config.httparty_options.deep_merge(body: params, headers: headers))
+      body = resp.body.force_encoding("utf-8")
+
       if resp.success?
-        json = JSON.parse(resp.body)
+        json = JSON.parse(body)
         access_token = json["response"]["access_token"]
       else
-        raise Error.new("Pixiv API access token call failed (status=#{resp.code} body=#{resp.body})")
+        raise Error.new("Pixiv API access token call failed (status=#{resp.code} body=#{body})")
       end
 
       access_token

--- a/app/views/static/error.html.erb
+++ b/app/views/static/error.html.erb
@@ -1,7 +1,7 @@
 <% if CurrentUser.user.is_builder? && @exception.present? %>
   <h1><%= @exception.class.to_s %> exception raised</h1>
   <ul style="font-family: monospace; font-size: 1.2em; list-style-type: none;">
-    <li><%= @exception.message %></li>
+    <li><%= @exception.message.force_encoding("utf-8") %></li>
     <%- Rails.backtrace_cleaner.clean(@exception.backtrace).each do |b| -%>
       <li style="list-style-type: none;"><%= b %></li>
     <%- end -%>
@@ -9,5 +9,5 @@
 <% elsif @error_message %>
   <p><%= @error_message %></p>
 <% else %>
-  <p><%= @exception.message %></p>
+  <p><%= @exception.message.force_encoding("utf-8") %></p>
 <% end %>

--- a/test/unit/downloads/pixiv_test.rb
+++ b/test/unit/downloads/pixiv_test.rb
@@ -74,19 +74,17 @@ module Downloads
 
       context "downloading a new manga image" do
         setup do
-          @medium_page = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=46304614"
-          @manga_page  = "http://www.pixiv.net/member_illust.php?mode=manga&illust_id=46304614"
-          @manga_big_p1_page = "http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=46304614&page=1"
+          @medium_page = "http://www.pixiv.net/member_illust.php?mode=medium&illust_id=46324488"
+          @manga_page  = "http://www.pixiv.net/member_illust.php?mode=manga&illust_id=46324488"
+          @manga_big_p1_page = "http://www.pixiv.net/member_illust.php?mode=manga_big&illust_id=46324488&page=1"
 
-          @p0_large_thumbnail = "https://i.pximg.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p0_master1200.jpg"
-          @p1_large_thumbnail = "https://i.pximg.net/c/1200x1200/img-master/img/2014/10/02/14/21/39/46304614_p1_master1200.jpg"
-          @p0_full_size_image = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
-          @p0_full_size_image_3 = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p0.gif"
-          @p1_full_size_image = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
-          @p1_full_size_image_3 = "https://i.pximg.net/img-original/img/2014/10/02/14/21/39/46304614_p1.gif"
+          @p0_large_thumbnail = "https://i.pximg.net/img-master/img/2014/10/03/18/10/20/46324488_p0_master1200.jpg"
+          @p1_large_thumbnail = "https://i.pximg.net/img-master/img/2014/10/03/18/10/20/46324488_p1_master1200.jpg"
+          @p0_full_size_image = "https://i.pximg.net/img-original/img/2014/10/03/18/10/20/46324488_p0.png"
+          @p1_full_size_image = "https://i.pximg.net/img-original/img/2014/10/03/18/10/20/46324488_p1.png"
 
-          @p0_file_size = 61_131
-          @p1_file_size = 46_818
+          @p0_file_size = 21_213
+          @p1_file_size = 24_672
         end
 
         should "download the full size image" do
@@ -98,17 +96,17 @@ module Downloads
         end
 
         should "download the full size image instead of the HTML page" do
-          assert_rewritten(@p0_full_size_image_3, @medium_page)
-          assert_rewritten(@p0_full_size_image_3, @manga_page)
-          assert_rewritten(@p1_full_size_image_3, @manga_big_p1_page)
+          assert_rewritten(@p0_full_size_image, @medium_page)
+          assert_rewritten(@p0_full_size_image, @manga_page)
+          assert_rewritten(@p1_full_size_image, @manga_big_p1_page)
           assert_downloaded(@p0_file_size, @medium_page)
           assert_downloaded(@p0_file_size, @manga_page)
           assert_downloaded(@p1_file_size, @manga_big_p1_page)
         end
 
         should "download the full size image instead of the thumbnail" do
-          assert_rewritten(@p0_full_size_image_3, @p0_large_thumbnail)
-          assert_rewritten(@p1_full_size_image_3, @p1_large_thumbnail)
+          assert_rewritten(@p0_full_size_image, @p0_large_thumbnail)
+          assert_rewritten(@p1_full_size_image, @p1_large_thumbnail)
           assert_downloaded(@p0_file_size, @p0_large_thumbnail)
           assert_downloaded(@p1_file_size, @p1_large_thumbnail)
         end

--- a/test/unit/downloads/pixiv_test.rb
+++ b/test/unit/downloads/pixiv_test.rb
@@ -43,8 +43,6 @@ module Downloads
         end
       end
 
-
-
       # Test a new illustration (one uploaded after 2014-09-30). New illustrations
       # must use /img-original/ for full size URLs. Old /imgXX/img/username/ style URLs
       # don't work for images uploaded after this date.
@@ -109,6 +107,27 @@ module Downloads
           assert_rewritten(@p1_full_size_image, @p1_large_thumbnail)
           assert_downloaded(@p0_file_size, @p0_large_thumbnail)
           assert_downloaded(@p1_file_size, @p1_large_thumbnail)
+        end
+      end
+
+      context "downloading a bad id image" do
+        setup do
+          @bad_id_full   = "https://i.pximg.net/img-original/img/2017/11/22/01/06/44/65991677_p0.png"
+          @bad_id_sample = "https://i.pximg.net/c/600x600/img-master/img/2017/11/22/01/06/44/65991677_p0_master1200.jpg"
+        end
+
+        should "not raise an error when rewriting the url" do
+          assert_nothing_raised { assert_not_rewritten(@bad_id_full) }
+        end
+
+        should_eventually "rewrite bad id samples to full size" do
+          assert_rewritten(@bad_id_full, @bad_id_sample)
+        end
+
+        # XXX This may fail someday. Pixiv doesn't delete bad id images right
+        # away, but they may be deleted eventually.
+        should "download the image" do
+          assert_downloaded(21440, @bad_id_full)
         end
       end
 

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -127,6 +127,14 @@ module Sources
         end        
       end
 
+      context "fetching source data for a deleted work" do
+        should "raise a bad id error" do
+          assert_raise(::PixivApiClient::BadIDError) do
+            get_source("https://i.pximg.net/img-original/img/2017/11/22/01/06/44/65991677_p0.png")
+          end
+        end
+      end
+
       context "fetching the commentary" do
         should "work when the description is blank" do
           get_source("https://www.pixiv.net/member_illust.php?mode=medium&illust_id=65981746")


### PR DESCRIPTION
Fixes #3395:

* 5ba6373: Fixes a broken download test. A test post was deleted from Pixiv.

*  183a7e0: Fixes a failbooru when uploading a deleted Pixiv post. The API error message from Pixiv had the encoding set to ASCIII-8BIT instead of UTF-8.

* 0b5ed16: Fixes a `PixivApiClient::Error` when uploading a Pixiv image for a deleted work. Makes the Pixiv URL rewriter return the URL as-is if there's a bad ID error. This is a partial fix, because really we shouldn't fetch the source data at all during the rewrite process unless it's necessary.
