### PR TITLE
Fix #3450: Aliased tags show up under translated tags.

### DIFF
--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -83,7 +83,9 @@ module Sources
 
       # Given a tag from the source site, should return an array of corresponding Danbooru tags.
       def translate_tag(untranslated_tag)
-        translated_tags = Tag.where(name: WikiPage.active.other_names_equal(untranslated_tag).uniq.select(:title))
+        translated_tag_names = WikiPage.active.other_names_equal(untranslated_tag).uniq.pluck(:title)
+        translated_tag_names = TagAlias.to_aliased(translated_tag_names)
+        translated_tags = Tag.where(name: translated_tag_names)
 
         if translated_tags.empty?
           normalized_name = TagAlias.to_aliased([Tag.normalize_name(untranslated_tag)])

--- a/test/unit/sources/pixiv_test.rb
+++ b/test/unit/sources/pixiv_test.rb
@@ -217,6 +217,17 @@ module Sources
           assert_includes(@translated_tags, "fate/grand_order")
           assert_equal(false, @translated_tags.grep("fate").any?)
         end
+
+        should "apply aliases to translated tags" do
+          tohsaka_rin = FactoryGirl.create(:tag, name: "tohsaka_rin")
+          toosaka_rin = FactoryGirl.create(:tag, name: "toosaka_rin")
+
+          FactoryGirl.create(:wiki_page, title: "tohsaka_rin", other_names: "遠坂凛")
+          FactoryGirl.create(:wiki_page, title: "toosaka_rin", other_names: "遠坂凛")
+          FactoryGirl.create(:tag_alias, antecedent_name: "tohsaka_rin", consequent_name: "toosaka_rin")
+
+          assert_equal([toosaka_rin], @site.translate_tag("遠坂凛"))
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #3450. Resolves aliases in translated tags. For example, say we lookup `遠坂凛` and find both `tohsaka_rin` and `toosaka_rin`. We apply aliases so that `tohsaka_rin` becomes `toosaka_rin`, which is then returned as the only translated tag after duplicate tags are filtered out.