### PR TITLE
Fix #3444: Add validation warning for non-general/meta tags

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1744,11 +1744,18 @@ class Post < ApplicationRecord
       new_tags = added_tags.select { |t| t.post_count <= 1 }
       new_general_tags = new_tags.select { |t| t.category == Tag.categories.general }
       new_artist_tags = new_tags.select { |t| t.category == Tag.categories.artist }
+      repopulated_tags = new_tags.select { |t| (t.category != Tag.categories.general) && (t.category != Tag.categories.meta) && (t.created_at < 1.hour.ago) }
 
       if new_general_tags.present?
         n = new_general_tags.size
         tag_wiki_links = new_general_tags.map { |tag| "[[#{tag.name}]]" }
         self.warnings[:base] << "Created #{n} new #{n == 1 ? "tag" : "tags"}: #{tag_wiki_links.join(", ")}"
+      end
+
+      if repopulated_tags.present?
+        n = repopulated_tags.size
+        tag_wiki_links = repopulated_tags.map { |tag| "[[#{tag.name}]]" }
+        self.warnings[:base] << "Repopulated #{n} old #{n == 1 ? "tag" : "tags"}: #{tag_wiki_links.join(", ")}"
       end
 
       new_artist_tags.each do |tag|


### PR DESCRIPTION
Fixes #3444.  The validation only applies to non-**General**/**Meta** tags since **General** tags are already covered and **Meta** tags can be empty before they get used.  It provides an hour leeway before throwing the warning, coinciding with the current merge time on post versions IIRC.  This should give the user ample time to fix or refix tagging errors.

Unfortunately, the above check can't be used to detect underused tags for the red CSS styling and hover error, unless we want to apply that to all non-**Meta** tags with a post count of 1.  However, displaying the warning from above should be sufficient.