### PR TITLE
Fix incorrect showing of favorites and favorite groups with privacy settings enabled

### DIFF
--- a/app/controllers/favorite_groups_controller.rb
+++ b/app/controllers/favorite_groups_controller.rb
@@ -13,6 +13,7 @@ class FavoriteGroupsController < ApplicationController
 
   def show
     @favorite_group = FavoriteGroup.find(params[:id])
+    check_read_privilege(@favorite_group)
     @post_set = PostSets::FavoriteGroup.new(@favorite_group, params[:page])
     respond_with(@favorite_group)
   end
@@ -37,13 +38,13 @@ class FavoriteGroupsController < ApplicationController
 
   def edit
     @favorite_group = FavoriteGroup.find(params[:id])
-    check_privilege(@favorite_group)
+    check_write_privilege(@favorite_group)
     respond_with(@favorite_group)
   end
 
   def update
     @favorite_group = FavoriteGroup.find(params[:id])
-    check_privilege(@favorite_group)
+    check_write_privilege(@favorite_group)
     @favorite_group.update_attributes(params[:favorite_group])
     unless @favorite_group.errors.any?
       flash[:notice] = "Favorite group updated"
@@ -53,7 +54,7 @@ class FavoriteGroupsController < ApplicationController
 
   def destroy
     @favorite_group = FavoriteGroup.find(params[:id])
-    check_privilege(@favorite_group)
+    check_write_privilege(@favorite_group)
     @favorite_group.destroy
     flash[:notice] = "Favorite group deleted"
     redirect_to favorite_groups_path
@@ -61,13 +62,17 @@ class FavoriteGroupsController < ApplicationController
 
   def add_post
     @favorite_group = FavoriteGroup.find(params[:id])
-    check_privilege(@favorite_group)
+    check_write_privilege(@favorite_group)
     @post = Post.find(params[:post_id])
     @favorite_group.add!(@post.id)
   end
 
 private
-  def check_privilege(favgroup)
+  def check_write_privilege(favgroup)
     raise User::PrivilegeError unless favgroup.editable_by?(CurrentUser.user)
+  end
+
+  def check_read_privilege(favgroup)
+    raise User::PrivilegeError unless favgroup.viewable_by?(CurrentUser.user)
   end
 end

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -400,12 +400,6 @@ class PostQueryBuilder
 
     if q[:ordfav].present?
       user_id = q[:ordfav].to_i
-      user = User.find(user_id)
-
-      if user.hide_favorites?
-        raise User::PrivilegeError.new
-      end
-
       relation = relation.joins("INNER JOIN favorites ON favorites.post_id = posts.id")
       relation = relation.where("favorites.user_id % 100 = ? and favorites.user_id = ?", user_id % 100, user_id).order("favorites.id DESC")
     end

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -237,4 +237,8 @@ class FavoriteGroup < ApplicationRecord
   def editable_by?(user)
     creator_id == user.id
   end
+
+  def viewable_by?(user)
+    creator_id == user.id || !creator.hide_favorites?
+  end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -617,13 +617,31 @@ class Tag < ApplicationRecord
             q[:favgroups] << favgroup_id
 
           when "-fav"
+            favuser = User.find_by_name(g2)
+
+            if favuser.hide_favorites?
+              raise User::PrivilegeError.new
+            end
+
             q[:tags][:exclude] << "fav:#{User.name_to_id(g2)}"
 
           when "fav"
+            favuser = User.find_by_name(g2)
+
+            if favuser.hide_favorites?
+              raise User::PrivilegeError.new
+            end
+
             q[:tags][:related] << "fav:#{User.name_to_id(g2)}"
 
           when "ordfav"
             user_id = User.name_to_id(g2)
+            favuser = User.find(user_id)
+
+            if favuser.hide_favorites?
+              raise User::PrivilegeError.new
+            end
+
             q[:tags][:related] << "fav:#{user_id}"
             q[:ordfav] = user_id
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -608,11 +608,23 @@ class Tag < ApplicationRecord
 
           when "-favgroup"
             favgroup_id = FavoriteGroup.name_to_id(g2)
+            favgroup = FavoriteGroup.find(favgroup_id)
+
+            if !favgroup.viewable_by?(CurrentUser.user)
+              raise User::PrivilegeError.new
+            end
+
             q[:favgroups_neg] ||= []
             q[:favgroups_neg] << favgroup_id
 
           when "favgroup"
             favgroup_id = FavoriteGroup.name_to_id(g2)
+            favgroup = FavoriteGroup.find(favgroup_id)
+
+            if !favgroup.viewable_by?(CurrentUser.user)
+              raise User::PrivilegeError.new
+            end
+
             q[:favgroups] ||= []
             q[:favgroups] << favgroup_id
 


### PR DESCRIPTION
This fixes a long existing hole in the privacy settings.  Previously, users could still check a user's favorites or favorite groups by using the post query.  Additionally, favorite groups could be found by enumerating them manually.

However, this now brings up the issue of a user wanting to only have some of their favorite groups public, and some private.  Having a favorite group public provides a nice way of showing a group of posts a user has collected so others can look at, such as demonstrating a certain issue.

The above should be handled as a separate pull though.  The simplest way to implement would be to add an ``is_public`` value to all favorite groups which overides any privacy settings.  So if ``is_public`` were true, then it would show the favorite group no matter what.  Otherwise, it would go by the user's privacy settings.

