### PR TITLE
Fix status:active so that it doesn't show flagged posts

### DIFF
--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -137,7 +137,7 @@ class PostQueryBuilder
     elsif q[:status] == "banned"
       relation = relation.where("posts.is_banned = TRUE")
     elsif q[:status] == "active"
-      relation = relation.where("posts.is_pending = FALSE AND posts.is_deleted = FALSE AND posts.is_banned = FALSE")
+      relation = relation.where("posts.is_pending = FALSE AND posts.is_deleted = FALSE AND posts.is_banned = FALSE AND posts.is_flagged = FALSE")
     elsif q[:status] == "all" || q[:status] == "any"
       # do nothing
     elsif q[:status_neg] == "pending"
@@ -149,7 +149,7 @@ class PostQueryBuilder
     elsif q[:status_neg] == "banned"
       relation = relation.where("posts.is_banned = FALSE")
     elsif q[:status_neg] == "active"
-      relation = relation.where("posts.is_pending = TRUE OR posts.is_deleted = TRUE OR posts.is_banned = TRUE")
+      relation = relation.where("posts.is_pending = TRUE OR posts.is_deleted = TRUE OR posts.is_banned = TRUE OR posts.is_flagged = TRUE")
     end
 
     if hide_deleted_posts?(q)


### PR DESCRIPTION
@nonamethanks  brought up this issue on Discord.  He indicated that the "status:active -status:flagged" search doesn't work, for one since only one status metatag is allowed, but also because **status:active** currently also includes flagged posts.

As a solution, the `is_flagged` flag is added to both the **status:active** and **-status:active** searches as applicable.  An alternate solution could be to set `is_pending` to true on flagged posts, but that would affect the code in a lot more places.