### PR TITLE
Fix cutoff for what is considered an added tag

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1741,7 +1741,7 @@ class Post < ApplicationRecord
     end
 
     def added_tags_are_valid
-      new_tags = added_tags.select { |t| t.post_count <= 1 }
+      new_tags = added_tags.select { |t| t.post_count <= 0 }
       new_general_tags = new_tags.select { |t| t.category == Tag.categories.general }
       new_artist_tags = new_tags.select { |t| t.category == Tag.categories.artist }
       repopulated_tags = new_tags.select { |t| (t.category != Tag.categories.general) && (t.category != Tag.categories.meta) && (t.created_at < 1.hour.ago) }


### PR DESCRIPTION
@nonamethanks noticed this issue and brought it up on Discord.  Basically, Danbooru was considering all tags with a post count of 1 to still be new tags by the tag validator.  This caused the notice to appear when incrementing the post count from 1 to 2.

This is because at the time that the validator function is running, the delayed job which increments the post count has not yet run.  Therefore, it should only accept tags that have a post count of 0 and below.

I checked this pull on both new and existing empty tags, and it worked for both cases.