### PR TITLE
Give option to make favorite groups public

### DIFF
--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -11,7 +11,7 @@ class FavoriteGroup < ApplicationRecord
   validate :creator_can_create_favorite_groups, :on => :create
   validate :validate_number_of_posts
   before_save :update_post_count
-  attr_accessible :name, :post_ids, :post_id_array, :as => [:member, :gold, :platinum, :builder, :moderator, :admin, :default]
+  attr_accessible :name, :post_ids, :post_id_array, :is_public, :as => [:member, :gold, :platinum, :builder, :moderator, :admin, :default]
 
   module SearchMethods
     def for_creator(user_id)
@@ -33,27 +33,30 @@ class FavoriteGroup < ApplicationRecord
       where("name ilike ? escape E'\\\\'", name.to_escaped_for_sql_like)
     end
 
+    def hide_private(user,params)
+      if user.hide_favorites?
+        where("is_public = true")
+      elsif params[:is_public].present?
+        where("is_public = ?", params[:is_public])
+      else
+        where("true")
+      end
+    end
+
     def search(params)
       q = super
       params = {} if params.blank?
 
       if params[:creator_id].present?
         user = User.find(params[:creator_id])
-        
-        if user.hide_favorites?
-          raise User::PrivilegeError.new
-        end
-
+        q = q.hide_private(user,params)
         q = q.where("creator_id = ?", user.id)
       elsif params[:creator_name].present?
         user = User.find_by_name(params[:creator_name])
-
-        if user.hide_favorites?
-          raise User::PrivilegeError.new
-        end
-
+        q = q.hide_private(user,params)
         q = q.where("creator_id = ?", user.id)
       else
+        q = q.hide_private(CurrentUser.user,params)
         q = q.where("creator_id = ?", CurrentUser.user.id)
       end
 
@@ -243,6 +246,6 @@ class FavoriteGroup < ApplicationRecord
   end
 
   def viewable_by?(user)
-    creator_id == user.id || !creator.hide_favorites?
+    creator_id == user.id || !creator.hide_favorites? || is_public
   end
 end

--- a/app/views/favorite_groups/edit.html.erb
+++ b/app/views/favorite_groups/edit.html.erb
@@ -7,6 +7,7 @@
     <%= simple_form_for(@favorite_group) do |f| %>
       <%= f.input :name, :as => :string, :input_html => { :value => @favorite_group.pretty_name } %>
       <%= f.input :post_ids, :label => "Posts" %>
+      <%= f.input :is_public %>
       <%= f.button :submit, "Submit" %>
     <% end %>
   </div>

--- a/db/migrate/20171219001521_add_is_public_to_favorite_groups.rb
+++ b/db/migrate/20171219001521_add_is_public_to_favorite_groups.rb
@@ -1,0 +1,7 @@
+class AddIsPublicToFavoriteGroups < ActiveRecord::Migration
+  def change
+    FavoriteGroup.without_timeout do
+      add_column :favorite_groups, :is_public, :boolean, default: false, null: false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1044,7 +1044,8 @@ CREATE TABLE favorite_groups (
     post_ids text DEFAULT ''::text NOT NULL,
     post_count integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone,
-    updated_at timestamp without time zone
+    updated_at timestamp without time zone,
+    is_public boolean DEFAULT false NOT NULL
 );
 
 
@@ -7529,4 +7530,6 @@ INSERT INTO schema_migrations (version) VALUES ('20170914200122');
 INSERT INTO schema_migrations (version) VALUES ('20171106075030');
 
 INSERT INTO schema_migrations (version) VALUES ('20171127195124');
+
+INSERT INTO schema_migrations (version) VALUES ('20171219001521');
 


### PR DESCRIPTION
Builds onto #3433 by giving the option to make favorite groups public.  It also changes how the index search parameters are handled, showing only the public favorite groups instead of throwing a permission error.