### PR TITLE
Fix #3460: Timeout in `update_last_ip_addr`.

### DIFF
--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -11,6 +11,8 @@ class SessionLoader
   end
 
   def load
+    CurrentUser.user = AnonymousUser.new
+
     if session[:user_id]
       load_session_user
     elsif cookie_password_hash_valid?
@@ -18,18 +20,13 @@ class SessionLoader
     else
       load_session_for_api
     end
-    
-    if CurrentUser.user
-      CurrentUser.user.unban! if CurrentUser.user.ban_expired?
-    else
-      CurrentUser.user = AnonymousUser.new
-    end
 
+    set_statement_timeout
     update_last_logged_in_at
     update_last_ip_addr
     set_time_zone
     store_favorite_tags_in_cookies
-    set_statement_timeout
+    CurrentUser.user.unban! if CurrentUser.user.ban_expired?
   end
 
 private


### PR DESCRIPTION
Possible fix for #3460. We were trying to update the user's last ip addr before we had initialized their statement timeout. Set their statement timeout earlier, before updating anything in the database, to avoid potential timeouts here.