### PR TITLE
Add autocomplete to tags input on post replacements

### DIFF
--- a/app/views/post_replacements/index.html.erb
+++ b/app/views/post_replacements/index.html.erb
@@ -6,7 +6,7 @@
 
     <%= simple_form_for(:search, url: post_replacements_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
       <%= f.input :creator_name, label: "Replacer", input_html: { value: params[:search][:creator_name] } %>
-      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match] } %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
       <%= f.submit "Search" %>
     <% end %>
 


### PR DESCRIPTION
This was missing from the **Tags** input on post_replacements/index.