### PR TITLE
Fix #3440: Implications aren't applied to automatic tags.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -712,12 +712,12 @@ class Post < ApplicationRecord
       normalized_tags = remove_negated_tags(normalized_tags)
       normalized_tags = TagAlias.to_aliased(normalized_tags)
       normalized_tags = %w(tagme) if normalized_tags.empty?
-      normalized_tags = TagImplication.with_descendants(normalized_tags)
-      normalized_tags = Tag.create_for_list(add_automatic_tags(normalized_tags))
+      normalized_tags = add_automatic_tags(normalized_tags)
       normalized_tags = normalized_tags + Tag.create_for_list(TagImplication.automatic_tags_for(normalized_tags))
-      normalized_tags = normalized_tags.compact
-      normalized_tags.sort!
-      set_tag_string(normalized_tags.uniq.sort.join(" "))
+      normalized_tags = TagImplication.with_descendants(normalized_tags)
+      normalized_tags = normalized_tags.compact.uniq.sort
+      normalized_tags = Tag.create_for_list(normalized_tags)
+      set_tag_string(normalized_tags.join(" "))
     end
 
     def remove_negated_tags(tags)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -16,6 +16,7 @@ class PostTest < ActiveSupport::TestCase
     super
 
     Timecop.travel(2.weeks.ago) do
+      User.any_instance.stubs(:validate_sock_puppets).returns(true)
       @user = FactoryGirl.create(:user)
     end
     CurrentUser.user = @user
@@ -798,6 +799,14 @@ class PostTest < ActiveSupport::TestCase
 
             assert(@post.has_tag?("james"), "expected 'jim' to be aliased to 'james'")
           end
+
+          should "apply implications after the character tag is added" do
+            FactoryGirl.create(:tag_implication, antecedent_name: "jimmy", consequent_name: "jim")
+            @post.add_tag("jimmy_(cosplay)")
+            @post.save
+
+            assert(@post.has_tag?("jim"), "expected 'jimmy' to imply 'jim'")
+          end
         end
 
         context "for a parent" do
@@ -1211,6 +1220,7 @@ class PostTest < ActiveSupport::TestCase
 
       context "with a .webm file extension" do
         setup do
+          FactoryGirl.create(:tag_implication, antecedent_name: "webm", consequent_name: "animated")
           @post.file_ext = "webm"
           @post.tag_string = ""
           @post.save
@@ -1218,6 +1228,10 @@ class PostTest < ActiveSupport::TestCase
 
         should "have the appropriate file type tag added automatically" do
           assert_match(/webm/, @post.tag_string)
+        end
+
+        should "apply implications after adding the file type tag" do
+          assert(@post.has_tag?("animated"), "expected 'webm' to imply 'animated'")
         end
       end
 


### PR DESCRIPTION
Fixes #3440. Applies implications after automatic tags are added.