### PR TITLE
Fix erroneous updates to wiki page when nothing changes

### DIFF
--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -382,7 +382,7 @@ class Artist < ApplicationRecord
         if @notes.present?
           create_wiki_page(body: @notes, title: name)
         end
-      elsif wiki_page.body != @notes || wiki_page.title != name
+      elsif (!@notes.nil? && (wiki_page.body != @notes)) || wiki_page.title != name
         # if anything changed, we need to update the wiki page
         wiki_page.body = @notes unless @notes.nil?
         wiki_page.title = name

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -190,6 +190,10 @@ class WikiPage < ApplicationRecord
     title.tr("_", " ")
   end
 
+  def wiki_page_changed?
+    title_changed? || body_changed? || is_locked_changed? || is_deleted_changed? || other_names_changed?
+  end
+
   def merge_version
     prev = versions.last
     prev.update_attributes(
@@ -219,7 +223,7 @@ class WikiPage < ApplicationRecord
   end
 
   def create_version
-    if title_changed? || body_changed? || is_locked_changed? || is_deleted_changed? || other_names_changed?
+    if wiki_page_changed?
       if merge_version?
         merge_version
       else
@@ -235,9 +239,11 @@ class WikiPage < ApplicationRecord
   def initialize_creator
     self.creator_id = CurrentUser.user.id
   end
-  
+
   def initialize_updater
-    self.updater_id = CurrentUser.user.id
+    if wiki_page_changed?
+      self.updater_id = CurrentUser.user.id
+    end
   end
 
   def post_set


### PR DESCRIPTION
Fixes #2974.  Besides artist edits that don't affect the wiki, it also prevents updating the **updater_id** on wiki page saves where nothing has changed.