### PR TITLE
Fix #3480: NoMethodError error when adding artist tag to post.

### DIFF
--- a/db/migrate/20171230220225_change_timestamps_to_non_null_on_tags.rb
+++ b/db/migrate/20171230220225_change_timestamps_to_non_null_on_tags.rb
@@ -1,0 +1,8 @@
+class ChangeTimestampsToNonNullOnTags < ActiveRecord::Migration
+  def change
+    Post.without_timeout do
+      change_column_null :tags, :created_at, false
+      change_column_null :tags, :updated_at, false
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3010,8 +3010,8 @@ CREATE TABLE tags (
     category integer DEFAULT 0 NOT NULL,
     related_tags text,
     related_tags_updated_at timestamp without time zone,
-    created_at timestamp without time zone,
-    updated_at timestamp without time zone,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
     is_locked boolean DEFAULT false NOT NULL
 );
 
@@ -7541,7 +7541,9 @@ INSERT INTO schema_migrations (version) VALUES ('20171106075030');
 
 INSERT INTO schema_migrations (version) VALUES ('20171127195124');
 
+INSERT INTO schema_migrations (version) VALUES ('20171218213037');
+
 INSERT INTO schema_migrations (version) VALUES ('20171219001521');
 
-INSERT INTO schema_migrations (version) VALUES ('20171218213037');
+INSERT INTO schema_migrations (version) VALUES ('20171230220225');
 

--- a/script/fixes/052_fix_tag_timestamps.rb
+++ b/script/fixes/052_fix_tag_timestamps.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'config', 'environment'))
+
+CurrentUser.user = User.system
+CurrentUser.ip_addr = "127.0.0.1"
+
+Tag.transaction do
+  Tag.without_timeout do
+    puts "Tag.where(updated_at: nil).count = #{Tag.where(updated_at: nil).count}"
+    puts "Tag.where(created_at: nil).count = #{Tag.where(created_at: nil).count}"
+
+    Tag.where(updated_at: nil).update_all(updated_at: Time.zone.now)
+    Tag.where(created_at: nil).update_all("created_at = updated_at")
+  end
+end


### PR DESCRIPTION
Fixes #3480. Initializes `created_at` and `updated_at` for any tags where these fields are null, and redefines the columns to be `NOT NULL`.