### PR TITLE
Differentiate version index views with reversion links

### DIFF
--- a/app/views/artist_commentary_versions/_revert_listing.html.erb
+++ b/app/views/artist_commentary_versions/_revert_listing.html.erb
@@ -1,0 +1,50 @@
+<div id="p-revert-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th width="5%">Post</th>
+        <th>Original</th>
+        <th>Translated</th>
+        <% if CurrentUser.is_moderator? %>
+          <th width="10%">IP Address</th>
+        <% end %>
+        <th width="10%">Edited By</th>
+        <th width="10%">Date</th>
+        <% if CurrentUser.is_member? %>
+          <th width="7%"></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @commentary_versions.each do |commentary_version| %>
+        <tr>
+          <td><%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %></td>
+          <td>
+            <h3><%= h(commentary_version.original_title) %></h3>
+            <div class="prose">
+              <%= format_text(commentary_version.original_description, :disable_mentions => true) %>
+            </div>
+          </td>
+          <td>
+            <h3><%= h(commentary_version.translated_title) %></h3>
+            <div class="prose">
+              <%= format_text(commentary_version.translated_description, :disable_mentions => true) %>
+            </div>
+          </td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip commentary_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= link_to_user commentary_version.updater %></td>
+          <td><%= compact_time commentary_version.updated_at %></td>
+          <% if CurrentUser.is_member? %>
+            <td>
+              <%= link_to "Revert to", revert_artist_commentary_path(commentary_version.post_id, :version_id => commentary_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/artist_commentary_versions/_standard_listing.html.erb
+++ b/app/views/artist_commentary_versions/_standard_listing.html.erb
@@ -1,0 +1,44 @@
+<div id="p-standard-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th width="5%">Post</th>
+        <th>Version</th>
+        <th>Original</th>
+        <th>Translated</th>
+        <% if CurrentUser.is_moderator? %>
+          <th width="10%">IP Address</th>
+        <% end %>
+        <th width="10%">Edited By</th>
+        <th width="10%">Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @commentary_versions.each do |commentary_version| %>
+        <tr>
+          <td><%= PostPresenter.preview(commentary_version.post, :tags => "status:any") %></td>
+          <td><%= link_to "#{commentary_version.post_id}.#{commentary_version.id}»", artist_commentary_versions_path(search: {post_id: commentary_version.post_id}) %></td>
+          <td>
+            <h3><%= h(commentary_version.original_title) %></h3>
+            <div class="prose">
+              <%= format_text(commentary_version.original_description, :disable_mentions => true) %>
+            </div>
+          </td>
+          <td>
+            <h3><%= h(commentary_version.translated_title) %></h3>
+            <div class="prose">
+              <%= format_text(commentary_version.translated_description, :disable_mentions => true) %>
+            </div>
+          </td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip commentary_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= link_to_user commentary_version.updater %></td>
+          <td><%= compact_time commentary_version.updated_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/artist_commentary_versions/index.html.erb
+++ b/app/views/artist_commentary_versions/index.html.erb
@@ -4,60 +4,11 @@
 
     <%= render "posts/partials/common/inline_blacklist" %>
 
-    <table width="100%" class="striped">
-      <thead>
-        <tr>
-          <th width="5%">Post</th>
-          <th>Original</th>
-          <th>Translated</th>
-          <% if CurrentUser.is_moderator? %>
-            <th width="10%">IP Address</th>
-          <% end %>
-          <th width="10%">Edited By</th>
-          <th width="10%">Date</th>
-          <% if CurrentUser.is_member? %>
-            <th width="7%"></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @commentary_versions.each do |commentary_version| %>
-          <tr>
-            <td>
-              <% if params.dig(:search, :post_id).present? %>
-                <%= link_to commentary_version.post_id, post_path(commentary_version.post_id) %>
-              <% else %>
-                <%= PostPresenter.preview(commentary_version.post, :tags => "status:any") %>
-              <% end %>
-            </td>
-            <td>
-              <h3><%= h(commentary_version.original_title) %></h3>
-              <div class="prose">
-                <%= format_text(commentary_version.original_description, :disable_mentions => true) %>
-              </div>
-            </td>
-            <td>
-              <h3><%= h(commentary_version.translated_title) %></h3>
-              <div class="prose">
-                <%= format_text(commentary_version.translated_description, :disable_mentions => true) %>
-              </div>
-            </td>
-            <% if CurrentUser.is_moderator? %>
-              <td>
-                <%= link_to_ip commentary_version.updater_ip_addr %>
-              </td>
-            <% end %>
-            <td><%= link_to_user commentary_version.updater %></td>
-            <td><%= compact_time commentary_version.updated_at %></td>
-            <% if CurrentUser.is_member? %>
-              <td>
-                <%= link_to "Revert to", revert_artist_commentary_path(commentary_version.post_id, :version_id => commentary_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if params.dig(:search, :post_id).present? %>
+      <%= render "revert_listing" %>
+    <% else %>
+      <%= render "standard_listing" %>
+    <% end %>
 
     <%= numbered_paginator(@commentary_versions) %>
 

--- a/app/views/artist_versions/_revert_listing.html.erb
+++ b/app/views/artist_versions/_revert_listing.html.erb
@@ -1,0 +1,54 @@
+<div id="p-revert-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th width="10%">Name</th>
+        <th width="10%">Other Names</th>
+        <th>Group</th>
+        <th>Updated</th>
+        <th>Updated by</th>
+        <% if CurrentUser.is_moderator? %>
+          <th>IP Address</th>
+        <% end %>
+        <th>Active</th>
+        <th width="30%">URLs</th>
+        <% if CurrentUser.is_member? %>
+          <th></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @artist_versions.each do |artist_version| %>
+        <tr class="<%= cycle 'even', 'odd' %>">
+          <% if artist_version.visible? %>
+            <td><%= link_to artist_version.name, artist_path(artist_version.artist_id) %></td>
+            <td><%= artist_version_other_names_diff(artist_version) %></td>
+            <td><%= artist_version.group_name %></td>
+          <% else %>
+            <td></td>
+            <td></td>
+            <td></td>
+          <% end %>
+          <td><%= compact_time artist_version.created_at %></td>
+          <td><%= link_to_user artist_version.updater %></td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip artist_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= artist_version.is_active? %></td>
+          <% if artist_version.visible? %>
+            <td><%= artist_version_urls_diff(artist_version) %></td>
+          <% else %>
+            <td></td>
+          <% end %>
+          <% if CurrentUser.is_member? %>
+            <td>
+              <%= link_to "Revert to", revert_artist_path(artist_version.artist_id, :version_id => artist_version.id), :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/artist_versions/_standard_listing.html.erb
+++ b/app/views/artist_versions/_standard_listing.html.erb
@@ -1,0 +1,49 @@
+<div id="p-standard-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th width="10%">Name</th>
+        <th width="10%">Other Names</th>
+        <th>Group</th>
+        <th>Updated</th>
+        <th>Updated by</th>
+        <% if CurrentUser.is_moderator? %>
+          <th>IP Address</th>
+        <% end %>
+        <th>Active</th>
+        <th width="30%">URLs</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @artist_versions.each do |artist_version| %>
+        <tr class="<%= cycle 'even', 'odd' %>">
+          <% if artist_version.visible? %>
+            <td>
+              <%= link_to artist_version.name, artist_path(artist_version.artist_id) %>
+              <%= link_to "»", artist_versions_path(search: {artist_id: artist_version.artist_id}) %>
+            </td>
+            <td><%= artist_version_other_names_diff(artist_version) %></td>
+            <td><%= artist_version.group_name %></td>
+          <% else %>
+            <td></td>
+            <td></td>
+            <td></td>
+          <% end %>
+          <td><%= compact_time artist_version.created_at %></td>
+          <td><%= link_to_user artist_version.updater %></td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip artist_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= artist_version.is_active? %></td>
+          <% if artist_version.visible? %>
+            <td><%= artist_version_urls_diff(artist_version) %></td>
+          <% else %>
+            <td></td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/artist_versions/index.html.erb
+++ b/app/views/artist_versions/index.html.erb
@@ -2,60 +2,11 @@
   <div id="a-index">
     <h1>Artist History</h1>
 
-    <div>
-      <table width="100%" class="striped">
-        <thead>
-          <tr>
-            <th width="10%">Name</th>
-            <th width="10%">Other Names</th>
-            <th>Group</th>
-            <th>Updated</th>
-            <th>Updated by</th>
-            <% if CurrentUser.is_moderator? %>
-              <th>IP Address</th>
-            <% end %>
-            <th>Active</th>
-            <th width="30%">URLs</th>
-            <% if CurrentUser.is_member? %>
-              <th></th>
-            <% end %>
-          </tr>
-        </thead>
-        <tbody>
-          <% @artist_versions.each do |artist_version| %>
-            <tr class="<%= cycle 'even', 'odd' %>">
-              <% if artist_version.visible? %>
-                <td><%= link_to artist_version.name, artist_path(artist_version.artist_id) %></td>
-                <td><%= artist_version_other_names_diff(artist_version) %></td>
-                <td><%= artist_version.group_name %></td>
-              <% else %>
-                <td></td>
-                <td></td>
-                <td></td>
-              <% end %>
-              <td><%= compact_time artist_version.created_at %></td>
-              <td><%= link_to_user artist_version.updater %></td>
-              <% if CurrentUser.is_moderator? %>
-                <td>
-                  <%= link_to_ip artist_version.updater_ip_addr %>
-                </td>
-              <% end %>
-              <td><%= artist_version.is_active? %></td>
-              <% if artist_version.visible? %>
-                <td><%= artist_version_urls_diff(artist_version) %></td>
-              <% else %>
-                <td></td>
-              <% end %>
-              <% if CurrentUser.is_member? %>
-                <td>
-                  <%= link_to "Revert to", revert_artist_path(artist_version.artist_id, :version_id => artist_version.id), :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
-                </td>
-              <% end %>
-            </tr>
-          <% end %>
-        </tbody>
-      </table>
-    </div>
+    <% if params.dig(:search, :artist_id).present? %>
+      <%= render "revert_listing" %>
+    <% else %>
+      <%= render "standard_listing" %>
+    <% end %>
 
     <%= numbered_paginator(@artist_versions, :search_count => params[:search]) %>
   </div>

--- a/app/views/note_versions/_revert_listing.html.erb
+++ b/app/views/note_versions/_revert_listing.html.erb
@@ -1,0 +1,62 @@
+<div id="p-revert-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th></th>
+        <th width="5%">Post</th>
+        <th width="5%">Note</th>
+        <th>Body</th>
+        <th width="5%">Position</th>
+        <% if CurrentUser.is_moderator? %>
+          <th width="10%">IP Address</th>
+        <% end %>
+        <th width="10%">Edited By</th>
+        <th width="10%">Date</th>
+        <% if CurrentUser.is_member? %>
+          <th width="7%"></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @note_versions.each do |note_version| %>
+        <tr>
+          <td></td>
+          <td>
+            <%= link_to note_version.post_id, post_path(note_version.post_id) %>
+            <% if params.dig(:search, :note_id).present? %>
+              <%= link_to "»", note_versions_path(search: {post_id: note_version.post_id}) %>
+            <% end %>
+          </td>
+          <td>
+            <%= link_to "#{note_version.note_id}.#{note_version.version}", post_path(note_version.post_id, anchor: "note-#{note_version.note_id}") %>
+            <% if params.dig(:search, :post_id).present? %>
+              <%= link_to "»", note_versions_path(search: {note_id: note_version.note_id}) %>
+            <% end %>
+          </td>
+          <td class="col-expand">
+            <%= h(note_version.body) %>
+            <% unless note_version.is_active? %>
+              <span class="inactive">(deleted)</span>
+            <% end %>
+            <%= note_version_body_diff_info(note_version) %>
+          </td>
+          <td>
+            <%= note_version_position_diff(note_version) %>
+          </td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip note_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= link_to_user note_version.updater %></td>
+          <td><%= compact_time note_version.updated_at %></td>
+          <% if CurrentUser.is_member? %>
+            <td>
+              <%= link_to "Revert to", revert_note_path(note_version.note_id, :version_id => note_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/note_versions/_standard_listing.html.erb
+++ b/app/views/note_versions/_standard_listing.html.erb
@@ -1,0 +1,50 @@
+<div id="p-standard-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th></th>
+        <th width="5%">Post</th>
+        <th width="5%">Note</th>
+        <th>Body</th>
+        <th width="5%">Position</th>
+        <% if CurrentUser.is_moderator? %>
+          <th width="10%">IP Address</th>
+        <% end %>
+        <th width="10%">Edited By</th>
+        <th width="10%">Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @note_versions.each do |note_version| %>
+        <tr>
+          <td></td>
+          <td>
+            <%= link_to note_version.post_id, post_path(note_version.post_id) %>
+            <%= link_to "»", note_versions_path(search: {post_id: note_version.post_id}) %>
+          </td>
+          <td>
+            <%= link_to "#{note_version.note_id}.#{note_version.version}", post_path(note_version.post_id, anchor: "note-#{note_version.note_id}") %>
+            <%= link_to "»", note_versions_path(search: {note_id: note_version.note_id}) %>
+          </td>
+          <td class="col-expand">
+            <%= h(note_version.body) %>
+            <% unless note_version.is_active? %>
+              <span class="inactive">(deleted)</span>
+            <% end %>
+            <%= note_version_body_diff_info(note_version) %>
+          </td>
+          <td>
+            <%= note_version_position_diff(note_version) %>
+          </td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip note_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= link_to_user note_version.updater %></td>
+          <td><%= compact_time note_version.updated_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/note_versions/index.html.erb
+++ b/app/views/note_versions/index.html.erb
@@ -2,59 +2,11 @@
   <div id="a-index">
     <h1>Note Changes</h1>
 
-    <table width="100%" class="striped autofit">
-      <thead>
-        <tr>
-          <th></th>
-          <th width="5%">Post</th>
-          <th width="5%">Note</th>
-          <th>Body</th>
-          <th width="5%">Position</th>
-          <% if CurrentUser.is_moderator? %>
-            <th width="10%">IP Address</th>
-          <% end %>
-          <th width="10%">Edited By</th>
-          <th width="10%">Date</th>
-          <% if CurrentUser.is_member? %>
-            <th width="7%"></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @note_versions.each do |note_version| %>
-          <tr>
-            <td></td>
-            <td><%= link_to note_version.post_id, post_path(note_version.post_id) %></td>
-            <td>
-              <%= link_to "#{note_version.note_id}.#{note_version.version}", post_path(note_version.post_id, anchor: "note-#{note_version.note_id}") %>
-              <%= link_to "»", note_versions_path(search: {note_id: note_version.note_id}) %>
-            </td>
-            <td class="col-expand">
-              <%= h(note_version.body) %>
-              <% unless note_version.is_active? %>
-                <span class="inactive">(deleted)</span>
-              <% end %>
-              <%= note_version_body_diff_info(note_version) %>
-            </td>
-            <td>
-              <%= note_version_position_diff(note_version) %>
-            </td>
-            <% if CurrentUser.is_moderator? %>
-              <td>
-                <%= link_to_ip note_version.updater_ip_addr %>
-              </td>
-            <% end %>
-            <td><%= link_to_user note_version.updater %></td>
-            <td><%= compact_time note_version.updated_at %></td>
-            <% if CurrentUser.is_member? %>
-              <td>
-                <%= link_to "Revert to", revert_note_path(note_version.note_id, :version_id => note_version.id), :remote => true, :method => :put, :data => {:confirm => "Are you sure you want to revert to this version?"} %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if params.dig(:search, :post_id).present? || params.dig(:search, :note_id).present? %>
+      <%= render "revert_listing" %>
+    <% else %>
+      <%= render "standard_listing" %>
+    <% end %>
 
     <%= numbered_paginator(@note_versions) %>
 

--- a/app/views/pool_versions/_revert_listing.html.erb
+++ b/app/views/pool_versions/_revert_listing.html.erb
@@ -1,0 +1,42 @@
+<div id="p-revert-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th>Pool</th>
+        <th>Post Count</th>
+        <th>Changes</th>
+        <th>Desc Chg</th>
+        <th>Updater</th>
+        <% if CurrentUser.is_moderator? %>
+          <th>IP Address</th>
+        <% end %>
+        <th>Date</th>
+        <% if CurrentUser.is_member? %>
+          <th></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @pool_versions.each do |pool_version| %>
+        <tr>
+          <td><%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), :class => "pool-category-#{pool_version.pool.category}" %></td>
+          <td><%= link_to pool_version.post_ids.size, pool_versions_path(:search => {:pool_id => pool_version.pool_id}) %></td>
+          <td><%= pool_version_diff(pool_version) %></td>
+          <td><%= link_to_if pool_version.description_changed, pool_version.description_changed, diff_pool_version_path(pool_version.id) %></td>
+          <td><%= link_to_user pool_version.updater %></td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip pool_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= compact_time pool_version.updated_at %></td>
+          <% if CurrentUser.is_member? %>
+            <td>
+              <%= link_to "Revert to", revert_pool_path(pool_version.pool_id, :version_id => pool_version.id), :method => :put, :remote => true %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/pool_versions/_standard_listing.html.erb
+++ b/app/views/pool_versions/_standard_listing.html.erb
@@ -1,0 +1,34 @@
+<div id="p-standard-listing">
+  <table width="100%" class="striped autofit">
+    <thead>
+      <tr>
+        <th>Pool</th>
+        <th>Post Count</th>
+        <th>Changes</th>
+        <th>Desc Chg</th>
+        <th>Updater</th>
+        <% if CurrentUser.is_moderator? %>
+          <th>IP Address</th>
+        <% end %>
+        <th>Date</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @pool_versions.each do |pool_version| %>
+        <tr>
+          <td><%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), :class => "pool-category-#{pool_version.pool.category}" %></td>
+          <td><%= link_to pool_version.post_ids.size, pool_versions_path(:search => {:pool_id => pool_version.pool_id}) %></td>
+          <td><%= pool_version_diff(pool_version) %></td>
+          <td><%= link_to_if pool_version.description_changed, pool_version.description_changed, diff_pool_version_path(pool_version.id) %></td>
+          <td><%= link_to_user pool_version.updater %></td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip pool_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= compact_time pool_version.updated_at %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/pool_versions/index.html.erb
+++ b/app/views/pool_versions/index.html.erb
@@ -2,46 +2,11 @@
   <div id="a-index">
     <h1>Pool History</h1>
 
-    <table width="100%" class="striped">
-      <thead>
-        <tr>
-          <th>Pool</th>
-          <th>Post Count</th>
-          <th>Changes</th>
-          <th>Desc Chg</th>
-          <th>Updater</th>
-          <% if CurrentUser.is_moderator? %>
-            <th>IP Address</th>
-          <% end %>
-          <th>Date</th>
-          <% if CurrentUser.is_member? %>
-            <th></th>
-          <% end %>
-        </tr>
-      </thead>
-      <tbody>
-        <% @pool_versions.each do |pool_version| %>
-          <tr>
-            <td><%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), :class => "pool-category-#{pool_version.pool.category}" %></td>
-            <td><%= link_to pool_version.post_ids.size, pool_versions_path(:search => {:pool_id => pool_version.pool_id}) %></td>
-            <td><%= pool_version_diff(pool_version) %></td>
-            <td><%= link_to_if pool_version.description_changed, pool_version.description_changed, diff_pool_version_path(pool_version.id) %></td>
-            <td><%= link_to_user pool_version.updater %></td>
-            <% if CurrentUser.is_moderator? %>
-              <td>
-                <%= link_to_ip pool_version.updater_ip_addr %>
-              </td>
-            <% end %>
-            <td><%= compact_time pool_version.updated_at %></td>
-            <% if CurrentUser.is_member? %>
-              <td>
-                <%= link_to "Revert to", revert_pool_path(pool_version.pool_id, :version_id => pool_version.id), :method => :put, :remote => true %>
-              </td>
-            <% end %>
-          </tr>
-        <% end %>
-      </tbody>
-    </table>
+    <% if params.dig(:search, :pool_id).present? %>
+      <%= render "revert_listing" %>
+    <% else %>
+      <%= render "standard_listing" %>
+    <% end %>
 
     <%= numbered_paginator(@pool_versions) %>
   </div>

--- a/app/views/post_versions/_revert_listing.html.erb
+++ b/app/views/post_versions/_revert_listing.html.erb
@@ -1,5 +1,5 @@
-<div class="listing">
-  <table class="striped">
+<div id="p-revert-listing">
+  <table class="striped autofit">
     <thead>
       <tr>
         <th width="5%">Post</th>
@@ -17,7 +17,7 @@
       </tr>
     </thead>
     <tbody>
-      <% post_versions.each do |post_version| %>
+      <% @post_versions.each do |post_version| %>
         <tr id="post-version-<%= post_version.id %>" <% if params[:hilite].to_i == post_version.id %>class="hilite"<% end %>>
           <td><%= link_to("#{post_version.post_id}.#{post_version.id}", post_path(post_version.post_id)) %></td>
           <td><%= compact_time(post_version.updated_at) %></td>

--- a/app/views/post_versions/_standard_listing.html.erb
+++ b/app/views/post_versions/_standard_listing.html.erb
@@ -1,0 +1,54 @@
+<div id="p-standard-listing">
+  <table class="striped autofit">
+    <thead>
+      <tr>
+        <th width="5%">Post</th>
+        <th width="15%">Date</th>
+        <th width="10%">User</th>
+        <th width="5%">Rating</th>
+        <th width="5%">Parent</th>
+        <% if CurrentUser.is_moderator? %>
+          <th width="10%">IP Address</th>
+        <% end %>
+        <th>Tags</th>
+        <% if CurrentUser.is_member? %>
+          <th width="7%"></th>
+        <% end %>
+      </tr>
+    </thead>
+    <tbody>
+      <% @post_versions.each do |post_version| %>
+        <tr id="post-version-<%= post_version.id %>" <% if params[:hilite].to_i == post_version.id %>class="hilite"<% end %>>
+          <td>
+            <%= link_to("#{post_version.post_id}.#{post_version.id}", post_path(post_version.post_id)) %>
+            <%= link_to "»", post_versions_path(search: {post_id: post_version.post_id}) %>
+          </td>
+          <td><%= compact_time(post_version.updated_at) %></td>
+          <td>
+            <% if post_version.updater %>
+              <%= link_to_user(post_version.updater) %>
+            <% end %>
+          </td>
+          <td><%= post_version.rating %></td>
+          <td><%= post_version.parent_id %></td>
+          <% if CurrentUser.is_moderator? %>
+            <td>
+              <%= link_to_ip post_version.updater_ip_addr %>
+            </td>
+          <% end %>
+          <td><%= post_version_diff(post_version) %></td>
+          <% if CurrentUser.is_member? %>
+            <td>
+              <% if post_version.visible? %>
+                <% if post_version.version != 1 %>
+                  <%= link_to "Undo", undo_post_version_path(post_version), :method => :put, :remote => true %> |
+                <% end %>
+              <% end %>
+            </td>
+          <% end %>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>
+

--- a/app/views/post_versions/index.html.erb
+++ b/app/views/post_versions/index.html.erb
@@ -7,7 +7,11 @@
     <% if @post_versions.length == 0 %>
       <%= render "post_sets/blank" %>
     <% else %>
-      <%= render "listing", :post_versions => @post_versions %>
+      <% if params.dig(:search, :post_id).present? %>
+        <%= render "revert_listing" %>
+      <% else %>
+        <%= render "standard_listing" %>
+      <% end %>
 
       <% if params[:lr] && CurrentUser.is_moderator? %>
         <p><%= link_to "Revert this user's changes", new_user_revert_path(:user_id => params[:lr]) %></p>


### PR DESCRIPTION
First ran this by @evazion on Discord.  Basically, it doesn't make sense to put revert links on the version indexes except when searching by instance, as the revert lacks all context to what changes have taken place before or after.  Undo links on **post_versions** don't have this issue since it displays all of the changes made in that version, therefore it's known that undo will reverse all of those changes.

Different partials were created primarily since an entire column was being removed for most of the tables.  The one exception was **post_versions** since there may be an undo link in that column that may need to be displayed, but it was also separated into partials just to keep things standard.  **wiki_page_versions** wasn't done since the revert link for that exists in the **wiki_page_version/show** view.