### PR TITLE
Fix #3464: CurrentUser.ip_addr isn't set for anonymous users.

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -47,6 +47,8 @@ class UsersController < ApplicationController
       @user.save
       if @user.errors.empty?
         session[:user_id] = @user.id
+      else
+        flash[:notice] = "Sign up failed: #{@user.errors.full_messages.join("; ")}"
       end
       set_current_user
       respond_with(@user)

--- a/app/logical/session_loader.rb
+++ b/app/logical/session_loader.rb
@@ -12,6 +12,7 @@ class SessionLoader
 
   def load
     CurrentUser.user = AnonymousUser.new
+    CurrentUser.ip_addr = request.remote_ip
 
     if session[:user_id]
       load_session_user
@@ -55,7 +56,6 @@ private
   end
   
   def authenticate_api_key(name, api_key)
-    CurrentUser.ip_addr = request.remote_ip
     CurrentUser.user = User.authenticate_api_key(name, api_key)
 
     if CurrentUser.user.nil?
@@ -64,7 +64,6 @@ private
   end
   
   def authenticate_legacy_api_key(name, password_hash)
-    CurrentUser.ip_addr = request.remote_ip
     CurrentUser.user = User.authenticate_hash(name, password_hash)
 
     if CurrentUser.user.nil?
@@ -73,13 +72,11 @@ private
   end
 
   def load_session_user
-    CurrentUser.ip_addr = request.remote_ip
     CurrentUser.user = User.find_by_id(session[:user_id])
   end
 
   def load_cookie_user
     CurrentUser.user = User.find_by_name(cookies.signed[:user_name])
-    CurrentUser.ip_addr = request.remote_ip
     session[:user_id] = CurrentUser.user.id
   end
 


### PR DESCRIPTION
Fixes #3464. Also fixes the account signup page not showing an error message when signup failed.