### PR TITLE
Fix deleted comments visibility on partial index by comment

### DIFF
--- a/app/views/comments/_index_by_comment.html.erb
+++ b/app/views/comments/_index_by_comment.html.erb
@@ -1,7 +1,7 @@
 <div id="p-index-by-comment" class="comments-for-post">
   <div class="list-of-comments">
     <% @comments.each do |comment| %>
-      <% if CurrentUser.is_moderator? || !comment.is_deleted? %>
+      <% if CurrentUser.is_moderator? || (params[:search] && params[:search][:is_deleted] =~ /t/) || !comment.is_deleted? %>
         <div id="post_<%= comment.post.id %>" class="post <%= PostPresenter.preview_class(comment.post) %>" <%= PostPresenter.data_attributes(comment.post) %>>
           <div class="preview">
             <% if comment.post.visible? %>


### PR DESCRIPTION
Related to issue #3291.  The resolution of that issue allows deleted comments to be shown on all other views but the `group_by=comment` partial view, since that partial has its own check for deleted comments as well.  Therefore, this adds the same fix used with the prior issue on the **index_by_comment** view.