### PR TITLE
Fix #3324: Incorporate replacement comment info in the replacement history

### DIFF
--- a/app/controllers/post_replacements_controller.rb
+++ b/app/controllers/post_replacements_controller.rb
@@ -14,6 +14,13 @@ class PostReplacementsController < ApplicationController
     respond_with(@post_replacement, location: @post)
   end
 
+  def update
+    @post_replacement = PostReplacement.find(params[:id])
+    @post_replacement.update(update_params)
+
+    respond_with(@post_replacement)
+  end
+
   def index
     params[:search][:post_id] = params.delete(:post_id) if params.has_key?(:post_id)
     @post_replacements = PostReplacement.search(params[:search]).paginate(params[:page], limit: params[:limit])
@@ -24,5 +31,13 @@ class PostReplacementsController < ApplicationController
 private
   def create_params
     params.require(:post_replacement).permit(:replacement_url, :replacement_file, :final_source, :tags)
+  end
+
+  def update_params
+    params.require(:post_replacement).permit(
+      :file_ext_was, :file_size_was, :image_width_was, :image_height_was, :md5_was,
+      :file_ext, :file_size, :image_width, :image_height, :md5,
+      :original_url, :replacement_url
+    )
   end
 end

--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -15,6 +15,8 @@
         <tr>
           <th width="1%">Post</th>
           <th>Source</th>
+          <th>MD5</th>
+          <th>Size</th>
           <th>Replacer</th>
         </tr>
       </thead>
@@ -36,6 +38,37 @@
                 </dd>
               </dl>
             </td>
+
+            <td>
+              <% if post_replacement.md5_was.present? && post_replacement.md5.present? %>
+                <dl>
+                  <dt>Original MD5</dt>
+                  <dd><%= post_replacement.md5_was %></dd>
+
+                  <dt>Replacement MD5</dt>
+                  <dd><%= post_replacement.md5 %></dd>
+                </dl>
+              <% end %>
+            </td>
+
+            <td>
+              <% if %i[image_width_was image_height_was file_size_was file_ext_was image_width image_height file_size file_ext].all? { |k| post_replacement[k].present? } %>
+                <dl>
+                  <dt>Original Size</dt>
+                  <dd>
+                    <%= post_replacement.image_width_was %>x<%= post_replacement.image_height_was %>
+                    (<%= post_replacement.file_size_was.to_s(:human_size, precision: 4) %>, <%= post_replacement.file_ext_was %>)
+                  </dd>
+
+                  <dt>Replacement Size</dt>
+                  <dd>
+                    <%= post_replacement.image_width %>x<%= post_replacement.image_height %>
+                    (<%= post_replacement.file_size.to_s(:human_size, precision: 4) %>, <%= post_replacement.file_ext %>)
+                  </dd>
+                </dl>
+              <% end %>
+            </td>
+
             <td>
               <%= compact_time post_replacement.created_at %>
               <br> by <%= link_to_user post_replacement.creator %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,7 +195,7 @@ Rails.application.routes.draw do
       get :diff
     end
   end
-  resources :post_replacements, :only => [:index, :new, :create]
+  resources :post_replacements, :only => [:index, :new, :create, :update]
   resources :posts do
     resources :events, :only => [:index], :controller => "post_events"
     resources :replacements, :only => [:index, :new, :create], :controller => "post_replacements"

--- a/db/migrate/20171218213037_add_metadata_to_post_replacements.rb
+++ b/db/migrate/20171218213037_add_metadata_to_post_replacements.rb
@@ -1,0 +1,17 @@
+class AddMetadataToPostReplacements < ActiveRecord::Migration
+  def change
+    PostReplacement.without_timeout do
+      add_column :post_replacements, :file_ext_was, :string
+      add_column :post_replacements, :file_size_was, :integer
+      add_column :post_replacements, :image_width_was, :integer
+      add_column :post_replacements, :image_height_was, :integer
+      add_column :post_replacements, :md5_was, :string
+
+      add_column :post_replacements, :file_ext, :string
+      add_column :post_replacements, :file_size, :integer
+      add_column :post_replacements, :image_width, :integer
+      add_column :post_replacements, :image_height, :integer
+      add_column :post_replacements, :md5, :string
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2666,7 +2666,17 @@ CREATE TABLE post_replacements (
     original_url text NOT NULL,
     replacement_url text NOT NULL,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    file_ext_was character varying,
+    file_size_was integer,
+    image_width_was integer,
+    image_height_was integer,
+    md5_was character varying,
+    file_ext character varying,
+    file_size integer,
+    image_width integer,
+    image_height integer,
+    md5 character varying
 );
 
 
@@ -7529,4 +7539,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170914200122');
 INSERT INTO schema_migrations (version) VALUES ('20171106075030');
 
 INSERT INTO schema_migrations (version) VALUES ('20171127195124');
+
+INSERT INTO schema_migrations (version) VALUES ('20171218213037');
 

--- a/test/functional/post_replacements_controller_test.rb
+++ b/test/functional/post_replacements_controller_test.rb
@@ -43,6 +43,25 @@ class PostReplacementsControllerTest < ActionController::TestCase
       end
     end
 
+    context "update action" do
+      should "update the replacement" do
+        params = {
+          format: :json,
+          id: @post_replacement.id,
+          post_replacement: {
+            file_size_was: 23,
+            file_size: 42,
+          }
+        }
+
+        put :update, params, { user_id: @user.id }
+        @post_replacement.reload
+
+        assert_equal(23, @post_replacement.file_size_was)
+        assert_equal(42, @post_replacement.file_size)
+      end
+    end
+
     context "index action" do
       should "render" do
         get :index, {format: :json}

--- a/test/unit/post_replacement_test.rb
+++ b/test/unit/post_replacement_test.rb
@@ -30,7 +30,7 @@ class PostReplacementTest < ActiveSupport::TestCase
 
   def teardown
     super
-    
+
     CurrentUser.user = nil
     CurrentUser.ip_addr = nil
     Delayed::Worker.delay_jobs = false
@@ -49,6 +49,7 @@ class PostReplacementTest < ActiveSupport::TestCase
       setup do
         @post.update(source: "https://www.google.com/images/branding/googlelogo/1x/googlelogo_color_272x92dp.png")
         @post.replace!(replacement_url: "https://www.google.com/intl/en_ALL/images/logo.gif", tags: "-tag1 tag2")
+        @replacement = @post.replacements.last
         @upload = Upload.last
       end
 
@@ -77,6 +78,22 @@ class PostReplacementTest < ActiveSupport::TestCase
 
       should "create a post replacement record" do
         assert_equal(@post.id, PostReplacement.last.post_id)
+      end
+
+      should "record the old file metadata" do
+        assert_equal(500, @replacement.image_width_was)
+        assert_equal(335, @replacement.image_height_was)
+        assert_equal(28086, @replacement.file_size_was)
+        assert_equal("jpg", @replacement.file_ext_was)
+        assert_equal("ecef68c44edb8a0d6a3070b5f8e8ee76", @replacement.md5_was)
+      end
+
+      should "record the new file metadata" do
+        assert_equal(276, @replacement.image_width)
+        assert_equal(110, @replacement.image_height)
+        assert_equal(8558, @replacement.file_size)
+        assert_equal("gif", @replacement.file_ext)
+        assert_equal("e80d1c59a673f560785784fb1ac10959", @replacement.md5)
       end
 
       should "correctly update the attributes" do


### PR DESCRIPTION
Fixes #3324:

* Tracks the changes in the image metadata - the md5, file size, file extension, image width, and image height - in the post replacement history.

* Adds a `PUT /post_replacements/:id.json` endpoint for updating an existing replacement's metadata. This is to allow for metadata in old replacements to be backpopulated. 

Screenshot of `/post_replacements`:

![image](https://user-images.githubusercontent.com/8430473/34134322-8c6c8134-e41f-11e7-95fe-302152933329.png)