### PR TITLE
Fix how cosplay tags are handled

### DIFF
--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -950,6 +950,19 @@ class Tag < ApplicationRecord
     end
   end
 
+  def self.convert_cosplay_tags(tags)
+    cosplay_tags,other_tags = tags.partition {|tag| tag.match(/\A(.+)_\(cosplay\)\Z/) }
+    cosplay_tags.grep(/\A(.+)_\(cosplay\)\Z/) { "#{TagAlias.to_aliased([$1]).first}_(cosplay)" } + other_tags
+  end
+
+  def self.invalid_cosplay_tags(tags)
+    tags.grep(/\A(.+)_\(cosplay\)\Z/) {|match| [match,TagAlias.to_aliased([$1]).first] }.
+      select do |name|
+        tag = Tag.find_by_name(name[1])
+        !tag.nil? && tag.category != Tag.categories.character
+      end.map {|tag| tag[0]}
+  end
+
   def editable_by?(user)
     return true if user.is_admin?
     return true if !is_locked? && user.is_builder? && post_count < 1_000


### PR DESCRIPTION
Fixes #3494.  Besides handling not allowing existing root tags to not be changed via *_(cosplay), I also discovered that *_(cosplay) tags weren't converted to use the alias form of the root tag.

Given the example alias of ``/nm -> nishizumi_miho``

How it was:
- /nm_(cosplay) => char:nishizumi_miho, cosplay, /nm_(cosplay)

How it changed:
- /nm_(cosplay) => char:nishizumi_miho, cosplay, nishizumi_miho_(cosplay)

The "char:" was left in for the case that a brand new character tag will be created.