### PR TITLE
Fix double render error in `/blah.js`.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,10 @@ class ApplicationController < ActionController::Base
   rescue_from SessionLoader::AuthenticationFailure, :with => :authentication_failed
   rescue_from Danbooru::Paginator::PaginationError, :with => :render_pagination_limit
 
+  # This is raised on requests to `/blah.js`. Rails has already rendered StaticController#not_found
+  # here, so calling `rescue_exception` would cause a double render error.
+  rescue_from ActionController::InvalidCrossOriginRequest, :with => lambda {}
+
   protected
 
   def show_moderation_notice?


### PR DESCRIPTION
http://danbooru.donmai.us/posts/js/bf.js
http://danbooru.donmai.us/posts/js/jquery.js
http://danbooru.donmai.us/prepare.js

Fixes a double render error in requests like those above. First `StaticController#not_found` is rendered, then a second render happens inside `rescue_from Exception, :with => :rescue_exception` due to Rails raising an `ActionController::InvalidCrossOriginRequest` exception.




