### PR TITLE
Fix #3484: /posts: don't show wiki tab for metatags

### DIFF
--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -146,16 +146,7 @@ module PostSets
     end
 
     def hide_from_crawler?
-      return true if !is_single_tag?
-      return true if is_pattern_search?
-      return true if page.to_i > 1
-      return true if is_metatag_search?
-      false
-    end
-
-    def is_metatag_search?
-      # filter out some common metatags
-      tag_string =~ /(?:rating|user|fav|status|order|source|score|width|height):/
+      !is_simple_tag? || page.to_i > 1
     end
 
     def is_single_tag?

--- a/app/logical/post_sets/post.rb
+++ b/app/logical/post_sets/post.rb
@@ -29,6 +29,10 @@ module PostSets
       is_single_tag? && ::WikiPage.titled(tag_string).exists? && wiki_page.visible?
     end
 
+    def has_blank_wiki?
+      is_simple_tag? && !has_wiki?
+    end
+
     def wiki_page
       if is_single_tag?
         ::WikiPage.titled(tag_string).first
@@ -156,6 +160,10 @@ module PostSets
 
     def is_single_tag?
       tag_array.size == 1
+    end
+
+    def is_simple_tag?
+      Tag.is_simple_tag?(tag_string)
     end
 
     def is_empty_tag?

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,8 +29,8 @@
           <li><%= link_to "Pool", pool_path(@post_set.pool), :id => "show-excerpt-link" %></li>
         <% elsif @post_set.has_favgroup? %>
           <li><%= link_to "Favorite Group", favorite_group_path(@post_set.favgroup), :id => "show-excerpt-link" %></li>
-        <% elsif @post_set.is_single_tag? && !@post_set.is_metatag_search? %>
-          <li><%= link_to "Wiki", "#", :id => "show-excerpt-link" %></li>
+        <% elsif @post_set.has_blank_wiki? %>
+          <li><%= link_to "Wiki", new_wiki_page_path(wiki_page: { title: @post_set.tag_string }), id: "show-excerpt-link" %></li>
         <% end %>
 
         <li id="searchbox-redirect-link"><a href="#search-box">Search&raquo;</a></li>


### PR DESCRIPTION
Fixes #3484:

* Shows the wiki tab only for simple tag searches that could have a wiki, not for metatags / wildcard tags / negated tags etc.

* Simplifies `PostSets::Post#hide_from_crawler?` and makes it hide all metatags.