### PR TITLE
Initial add of IQDB standalone page

### DIFF
--- a/app/assets/stylesheets/specific/iqdb_queries.scss
+++ b/app/assets/stylesheets/specific/iqdb_queries.scss
@@ -1,0 +1,13 @@
+div#c-iqdb-queries {
+  div#a-check {
+    article.post-preview {
+      height: 180px;
+      width: 180px;
+      border: lightgrey solid 1px;
+
+      img {
+        margin-top: 10px;
+      }
+    }
+  }
+}

--- a/app/controllers/iqdb_queries_controller.rb
+++ b/app/controllers/iqdb_queries_controller.rb
@@ -2,31 +2,49 @@
 class IqdbQueriesController < ApplicationController
   respond_to :html, :json, :xml
 
-  def index
-    if !Danbooru.config.iqdbs_server
-      raise NotImplementedError.new("the IQDBs service isn't configured. Similarity searches are not available.")
-    end
-
+  def show
+    server_check
     if params[:url]
       create_by_url
+      respond_with(@results) do |fmt|
+        fmt.html { render :layout => false, :action => "create_by_url" }
+      end
     elsif params[:post_id]
       create_by_post
+      respond_with(@results) do |fmt|
+        fmt.js { render :layout => false, :action => "create_by_post" }
+      end
     else
       render :nothing => true, :status => 422
     end
   end
 
+  def check
+    server_check
+    if params[:url].present?
+      create_by_url
+    elsif params[:post_id].present?
+      create_by_post
+    else
+      @results = []
+    end
+    respond_with(@results)
+  end
+
   # Support both POST /iqdb_queries and GET /iqdb_queries.
-  alias_method :create, :index
+  alias_method :create, :show
 
 protected
+  def server_check
+    if !Danbooru.config.iqdbs_server
+      raise NotImplementedError.new("the IQDBs service isn't configured. Similarity searches are not available.")
+    end
+  end
+
   def create_by_url
     @download = Iqdb::Download.new(params[:url])
     @download.find_similar
     @results = @download.matches
-    respond_with(@results) do |fmt|
-      fmt.html { render :layout => false, :action => "create_by_url" }
-    end
   end
 
   def create_by_post
@@ -34,8 +52,5 @@ protected
     @download = Iqdb::Download.new(@post.complete_preview_file_url)
     @download.find_similar
     @results = @download.matches
-    respond_with(@results) do |fmt|
-      fmt.js { render :layout => false, :action => "create_by_post" }
-    end
   end
 end

--- a/app/views/iqdb_queries/check.html.erb
+++ b/app/views/iqdb_queries/check.html.erb
@@ -1,0 +1,34 @@
+<div id="c-iqdb-queries">
+  <div id="a-check">
+    <h1>IQDB Queries</h1>
+    <section>
+      <%= form_tag(check_iqdb_queries_path, :method => :get, :class => "simple_form inline-form" ) do %>
+        <div class="input string optional">
+          <%= label_tag "url", "URL", class: "string optional" %>
+          <%= text_field_tag "url", params[:url] %>
+        </div>
+        <div class="input string optional">
+          <%= label_tag "post_id", "Post ID", class: "string optional" %>
+          <%= text_field_tag "post_id", params[:post_id] %>
+        </div>
+        <%= submit_tag "Check" %>
+      <% end %>
+    </section>
+    <% if params[:url].present? || params[:post_id].present? %>
+      <section>
+        <h2>Similar results</h2>
+        <% if @results.any? %>
+          <% @results.each do |match| %>
+            <%= PostPresenter.preview(match[:post], :tags => "status:any", :size => true, :similarity => match[:score]) %>
+          <% end %>
+        <% else %>
+          <p>No matches found</p>
+        <% end %>
+      </section>
+     <% end %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  IQDB Queries - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -28,6 +28,7 @@
         <li><%= link_to("Keyboard Shortcuts", keyboard_shortcuts_path) %></li>
         <li><%= link_to("Bookmarklet", bookmarklet_path) %></li>
         <li><%= link_to("API Documentation", wiki_pages_path(:title => "help:api")) %></li>
+        <li><%= link_to("IQDB Queries", check_iqdb_queries_path) %></li>
       </ul>
       <ul>
         <li><h1>Artists</h1></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -153,7 +153,9 @@ Rails.application.routes.draw do
     resource :visit, :controller => "forum_topic_visits"
   end
   resources :ip_bans
-  resources :iqdb_queries, :only => [:create, :index]
+  resource :iqdb_queries, :only => [:create, :show, :check] do
+    get :check
+  end
   resources :janitor_trials do
     collection do
       get :test


### PR DESCRIPTION
A partial fix of #2833.  I say partial since it would be nice to eventually add support for local files, and so I'd like to keep that issue open at least for now.

I converted the endpoint to a singular resource since it doesn't really need the actions that resources do, and I added an additional named action since it didn't make sense to have the standalone page on the new or edit action.