### PR TITLE
Fix #3430: Accept the search[id] param in all controllers 

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,7 +9,7 @@ class ApplicationRecord < ActiveRecord::Base
 
         column = column_for_attribute(attribute)
         qualified_column = "#{table_name}.#{column.name}"
-        parsed_range = Tag.parse_helper(range, :integer)
+        parsed_range = Tag.parse_helper(range, column.type)
 
         PostQueryBuilder.new(nil).add_range_relation(parsed_range, qualified_column, self)
       end
@@ -19,6 +19,8 @@ class ApplicationRecord < ActiveRecord::Base
 
         q = all
         q = q.attribute_matches(:id, params[:id])
+        q = q.attribute_matches(:created_at, params[:created_at]) if attribute_names.include?("created_at")
+        q = q.attribute_matches(:updated_at, params[:updated_at]) if attribute_names.include?("updated_at")
         q
       end
     end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,6 +1,29 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
+  concerning :SearchMethods do
+    class_methods do
+      # range: "5", ">5", "<5", ">=5", "<=5", "5..10", "5,6,7"
+      def attribute_matches(attribute, range)
+        return all if range.blank?
+
+        column = column_for_attribute(attribute)
+        qualified_column = "#{table_name}.#{column.name}"
+        parsed_range = Tag.parse_helper(range, :integer)
+
+        PostQueryBuilder.new(nil).add_range_relation(parsed_range, qualified_column, self)
+      end
+
+      def search(params = {})
+        params ||= {}
+
+        q = all
+        q = q.attribute_matches(:id, params[:id])
+        q
+      end
+    end
+  end
+
   module ApiMethods
     extend ActiveSupport::Concern
 

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -426,7 +426,7 @@ class Artist < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       case params[:name]
@@ -494,10 +494,6 @@ class Artist < ApplicationRecord
         q = q.banned
       elsif params[:is_banned] == "false"
         q = q.unbanned
-      end
-
-      if params[:id].present?
-        q = q.where("artists.id in (?)", params[:id].split(",").map(&:to_i))
       end
 
       if params[:creator_name].present?

--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -32,7 +32,7 @@ class ArtistCommentary < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:text_matches].present?

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -14,7 +14,7 @@ class ArtistVersion < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:name].present?

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -23,11 +23,7 @@ class BulkUpdateRequest < ApplicationRecord
 
   module SearchMethods
     def search(params = {})
-      q = where("true")
-
-      if params[:id].present?
-        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
-      end
+      q = super
 
       if params[:user_name].present?
         q = q.where(user_id: User.name_to_id(params[:user_name]))

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -92,14 +92,10 @@ class Comment < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
 
       if params[:body_matches].present?
         q = q.body_matches(params[:body_matches])
-      end
-
-      if params[:id].present?
-        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
       end
 
       if params[:post_id].present?

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -186,7 +186,7 @@ class Dmail < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:title_matches].present?

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -34,7 +34,7 @@ class FavoriteGroup < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:creator_id].present?

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -65,7 +65,8 @@ class ForumPost < ApplicationRecord
     end
 
     def search(params)
-      q = permitted
+      q = super
+      q = q.permitted
       return q if params.blank?
 
       if params[:creator_id].present?

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -73,11 +73,8 @@ class ForumTopic < ApplicationRecord
     end
 
     def search(params)
-      q = permitted
-
-      if params[:id].present?
-        q = q.where(id: params[:id].split(",").map(&:to_i))
-      end
+      q = super
+      q = q.permitted
 
       if params[:mod_only].present?
         q = q.where("min_level >= ?", MIN_LEVELS[:Moderator])

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -42,7 +42,7 @@ class Note < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:body_matches].present?

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -50,15 +50,11 @@ class Pool < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:name_matches].present?
         q = q.name_matches(params[:name_matches])
-      end
-
-      if params[:id].present?
-        q = q.where("pools.id in (?)", params[:id].split(","))
       end
 
       if params[:description_matches].present?

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -15,7 +15,7 @@ class PoolArchive < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:updater_id].present?

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -13,7 +13,7 @@ class PoolVersion < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:updater_id].present?

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -44,7 +44,8 @@ class PostAppeal < ApplicationRecord
     end
 
     def search(params)
-      q = order("post_appeals.id desc")
+      q = super
+      q = q.order("post_appeals.id desc")
       return q if params.blank?
 
       if params[:reason_matches].present?

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -26,7 +26,7 @@ class PostArchive < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:updater_name].present?

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -66,7 +66,8 @@ class PostFlag < ApplicationRecord
     end
 
     def search(params)
-      q = order("post_flags.id desc")
+      q = super
+      q = q.order("post_flags.id desc")
       return q if params.blank?
 
       if params[:reason_matches].present?

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -89,7 +89,7 @@ class PostReplacement < ApplicationRecord
     end
 
     def search(params = {})
-      q = all
+      q = super
 
       if params[:creator_id].present?
         q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
@@ -97,10 +97,6 @@ class PostReplacement < ApplicationRecord
 
       if params[:creator_name].present?
         q = q.where(creator_id: User.name_to_id(params[:creator_name]))
-      end
-
-      if params[:id].present?
-        q = q.where(id: params[:id].split(",").map(&:to_i))
       end
 
       if params[:post_id].present?

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -14,7 +14,7 @@ class PostVersion < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:updater_name].present?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -275,7 +275,7 @@ class Tag < ApplicationRecord
       when :float
         object.to_f
 
-      when :date
+      when :date, :datetime
         begin
           Time.zone.parse(object)
         rescue Exception

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -838,7 +838,7 @@ class Tag < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:fuzzy_name_matches].present?

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -73,11 +73,7 @@ class TagRelationship < ApplicationRecord
     end
 
     def search(params)
-      q = all
-
-      if params[:id].present?
-        q = q.where(id: params[:id].split(",").map(&:to_i))
-      end
+      q = super
 
       if params[:name_matches].present?
         q = q.name_matches(params[:name_matches])

--- a/app/models/tag_subscription.rb
+++ b/app/models/tag_subscription.rb
@@ -39,7 +39,7 @@ class TagSubscription < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:creator_id]

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -495,7 +495,7 @@ class Upload < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:uploader_id].present?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -813,7 +813,7 @@ class User < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:name].present?
@@ -834,10 +834,6 @@ class User < ApplicationRecord
 
       if params[:level].present?
         q = q.where("level = ?", params[:level].to_i)
-      end
-
-      if params[:id].present?
-        q = q.where("id in (?)", params[:id].split(",").map(&:to_i))
       end
 
       bitprefs_length = BOOLEAN_ATTRIBUTES.length

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -44,7 +44,7 @@ class UserFeedback < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:user_id].present?

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -60,7 +60,7 @@ class WikiPage < ApplicationRecord
     end
 
     def search(params = {})
-      q = where("true")
+      q = super
       params = {} if params.blank?
 
       if params[:title].present?

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -11,7 +11,7 @@ class WikiPageVersion < ApplicationRecord
     end
 
     def search(params)
-      q = where("true")
+      q = super
       return q if params.blank?
 
       if params[:updater_id].present?

--- a/test/unit/application_record.rb
+++ b/test/unit/application_record.rb
@@ -15,5 +15,10 @@ class ApplicationRecordTest < ActiveSupport::TestCase
       assert_equal(@tags.reverse, Tag.search(id: "#{@tags[0].id}..#{@tags[2].id}"))
       assert_equal(@tags.reverse, Tag.search(id: @tags.map(&:id).join(",")))
     end
+
+    should "support the created_at and updated_at params" do
+      assert_equal(@tags.reverse, Tag.search(created_at: ">=#{@tags.first.created_at}"))
+      assert_equal(@tags.reverse, Tag.search(updated_at: ">=#{@tags.first.updated_at}"))
+    end
   end
 end

--- a/test/unit/application_record.rb
+++ b/test/unit/application_record.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class ApplicationRecordTest < ActiveSupport::TestCase
+  setup do
+    @tags = FactoryGirl.create_list(:tag, 3, post_count: 1)
+  end
+
+  context "ApplicationRecord#search" do
+    should "support the id param" do
+      assert_equal([@tags.first], Tag.search(id: @tags.first.id))
+    end
+
+    should "support ranges in the id param" do
+      assert_equal(@tags.reverse, Tag.search(id: ">=1"))
+      assert_equal(@tags.reverse, Tag.search(id: "#{@tags[0].id}..#{@tags[2].id}"))
+      assert_equal(@tags.reverse, Tag.search(id: @tags.map(&:id).join(",")))
+    end
+  end
+end


### PR DESCRIPTION
Implements #3430:

* Refactors to add a `search` method to `ApplicationRecord` which handles the `search[id]` param. The `search` method in each model now calls `super` first to handle `search[id]`.

* Adds support for `search[created_at]` and `search[updated_at]` params while we're at it. It's easy and nearly every model has these columns.

* `Tag#parse_helper` and `PostQueryBuilder#add_range_relation` are used to parse the params, so that ranges (e.g. `search[id]=1..10`) are supported. These methods should probably be factored out to make this cleaner.