### PR TITLE
Fix "The action 'show' could not be found for FavoritesController"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,7 +45,7 @@ Rails.application.routes.draw do
     end
   end
   namespace :explore do
-    resources :posts do
+    resources :posts, :only => [] do
       collection do
         get :popular
         get :viewed
@@ -196,7 +196,7 @@ Rails.application.routes.draw do
     end
   end
   resources :post_replacements, :only => [:index, :new, :create, :update]
-  resources :posts do
+    resources :posts, :only => [:index, :show, :update] do
     resources :events, :only => [:index], :controller => "post_events"
     resources :replacements, :only => [:index, :new, :create], :controller => "post_replacements"
     resource :artist_commentary, :only => [:index, :show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -124,7 +124,7 @@ Rails.application.routes.draw do
     end
   end
   resource  :dtext_preview, :only => [:create]
-  resources :favorites
+  resources :favorites, :only => [:index, :create, :destroy]
   resources :favorite_groups do
     member do
       put :add_post


### PR DESCRIPTION
Fixes an error with requests to http://danbooru.donmai.us/favorites/1234 not returning the normal `not found` 404 page.

This error is coming up a lot in New Relic due to certain bots trying to crawl `/favorites/$post_id` pages, even though those pages don't exist.

EDIT: Also fixed some other invalid routes under `/posts` and `/explore/posts`.