### PR TITLE
Fix fuzzy autocomlete results

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -943,7 +943,7 @@ class Tag < ApplicationRecord
       tags = Tag.select("DISTINCT ON (name, post_count) *").from(sql_query).order("post_count desc").limit(10)
 
       if tags.empty?
-        tags = Tag.fuzzy_name_matches(name).order_similarity(name).nonempty.limit(10)
+        tags = Tag.select("tags.name, tags.post_count, tags.category, null AS antecedent_name").fuzzy_name_matches(name).order_similarity(name).nonempty.limit(10)
       end
 
       tags


### PR DESCRIPTION
I discovered the other day that the fuzzy name matching on autocomplete results didn't have the **antecedent_name** field defined in the results which luckily doesn't affect the Javascript as ``undefined`` evaluates to ``false``.  Additionally, it was also returning information it didn't need to, i.e. the entire tag record.

### Normal search
http://danbooru.donmai.us/tags/autocomplete.json?search[name_matches]=f-22_raptor
```
[{
    "id": null,
    "name": "f-22_raptor",
    "post_count": 98,
    "category": 0,
    "antecedent_name": null
}]
```
### Fuzzy search
http://danbooru.donmai.us/tags/autocomplete.json?search[name_matches]=f-22_rapter
```
[{
    "id": 1347519,
    "name": "f-22_raptor",
    "post_count": 98,
    "related_tags": "f-22_raptor 98 airplane 81 aircraft 81 jet 74 military 67 military_vehicle 55 fighter_jet 52 highres 47 1girl 41 ace_combat 37 original 36 solo 34 cloud 31 sky 29 long_hair 27 multiple_girls 24 weapon 23 no_humans 22 flying 21 mecha_musume 20 blonde_hair 19 day 19 thighhighs 18 condensation_trail 18 ace_combat_04 18",
    "related_tags_updated_at": "2018-01-03T13:07:41.786Z",
    "category": 0,
    "created_at": "2016-01-08T03:30:59.933Z",
    "updated_at": "2018-01-03T13:07:41.787Z",
    "is_locked": false
}]
```