### PR TITLE
Changed safe mode error message for Gold+ users

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -87,11 +87,15 @@ module PostSets
     end
 
     def banned_posts
-      posts.select(&:is_banned?)
+      posts.select { |p| p.banblocked? }
     end
 
     def censored_posts
-      hidden_posts - banned_posts
+      posts.select { |p| p.levelblocked? && !p.banblocked? }
+    end
+
+    def safe_posts
+      posts.select { |p| p.safeblocked? && !p.levelblocked? && !p.banblocked? }
     end
 
     def use_sequential_paginator?

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1761,11 +1761,22 @@ class Post < ApplicationRecord
   )
   has_bit_flags BOOLEAN_ATTRIBUTES
 
+  def safeblocked?
+    CurrentUser.safe_mode? && (rating != "s" || has_tag?("toddlercon|toddler|diaper|tentacle|rape|bestiality|beastiality|lolita|loli|nude|shota|pussy|penis"))
+  end
+
+  def levelblocked?
+    !Danbooru.config.can_user_see_post?(CurrentUser.user, self)
+  end
+
+  def banblocked?
+    is_banned? && !CurrentUser.is_gold?
+  end
+
   def visible?
-    return false if !Danbooru.config.can_user_see_post?(CurrentUser.user, self)
-    return false if CurrentUser.safe_mode? && rating != "s"
-    return false if CurrentUser.safe_mode? && has_tag?("toddlercon|toddler|diaper|tentacle|rape|bestiality|beastiality|lolita|loli|nude|shota|pussy|penis")
-    return false if is_banned? && !CurrentUser.is_gold?
+    return false if safeblocked?
+    return false if levelblocked?
+    return false if banblocked?
     return true
   end
 

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -149,10 +149,19 @@ class PostPresenter < Presenter
     categorized_tag_groups.flatten.slice(0, 25).join(", ").tr("_", " ")
   end
 
+  def safe_mode_message(template)
+    html = ["This image is unavailable on safe mode (#{Danbooru.config.app_name}). Go to "]
+    html << template.link_to("Danbooru", "http://danbooru.donmai.us")
+    html << " or disable safe mode to view ("
+    html << template.link_to("learn more", template.wiki_pages_path(title: "help:user_settings"))
+    html << ")."
+    html.join.html_safe
+  end
+
   def image_html(template)
-    return template.content_tag("p", "The artist requested removal of this image") if @post.is_banned? && !CurrentUser.user.is_gold?
-    return template.content_tag("p", template.link_to("You need a gold account to see this image.", template.new_user_upgrade_path)) if !Danbooru.config.can_user_see_post?(CurrentUser.user, @post)
-    return template.content_tag("p", "This image is unavailable") if !@post.visible?
+    return template.content_tag("p", "The artist requested removal of this image") if @post.banblocked?
+    return template.content_tag("p", template.link_to("You need a gold account to see this image.", template.new_user_upgrade_path)) if @post.levelblocked?
+    return template.content_tag("p", safe_mode_message(template)) if @post.safeblocked?
 
     if @post.is_flash?
       template.render("posts/partials/show/flash", :post => @post)

--- a/app/views/posts/partials/index/_posts.html.erb
+++ b/app/views/posts/partials/index/_posts.html.erb
@@ -6,11 +6,15 @@
   <% if post_set.hidden_posts.present? %>
     <div class="tn hidden-posts-notice">
       <% if post_set.banned_posts.present? %>
-        <%= post_set.banned_posts.size %> post(s) were removed from this page at the artist's request (<%= link_to "learn more", wiki_pages_path(title: "banned_artist") %>).
+        <%= post_set.banned_posts.size %> post(s) were removed from this page at the artist's request (<%= link_to "learn more", wiki_pages_path(title: "banned_artist") %>).<br>
       <% end %>
 
       <% if post_set.censored_posts.present? %>
-        <%= post_set.censored_posts.size %> post(s) on this page require a <%= link_to "Gold account", new_user_upgrade_path %> to view (<%= link_to "learn more", wiki_pages_path(title: "help:censored_tags") %>).
+        <%= post_set.censored_posts.size %> post(s) on this page require a <%= link_to "Gold account", new_user_upgrade_path %> to view (<%= link_to "learn more", wiki_pages_path(title: "help:censored_tags") %>).<br>
+      <% end %>
+
+      <% if post_set.safe_posts.present? %>
+        <%= post_set.safe_posts.size %> post(s) on this page were hidden by safe mode (<%= Danbooru.config.app_name %>). Go to <%= link_to "Danbooru", "http://danbooru.donmai.us" %> or disable safe mode to view (<%= link_to "learn more", wiki_pages_path(title: "help:user_settings") %>).<br>
       <% end %>
     </div>
   <% end %>


### PR DESCRIPTION
It seems about once every few months a user asks on the forum why they can't view certain posts after they have upgraded to Gold+.  [Topic #14724](http://danbooru.donmai.us/forum_topics/14724) is just the latest, but if you look back, you can see it happens pretty often, probably moreso than gets reported.

This issue occurs mostly because the error message is confusing as pointed out by @kittey on the above topic.  It tells Gold+ users to upgrade to Gold when it hides content in Safe Mode.  Going by his recommendation to fix this issue, I changed the error message to redirect Gold+ users to Danbooru or to adjust their user settings due to #3392.  The wiki that was linked doesn't exist yet (**Help:User Settings**), but such a wiki probably should exist and I plan on creating one.  A hard link was added to the Danbooru domain, but if it's an issue it can always be moved to the config file (along with several other embedded hard links).