### PR TITLE
Fix #3406: Autocorrect typos during autocomplete

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -244,7 +244,7 @@
     $.ajax({
       url: "/tags/autocomplete.json",
       data: {
-        "search[name_matches]": term + "*"
+        "search[name_matches]": term
       },
       method: "get",
       success: function(data) {

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -890,21 +890,29 @@ class Tag < ApplicationRecord
     end
 
     def names_matches_with_aliases(name)
-      query1 = Tag.select("tags.name, tags.post_count, tags.category, null AS antecedent_name")
-        .search(:name_matches => name, :order => "count").limit(10)
+      name = normalize_name(name)
+      wildcard_name = name + '*'
 
-      name = name.mb_chars.downcase.to_escaped_for_sql_like
+      query1 = Tag.select("tags.name, tags.post_count, tags.category, null AS antecedent_name")
+        .search(:name_matches => wildcard_name, :order => "count").limit(10)
+
       query2 = TagAlias.select("tags.name, tags.post_count, tags.category, tag_aliases.antecedent_name")
         .joins("INNER JOIN tags ON tags.name = tag_aliases.consequent_name")
-        .where("tag_aliases.antecedent_name LIKE ? ESCAPE E'\\\\'", name)
+        .where("tag_aliases.antecedent_name LIKE ? ESCAPE E'\\\\'", wildcard_name.to_escaped_for_sql_like)
         .active
-        .where("tags.name NOT LIKE ? ESCAPE E'\\\\'", name)
+        .where("tags.name NOT LIKE ? ESCAPE E'\\\\'", wildcard_name.to_escaped_for_sql_like)
         .where("tag_aliases.post_count > 0")
         .order("tag_aliases.post_count desc")
         .limit(20) # Get 20 records even though only 10 will be displayed in case some duplicates get filtered out.
 
       sql_query = "((#{query1.to_sql}) UNION ALL (#{query2.to_sql})) AS unioned_query"
-      Tag.select("DISTINCT ON (name, post_count) *").from(sql_query).order("post_count desc").limit(10)
+      tags = Tag.select("DISTINCT ON (name, post_count) *").from(sql_query).order("post_count desc").limit(10)
+
+      if tags.empty?
+        tags = Tag.fuzzy_name_matches(name).order_similarity(name).nonempty.limit(10)
+      end
+
+      tags
     end
   end
 

--- a/db/migrate/20171127195124_add_trigram_index_to_tags.rb
+++ b/db/migrate/20171127195124_add_trigram_index_to_tags.rb
@@ -1,0 +1,9 @@
+class AddTrigramIndexToTags < ActiveRecord::Migration
+  def up
+    execute "create index index_tags_on_name_trgm on tags using gin (name gin_trgm_ops)"
+  end
+
+  def down
+    execute "drop index index_tags_on_name_trgm"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -7009,6 +7009,13 @@ CREATE INDEX index_tags_on_name_pattern ON tags USING btree (name text_pattern_o
 
 
 --
+-- Name: index_tags_on_name_trgm; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_tags_on_name_trgm ON tags USING gin (name gin_trgm_ops);
+
+
+--
 -- Name: index_token_buckets_on_user_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -7520,4 +7527,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170709190409');
 INSERT INTO schema_migrations (version) VALUES ('20170914200122');
 
 INSERT INTO schema_migrations (version) VALUES ('20171106075030');
+
+INSERT INTO schema_migrations (version) VALUES ('20171127195124');
 


### PR DESCRIPTION
Implements #3406. During autocompletion, if no matches are found (presumably because of a typo), then we do a fuzzy name search and return the tags that the closest to what the user typed.

A trigram index is added to make this efficient. A query takes about 100ms-150ms on my machine.

The best way to see how this feels is to try it for yourself. I have it running on http://devbooru.tk:10000/. Some things it's able to correct:

* `longhaie` -> `long_hair` (simple typos)
* `miku_hatsune` -> `hatsune_miku` (wrong name order)
* `ataraxia` -> `fate/hollow_ataraxia` (missing words)