### PR TITLE
Fix #1563: Warn users attempting to upload with very few tags.

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -22,6 +22,7 @@ class Post < ApplicationRecord
   validate :removed_tags_are_valid
   validate :has_artist_tag
   validate :has_copyright_tag
+  validate :has_enough_tags
   validate :post_is_not_its_own_parent
   validate :updater_can_change_rating
   before_save :update_tag_post_counts
@@ -1792,6 +1793,14 @@ class Post < ApplicationRecord
       return if has_tag?("copyright_request") || tags.any? { |t| t.category == Tag.categories.copyright }
 
       self.warnings[:base] << "Copyright tag is required. Consider adding [[copyright request]] or [[original]]"
+    end
+
+    def has_enough_tags
+      return if !new_record?
+
+      if tags.count { |t| t.category == Tag.categories.general } < 10
+        self.warnings[:base] << "Uploads must have at least 10 general tags. Read [[howto:tag]] for guidelines on tagging your uploads"
+      end
     end
   end
   

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -1636,6 +1636,11 @@ class PostTest < ActiveSupport::TestCase
         should "warn when missing a copyright tag" do
           assert_match(/Copyright tag is required/, @post.warnings.full_messages.join)
         end
+
+        should "warn when an upload doesn't have enough tags" do
+          post = FactoryGirl.create(:post, tag_string: "tagme")
+          assert_match(/Uploads must have at least \d+ general tags/, post.warnings.full_messages.join)
+        end
       end
     end
   end


### PR DESCRIPTION
Fixes #1563. Adds a warning when an upload has less than 10 general tags.

The idea of warning about uploads with not enough tags has been proposed more than a few times over the years. Exactly how many is "not enough" is of course debatable. I chose 10 gentags because ~97% of posts from the past year have at least this many tags. This puts the threshold well below what most posts have.