### PR TITLE
Fix Dmail so that prior unread mail won't cause notice to appear

### DIFF
--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -99,7 +99,7 @@
       <%= render "users/ban_notice" %>
     <% end %>
 
-    <% if CurrentUser.has_mail? && CurrentUser.dmails.unread.first.present? && cookies[:hide_dmail_notice].to_i != CurrentUser.dmails.unread.first.id %>
+    <% if CurrentUser.has_mail? && CurrentUser.dmails.unread.first.present? && (cookies[:hide_dmail_notice].blank? || cookies[:hide_dmail_notice].to_i < CurrentUser.dmails.unread.first.id) %>
       <%= render "users/dmail_notice" %>
     <% end %>
 


### PR DESCRIPTION
I noticed this bug recently due to leaving several Dmails unread for script testing purposes.

Basically, if you get a new mail and then hide the notice, it will set the ID to the most recent unread Dmail.  However, if that message gets read, then it will no longer be the most recent unread, causing the prior ID equality check to fail, causing the user to get the unread mail notice even though there is no new mail.

So instead of checking for equality, it now checks for presence in case the cookie doesn't exist, then it checks that the most recent Dmail ID is greater than the cookie's value.