### PR TITLE
Fix 3455: Convert tag category Javascript/CSS assets to ERB

### DIFF
--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -9,7 +9,6 @@
   Danbooru.Autocomplete.initialize_all = function() {
     if (Danbooru.meta("enable-auto-complete") === "true") {
       Danbooru.Autocomplete.enable_local_storage = this.test_local_storage();
-      this.update_static_metatags();
       this.initialize_tag_autocomplete();
       this.initialize_mention_autocomplete();
       this.prune_local_storage();
@@ -95,7 +94,7 @@
     var $fields_multiple = $('[data-autocomplete="tag-query"], [data-autocomplete="tag-edit"]');
     var $fields_single = $('[data-autocomplete="tag"]');
 
-    var prefixes = "-|~|" + $.map(JSON.parse(Danbooru.meta("tag-category-names")), function (category) { return category + ':'}).join('|');
+    var prefixes = "-|~|" + "<%= TagCategory.mapping.keys.map {|category| category + ':'}.join('|') %>";
     var metatags = "order|-status|status|-rating|rating|-locked|locked|child|filetype|-filetype|" +
       "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-fav|fav|ordfav|" +
       "-pool|pool|ordpool|favgroup|-search|search";
@@ -329,7 +328,7 @@
       "tagcount", "tagcount_asc",
       "rank",
       "random"
-    ],
+    ].concat(<%= TagCategory.short_name_list.map {|category| [category + "tags", category + "tags_asc"]}.flatten %>),
     status: [
       "any", "deleted", "active", "pending", "flagged", "banned"
     ],
@@ -345,11 +344,6 @@
     filetype: [
       "jpg", "png", "gif", "swf", "zip", "webm", "mp4"
     ],
-  }
-
-  //This must be done as a separate function as Danbooru.meta does not exist at program initialization
-  Danbooru.Autocomplete.update_static_metatags = function () {
-    Array.prototype.push.apply(Danbooru.Autocomplete.static_metatags.order,$.map(JSON.parse(Danbooru.meta("short-tag-category-names")), function(shorttag) { return [shorttag + "tags", shorttag + "tags_asc"]}));
   }
 
   Danbooru.Autocomplete.static_metatag_source = function(term, resp, metatag) {

--- a/app/assets/javascripts/related_tag.js.erb
+++ b/app/assets/javascripts/related_tag.js.erb
@@ -12,15 +12,9 @@
 
   Danbooru.RelatedTag.initialize_buttons = function() {
     this.common_bind("#related-tags-button", "");
-    var related_buttons;
-    try {
-      related_buttons = JSON.parse(Danbooru.meta("related-tag-button-list"));
-    } catch (e) {
-      related_buttons = [];
-    }
-    $.each(related_buttons, function(i,category) {
-      Danbooru.RelatedTag.common_bind("#related-" + category + "-button", category);
-    });
+    <% TagCategory.related_button_list.each do |category| %>
+      Danbooru.RelatedTag.common_bind("#related-<%= category %>-button", "<%= category %>");
+    <% end %>
     $("#find-artist-button").click(Danbooru.RelatedTag.find_artist);
   }
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import "jquery.dropdown.scss";
 @import "common/*";
 @import "specific/*";
+@import "erb/posts";

--- a/app/assets/stylesheets/erb/posts.scss.erb
+++ b/app/assets/stylesheets/erb/posts.scss.erb
@@ -179,45 +179,15 @@ body[data-user-can-approve-posts="true"] .post-preview {
   }
 }
 
-.category-0 a, a.tag-type-0, .ui-state-focus a.tag-type-0 {
-  color: $link_color;
+<% TagCategory.css_mapping.each do |category,cssmap| %>
+  .category-<%= category %> a, a.tag-type-<%= category %>, .ui-state-focus a.tag-type-<%= category %> {
+    color: <%= cssmap["color"] %>;
 
-  &:hover {
-    color: $link_hover_color;
+    &:hover {
+      color: <%= cssmap["hover"] %>;
+    }
   }
-}
-
-.category-1 a, a.tag-type-1, .ui-state-focus a.tag-type-1 {
-  color: #A00;
-
-  &:hover {
-    color: #B66;
-  }
-}
-
-.category-3 a, a.tag-type-3, .ui-state-focus a.tag-type-3 {
-  color: #A0A;
-
-  &:hover {
-    color: #B6B;
-  }
-}
-
-.category-4 a, a.tag-type-4, .ui-state-focus a.tag-type-4 {
-  color: #0A0;
-
-  &:hover {
-    color: #6B6;
-  }
-}
-
-.category-5 a, a.tag-type-5, .ui-state-focus a.tag-type-5 {
-  color: #F80;
-
-  &:hover {
-    color: #FA6;
-  }
-}
+<% end %>
 
 .category-banned a, a.tag-type-banned,, .ui-state-focus a.tag-type-banned {
   color: black;

--- a/app/logical/tag_category.rb
+++ b/app/logical/tag_category.rb
@@ -34,9 +34,14 @@ class TagCategory
       @@header_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["header"]]}]
     end
 
-    # Returns a hash mapping for related tag buttons (javascripts/related_tag.js)
+    # Returns a hash mapping for related tag buttons (javascripts/related_tag.js.erb)
     def related_button_mapping
       @@related_button_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [k,v["relatedbutton"]]}]
+    end
+
+    # Returns a hash mapping for CSS (stylesheets/posts.scss.erb)
+    def css_mapping
+      @@css_mapping ||= Hash[Danbooru.config.full_tag_config_info.map {|k,v| [v["category"],v["css"]]}]
     end
   end
 

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -8,8 +8,6 @@
   <% unless CurrentUser.disable_responsive_mode? %>
     <meta name="viewport" content="width=device-width,initial-scale=1">
   <% end %>
-  <meta name="tag-category-names" content="<%= TagCategory.categories %>">
-  <meta name="short-tag-category-names" content="<%= TagCategory.short_name_list %>">
   <meta name="current-user-name" content="<%= CurrentUser.name %>">
   <meta name="current-user-id" content="<%= CurrentUser.id %>">
   <meta name="current-user-can-approve-posts" content="<%= CurrentUser.can_approve_posts? %>">

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -157,7 +157,6 @@
 <% end %>
 
 <% content_for(:html_header) do %>
-  <meta name="related-tag-button-list" content="<%= TagCategory.related_button_list %>">
   <meta name="description" content="<%= @post.presenter.humanized_tag_string %>">
   <meta name="tags" content="<%= @post.tag_string %>">
   <meta name="favorites" content="<%= @post.fav_string %>">

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -141,8 +141,4 @@
   Upload - <%= Danbooru.config.app_name %>
 <% end %>
 
-<% content_for(:html_header) do %>
-  <meta name="related-tag-button-list" content="<%= Danbooru.config.related_tag_button_list %>">
-<% end %>
-
 <%= render "posts/partials/common/secondary_links" %>

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -227,7 +227,11 @@ module Danbooru
           "extra" => [],
           "header" => %{<h1 class="general-tag-list">Tags</h1>},
           "humanized" => nil,
-          "relatedbutton" => "General"
+          "relatedbutton" => "General",
+          "css" => {
+            "color" => "$link_color",
+            "hover" => "$link_hover_color"
+          }
         },
         "character" => {
           "category" => 4,
@@ -240,7 +244,11 @@ module Danbooru
             "regexmap" => /^(.+?)(?:_\(.+\))?$/,
             "formatstr" => "%s"
           },
-          "relatedbutton" => "Characters"
+          "relatedbutton" => "Characters",
+          "css" => {
+            "color" => "#0A0",
+            "hover" => "#6B6"
+          }
         },
         "copyright" => {
           "category" => 3,
@@ -253,7 +261,11 @@ module Danbooru
             "regexmap" => //,
             "formatstr" => "(%s)"
           },
-          "relatedbutton" => "Copyrights"
+          "relatedbutton" => "Copyrights",
+          "css" => {
+            "color" => "#A0A",
+            "hover" => "#B6B"
+          }
         },
         "artist" => {
           "category" => 1,
@@ -266,7 +278,11 @@ module Danbooru
             "regexmap" => //,
             "formatstr" => "drawn by %s"
           },
-          "relatedbutton" => "Artists"
+          "relatedbutton" => "Artists",
+          "css" => {
+            "color" => "#A00",
+            "hover" => "#B66"
+          }
         },
         "meta" => {
           "category" => 5,
@@ -274,7 +290,11 @@ module Danbooru
           "extra" => [],
           "header" => %{<h2 class="meta-tag-list">Meta</h2>},
           "humanized" => nil,
-          "relatedbutton" => nil
+          "relatedbutton" => nil,
+          "css" => {
+            "color" => "#F80",
+            "hover" => "#FA6"
+          }
         }
       }
     end


### PR DESCRIPTION
Fixes #3455.  ~~Also, I didn't consider worth it to add the very short category names of **ch** and **co**.~~