### PR TITLE
Add character list wikis to copyright related tag response

### DIFF
--- a/app/assets/javascripts/related_tag.js
+++ b/app/assets/javascripts/related_tag.js
@@ -124,6 +124,7 @@
     var query = Danbooru.RelatedTag.recent_search.query;
     var related_tags = Danbooru.RelatedTag.recent_search.tags;
     var wiki_page_tags = Danbooru.RelatedTag.recent_search.wiki_page_tags;
+    var other_wikis = Danbooru.RelatedTag.recent_search.other_wikis;
     var $dest = $("#related-tags");
     $dest.empty();
 
@@ -134,6 +135,9 @@
     if (wiki_page_tags.length) {
       $dest.append(Danbooru.RelatedTag.build_html("wiki:" + query, wiki_page_tags, "wiki"));
     }
+    $.each(other_wikis, function(i,wiki) {
+      $dest.append(Danbooru.RelatedTag.build_html("wiki:" + wiki.title, wiki.wiki_page_tags, "otherwiki" + i.toString()));
+    });
     if (Danbooru.RelatedTag.recent_artists) {
       var tags = [];
       if (Danbooru.RelatedTag.recent_artists.length === 0) {

--- a/app/logical/related_tag_query.rb
+++ b/app/logical/related_tag_query.rb
@@ -26,12 +26,26 @@ class RelatedTagQuery
     results
   end
 
+  def other_wiki_category_tags
+    if Tag.category_for(query) != Tag.categories.copyright
+      return []
+    end
+    listtags = (wiki_page.try(:tags) || []).select {|name| name =~ /^list_of_/i }
+    results = listtags.map do |name|
+      listlinks = WikiPage.titled(name).first.try(:tags) || []
+      if listlinks.length > 0
+        {"title" => name, "wiki_page_tags" => map_with_category_data(listlinks)}
+      end
+    end
+    results.reject {|list| list.nil?}
+  end
+
   def tags_for_html
     map_with_category_data(tags)
   end
 
   def to_json
-    {:query => query, :category => category, :tags => map_with_category_data(tags), :wiki_page_tags => map_with_category_data(wiki_page_tags)}.to_json
+    {:query => query, :category => category, :tags => map_with_category_data(tags), :wiki_page_tags => map_with_category_data(wiki_page_tags), :other_wikis => other_wiki_category_tags}.to_json
   end
 
 protected


### PR DESCRIPTION
I first brought up this idea on the [forum](http://danbooru.donmai.us/forum_topics/14709).  Basically the **list_of_*** character wikis contain a lot of useful information that is currently awkward to access when tagging a post, since you have to add the **list_of_*** text, click the related tag button, and then remember to remove that **list_of_*** when done so that you don't inadvertently create a tag, all without autocomplete since the tag either doesn't exist or is empty.

The above is why I haven't migrated the characters on several different copyright wikis, as I find having the list of characters right at hand extremely convenient.  Having this pull in place would allow a lot of these copyright wikis to be cleaned up and made more efficient.

This pull would only be active on copyright tags with **list_of_*** wikis, as the two almost always have a high degree of correlation, usually being the character page for that series.  I would have liked to restrict it to **list_of_*_characters**, but there a [few oddballs that make this unrealizable](http://danbooru.donmai.us/wiki_pages/80359#dtext-list-character).  Additionally, it doesn't mess with the current API schema, but instead it adds an additional entry **other_wikis** which contains the array of **list_of_*** wiki tags, and is empty in all other cases.