### PR TITLE
Fix spacing issues on versions

### DIFF
--- a/app/views/artist_versions/_revert_listing.html.erb
+++ b/app/views/artist_versions/_revert_listing.html.erb
@@ -22,7 +22,7 @@
         <tr class="<%= cycle 'even', 'odd' %>">
           <% if artist_version.visible? %>
             <td><%= link_to artist_version.name, artist_path(artist_version.artist_id) %></td>
-            <td><%= artist_version_other_names_diff(artist_version) %></td>
+            <td class="col-expand"><%= artist_version_other_names_diff(artist_version) %></td>
             <td><%= artist_version.group_name %></td>
           <% else %>
             <td></td>

--- a/app/views/artist_versions/_standard_listing.html.erb
+++ b/app/views/artist_versions/_standard_listing.html.erb
@@ -22,7 +22,7 @@
               <%= link_to artist_version.name, artist_path(artist_version.artist_id) %>
               <%= link_to "»", artist_versions_path(search: {artist_id: artist_version.artist_id}) %>
             </td>
-            <td><%= artist_version_other_names_diff(artist_version) %></td>
+            <td class="col-expand"><%= artist_version_other_names_diff(artist_version) %></td>
             <td><%= artist_version.group_name %></td>
           <% else %>
             <td></td>

--- a/app/views/pool_versions/_revert_listing.html.erb
+++ b/app/views/pool_versions/_revert_listing.html.erb
@@ -21,7 +21,7 @@
         <tr>
           <td><%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), :class => "pool-category-#{pool_version.pool.category}" %></td>
           <td><%= link_to pool_version.post_ids.size, pool_versions_path(:search => {:pool_id => pool_version.pool_id}) %></td>
-          <td><%= pool_version_diff(pool_version) %></td>
+          <td class="col-expand"><%= pool_version_diff(pool_version) %></td>
           <td><%= link_to_if pool_version.description_changed, pool_version.description_changed, diff_pool_version_path(pool_version.id) %></td>
           <td><%= link_to_user pool_version.updater %></td>
           <% if CurrentUser.is_moderator? %>

--- a/app/views/pool_versions/_standard_listing.html.erb
+++ b/app/views/pool_versions/_standard_listing.html.erb
@@ -18,7 +18,7 @@
         <tr>
           <td><%= link_to pool_version.pretty_name, pool_path(pool_version.pool_id), :class => "pool-category-#{pool_version.pool.category}" %></td>
           <td><%= link_to pool_version.post_ids.size, pool_versions_path(:search => {:pool_id => pool_version.pool_id}) %></td>
-          <td><%= pool_version_diff(pool_version) %></td>
+          <td class="col-expand"><%= pool_version_diff(pool_version) %></td>
           <td><%= link_to_if pool_version.description_changed, pool_version.description_changed, diff_pool_version_path(pool_version.id) %></td>
           <td><%= link_to_user pool_version.updater %></td>
           <% if CurrentUser.is_moderator? %>

--- a/app/views/post_versions/_revert_listing.html.erb
+++ b/app/views/post_versions/_revert_listing.html.erb
@@ -33,7 +33,7 @@
               <%= link_to_ip post_version.updater_ip_addr %>
             </td>
           <% end %>
-          <td><%= post_version_diff(post_version) %></td>
+          <td class="col-expand"><%= post_version_diff(post_version) %></td>
           <% if CurrentUser.is_member? %>
             <td>
               <% if post_version.visible? %>

--- a/app/views/post_versions/_standard_listing.html.erb
+++ b/app/views/post_versions/_standard_listing.html.erb
@@ -36,12 +36,12 @@
               <%= link_to_ip post_version.updater_ip_addr %>
             </td>
           <% end %>
-          <td><%= post_version_diff(post_version) %></td>
+          <td class="col-expand"><%= post_version_diff(post_version) %></td>
           <% if CurrentUser.is_member? %>
             <td>
               <% if post_version.visible? %>
                 <% if post_version.version != 1 %>
-                  <%= link_to "Undo", undo_post_version_path(post_version), :method => :put, :remote => true %> |
+                  <%= link_to "Undo", undo_post_version_path(post_version), :method => :put, :remote => true %>
                 <% end %>
               <% end %>
             </td>


### PR DESCRIPTION
User unbreakable and chinatsu reported on Discord that there was some spacing issues on the post versions table on Firefox and Internet Explorer where the **Tags** section would run off the screen.
https://cdn.discordapp.com/attachments/310846683376517121/397908244590231553/unknown.png

This was caused due to the changes in #3486.  I checked the other affected versions and fixed a few other problem areas.

1. **Other Names** on artist versions
2. **Changes** on pool versions

I left both the **Original** and **Translated** columns alone on the artist commentaries even though they can both get long, as it may be beneficial to see where the carriage returns are at.
  
  ### Edit:
Went back and removed the pipe character '|' on the post version standard listing as it's not needed.