### PR TITLE
Fix index default order

### DIFF
--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -341,7 +341,8 @@
       "filesize", "filesize_asc",
       "tagcount", "tagcount_asc",
       "rank",
-      "random"
+      "random",
+      "custom"
     ].concat(<%= TagCategory.short_name_list.map {|category| [category + "tags", category + "tags_asc"]}.flatten %>),
     status: [
       "any", "deleted", "active", "pending", "flagged", "banned"

--- a/app/controllers/artist_commentaries_controller.rb
+++ b/app/controllers/artist_commentaries_controller.rb
@@ -3,7 +3,7 @@ class ArtistCommentariesController < ApplicationController
   before_filter :member_only, :except => [:index, :show]
 
   def index
-    @commentaries = ArtistCommentary.search(params[:search]).order("artist_commentaries.id desc").paginate(params[:page], :limit => params[:limit])
+    @commentaries = ArtistCommentary.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@commentaries) do |format|
       format.xml do
         render :xml => @commentaries.to_xml(:root => "artist-commentaries")

--- a/app/controllers/artist_commentary_versions_controller.rb
+++ b/app/controllers/artist_commentary_versions_controller.rb
@@ -2,7 +2,7 @@ class ArtistCommentaryVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @commentary_versions = ArtistCommentaryVersion.search(params[:search]).order("artist_commentary_versions.id desc").paginate(params[:page], :limit => params[:limit])
+    @commentary_versions = ArtistCommentaryVersion.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@commentary_versions) do |format|
       format.xml do
         render :xml => @commentary_versions.to_xml(:root => "artist-commentary-versions")

--- a/app/controllers/artist_versions_controller.rb
+++ b/app/controllers/artist_versions_controller.rb
@@ -3,7 +3,7 @@ class ArtistVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @artist_versions = ArtistVersion.search(params[:search]).order("id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @artist_versions = ArtistVersion.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@artist_versions) do |format|
       format.xml do
         render :xml => @artist_versions.to_xml(:root => "artist-versions")

--- a/app/controllers/dmails_controller.rb
+++ b/app/controllers/dmails_controller.rb
@@ -20,7 +20,7 @@ class DmailsController < ApplicationController
       cookies.permanent[:dmail_folder] = params[:folder]
     end
     @query = Dmail.active.visible.search(params[:search])
-    @dmails = @query.order("dmails.created_at desc").paginate(params[:page], :limit => params[:limit])
+    @dmails = @query.paginate(params[:page], :limit => params[:limit])
     respond_with(@dmails) do |format|
       format.xml do
         render :xml => @dmails.to_xml(:root => "dmails")

--- a/app/controllers/favorite_groups_controller.rb
+++ b/app/controllers/favorite_groups_controller.rb
@@ -3,7 +3,7 @@ class FavoriteGroupsController < ApplicationController
   respond_to :html, :xml, :json, :js
 
   def index
-    @favorite_groups = FavoriteGroup.search(params[:search]).order("updated_at desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @favorite_groups = FavoriteGroup.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@favorite_groups) do |format|
       format.xml do
         render :xml => @favorite_groups.to_xml(:root => "favorite-groups")

--- a/app/controllers/forum_posts_controller.rb
+++ b/app/controllers/forum_posts_controller.rb
@@ -25,7 +25,7 @@ class ForumPostsController < ApplicationController
 
   def index
     @query = ForumPost.search(params[:search])
-    @forum_posts = @query.includes(:topic).order("forum_posts.id DESC").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @forum_posts = @query.includes(:topic).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@forum_posts) do |format|
       format.xml do
         render :xml => @forum_posts.to_xml(:root => "forum-posts")

--- a/app/controllers/mod_actions_controller.rb
+++ b/app/controllers/mod_actions_controller.rb
@@ -2,7 +2,7 @@ class ModActionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @mod_actions = ModAction.search(params[:search]).order("id desc").paginate(params[:page], :limit => params[:limit])
+    @mod_actions = ModAction.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@mod_actions)
   end
 end

--- a/app/controllers/note_versions_controller.rb
+++ b/app/controllers/note_versions_controller.rb
@@ -2,7 +2,7 @@ class NoteVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @note_versions = NoteVersion.search(params[:search]).order("note_versions.id desc").paginate(params[:page], :limit => params[:limit])
+    @note_versions = NoteVersion.search(params[:search]).paginate(params[:page], :limit => params[:limit])
     respond_with(@note_versions) do |format|
       format.html { @note_versions = @note_versions.includes(:updater) }
       format.xml do

--- a/app/controllers/notes_controller.rb
+++ b/app/controllers/notes_controller.rb
@@ -6,7 +6,7 @@ class NotesController < ApplicationController
   end
 
   def index
-    @notes = Note.search(params[:search]).order("id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @notes = Note.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@notes) do |format|
       format.html { @notes = @notes.includes(:creator) }
       format.xml do

--- a/app/controllers/pool_versions_controller.rb
+++ b/app/controllers/pool_versions_controller.rb
@@ -7,7 +7,7 @@ class PoolVersionsController < ApplicationController
       @pool = Pool.find(params[:search][:pool_id])
     end
 
-    @pool_versions = PoolArchive.search(params[:search]).order("updated_at desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @pool_versions = PoolArchive.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@pool_versions) do |format|
       format.xml do
         render :xml => @pool_versions.to_xml(:root => "pool-versions")

--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -17,7 +17,7 @@ class PoolsController < ApplicationController
   end
 
   def index
-    @pools = Pool.search(params[:search]).order("updated_at desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @pools = Pool.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@pools) do |format|
       format.xml do
         render :xml => @pools.to_xml(:root => "pools")

--- a/app/controllers/post_versions_controller.rb
+++ b/app/controllers/post_versions_controller.rb
@@ -4,7 +4,7 @@ class PostVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @post_versions = PostArchive.includes(:updater, post: [:versions]).search(params[:search]).order("updated_at desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @post_versions = PostArchive.includes(:updater, post: [:versions]).search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@post_versions) do |format|
       format.xml do
         render :xml => @post_versions.to_xml(:root => "post-versions")

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -32,7 +32,7 @@ class UploadsController < ApplicationController
 
   def index
     @search = Upload.search(params[:search])
-    @uploads = @search.order("id desc").paginate(params[:page], :limit => params[:limit])
+    @uploads = @search.paginate(params[:page], :limit => params[:limit])
     respond_with(@uploads) do |format|
       format.xml do
         render :xml => @uploads.to_xml(:root => "uploads")

--- a/app/controllers/user_feedbacks_controller.rb
+++ b/app/controllers/user_feedbacks_controller.rb
@@ -20,7 +20,7 @@ class UserFeedbacksController < ApplicationController
 
   def index
     @search = UserFeedback.visible.search(params[:search])
-    @user_feedbacks = @search.paginate(params[:page], :limit => params[:limit]).order("created_at desc")
+    @user_feedbacks = @search.paginate(params[:page], :limit => params[:limit])
     respond_with(@user_feedbacks) do |format|
       format.xml do
         render :xml => @user_feedbacks.to_xml(:root => "user-feedbacks")

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
         redirect_to user_path(@user)
       end
     else
-      @users = User.search(params[:search]).order("users.id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+      @users = User.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
       respond_with(@users) do |format|
         format.xml do
           render :xml => @users.to_xml(:root => "users")

--- a/app/controllers/wiki_page_versions_controller.rb
+++ b/app/controllers/wiki_page_versions_controller.rb
@@ -2,7 +2,7 @@ class WikiPageVersionsController < ApplicationController
   respond_to :html, :xml, :json
 
   def index
-    @wiki_page_versions = WikiPageVersion.search(params[:search]).order("id desc").paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    @wiki_page_versions = WikiPageVersion.search(params[:search]).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
     respond_with(@wiki_page_versions) do |format|
       format.xml do
         render :xml => @wiki_page_versions.to_xml(:root => "wiki-page-versions")

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -515,6 +515,11 @@ class PostQueryBuilder
     when "rank"
       relation = relation.order("log(3, posts.score) + (extract(epoch from posts.created_at) - extract(epoch from timestamp '2005-05-24')) / 35000 DESC")
 
+    when "custom"
+      if q[:post_id].present? && q[:post_id][0] == :in
+        relation = relation.find_ordered(q[:post_id][1])
+      end
+
     else
       relation = relation.order("posts.id DESC")
     end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -536,7 +536,6 @@ class Artist < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       case params[:name]
       when /^http/
@@ -581,18 +580,6 @@ class Artist < ApplicationRecord
         q = q.url_matches(params[:url_matches])
       end
 
-      params[:order] ||= params.delete(:sort)
-      case params[:order]
-      when "name"
-        q = q.order("artists.name")
-      when "updated_at"
-        q = q.order("artists.updated_at desc")
-      when "post_count"
-        q = q.includes(:tag).order("tags.post_count desc nulls last").references(:tags)
-      else
-        q = q.order("artists.id desc")
-      end
-
       if params[:is_active] == "true"
         q = q.active
       elsif params[:is_active] == "false"
@@ -622,6 +609,18 @@ class Artist < ApplicationRecord
         q = q.joins(:tag).where("tags.post_count > 0")
       elsif params[:has_tag] == "false"
         q = q.includes(:tag).where("tags.name IS NULL OR tags.post_count <= 0").references(:tags)
+      end
+
+      params[:order] ||= params.delete(:sort)
+      case params[:order]
+      when "name"
+        q = q.order("artists.name")
+      when "updated_at"
+        q = q.order("artists.updated_at desc")
+      when "post_count"
+        q = q.includes(:tag).order("tags.post_count desc nulls last").order("artists.name").references(:tags)
+      else
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -33,7 +33,6 @@ class ArtistCommentary < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:text_matches].present?
         q = q.text_matches(params[:text_matches])
@@ -62,7 +61,7 @@ class ArtistCommentary < ApplicationRecord
       q = q.deleted if params[:is_deleted] == "yes"
       q = q.undeleted if params[:is_deleted] == "no"
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/artist_commentary_version.rb
+++ b/app/models/artist_commentary_version.rb
@@ -7,7 +7,6 @@ class ArtistCommentaryVersion < ApplicationRecord
 
   def self.search(params)
     q = super
-    return q if params.blank?
 
     if params[:updater_id]
       q = q.where("updater_id = ?", params[:updater_id].to_i)
@@ -17,7 +16,7 @@ class ArtistCommentaryVersion < ApplicationRecord
       q = q.where("post_id = ?", params[:post_id].to_i)
     end
 
-    q
+    q.apply_default_order(params)
   end
 
   def initialize_updater

--- a/app/models/artist_version.rb
+++ b/app/models/artist_version.rb
@@ -15,7 +15,6 @@ class ArtistVersion < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:name].present?
         q = q.where("name like ? escape E'\\\\'", params[:name].to_escaped_for_sql_like)
@@ -33,13 +32,6 @@ class ArtistVersion < ApplicationRecord
         q = q.where(artist_id: params[:artist_id].split(",").map(&:to_i))
       end
 
-      params[:order] ||= params.delete(:sort)
-      if params[:order] == "name"
-        q = q.reorder("name")
-      else
-        q = q.reorder("id desc")
-      end
-
       if params[:is_active] == "true"
         q = q.where("is_active = true")
       elsif params[:is_active] == "false"
@@ -50,6 +42,13 @@ class ArtistVersion < ApplicationRecord
         q = q.where("is_banned = true")
       elsif params[:is_banned] == "false"
         q = q.where("is_banned = false")
+      end
+
+      params[:order] ||= params.delete(:sort)
+      if params[:order] == "name"
+        q = q.order("artist_versions.name").default_order
+      else
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -27,7 +27,6 @@ class Ban < ApplicationRecord
 
   def self.search(params)
     q = super
-    return q if params.blank?
 
     if params[:banner_name]
       q = q.where("banner_id = (select _.id from users _ where lower(_.name) = ?)", params[:banner_name].mb_chars.downcase)
@@ -58,7 +57,7 @@ class Ban < ApplicationRecord
     when "expires_at_desc"
       q = q.order("bans.expires_at desc")
     else
-      q = q.order("bans.id desc")
+      q = q.apply_default_order(params)
     end
 
     q

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -22,6 +22,10 @@ class BulkUpdateRequest < ApplicationRecord
   scope :pending_first, lambda { order("(case status when 'pending' then 0 when 'approved' then 1 else 2 end)") }
 
   module SearchMethods
+    def default_order
+      pending_first.order(id: :desc)
+    end
+
     def search(params = {})
       q = super
 
@@ -63,8 +67,8 @@ class BulkUpdateRequest < ApplicationRecord
         q = q.order(updated_at: :desc)
       when "updated_at_asc"
         q = q.order(updated_at: :asc)
-      when "status_desc"
-        q = q.pending_first.order(id: :desc)
+      else
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -131,7 +131,7 @@ class Comment < ApplicationRecord
       when "updated_at", "updated_at_desc"
         q = q.order("comments.updated_at DESC")
       else
-        q = q.order("comments.id DESC")
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/dmail.rb
+++ b/app/models/dmail.rb
@@ -187,7 +187,6 @@ class Dmail < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:title_matches].present?
         q = q.title_matches(params[:title_matches])
@@ -225,7 +224,7 @@ class Dmail < ApplicationRecord
         q = q.unread
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/favorite_group.rb
+++ b/app/models/favorite_group.rb
@@ -39,13 +39,16 @@ class FavoriteGroup < ApplicationRecord
       elsif params[:is_public].present?
         where("is_public = ?", params[:is_public])
       else
-        where("true")
+        all
       end
+    end
+
+    def default_order
+      order(updated_at: :desc)
     end
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:creator_id].present?
         user = User.find(params[:creator_id])
@@ -64,7 +67,7 @@ class FavoriteGroup < ApplicationRecord
         q = q.name_matches(params[:name_matches])
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/forum_post.rb
+++ b/app/models/forum_post.rb
@@ -67,7 +67,6 @@ class ForumPost < ApplicationRecord
     def search(params)
       q = super
       q = q.permitted
-      return q if params.blank?
 
       if params[:creator_id].present?
         q = q.where("forum_posts.creator_id = ?", params[:creator_id].to_i)
@@ -93,7 +92,7 @@ class ForumPost < ApplicationRecord
         q = q.joins(:topic).where("forum_topics.category_id = ?", params[:topic_category_id].to_i)
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -75,6 +75,10 @@ class ForumTopic < ApplicationRecord
       order(is_sticky: :desc, updated_at: :desc)
     end
 
+    def default_order
+      order(updated_at: :desc)
+    end
+
     def search(params)
       q = super
       q = q.permitted
@@ -99,7 +103,7 @@ class ForumTopic < ApplicationRecord
       when "sticky"
         q = q.sticky_first
       else
-        q = q.order(updated_at: :desc)
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -53,7 +53,6 @@ class ModAction < ApplicationRecord
 
   def self.search(params)
     q = super
-    return q if params.blank?
 
     if params[:creator_id].present?
       q = q.where("creator_id = ?", params[:creator_id].to_i)
@@ -67,7 +66,7 @@ class ModAction < ApplicationRecord
       q = q.attribute_matches(:category, params[:category])
     end
 
-    q
+    q.apply_default_order(params)
   end
 
   def category_id

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -43,7 +43,6 @@ class Note < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:body_matches].present?
         q = q.body_matches(params[:body_matches])
@@ -71,7 +70,7 @@ class Note < ApplicationRecord
         q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -6,7 +6,6 @@ class NoteVersion < ApplicationRecord
 
   def self.search(params)
     q = super
-    return q if params.blank?
 
     if params[:updater_id]
       q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
@@ -20,7 +19,7 @@ class NoteVersion < ApplicationRecord
       q = q.where(note_id: params[:note_id].split(",").map(&:to_i))
     end
 
-    q
+    q.apply_default_order(params)
   end
 
   def initialize_updater

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -49,9 +49,12 @@ class Pool < ApplicationRecord
       where("lower(pools.name) like ? escape E'\\\\'", name.to_escaped_for_sql_like)
     end
 
+    def default_order
+      order(updated_at: :desc)
+    end
+
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:name_matches].present?
         q = q.name_matches(params[:name_matches])
@@ -75,18 +78,6 @@ class Pool < ApplicationRecord
         q = q.where("pools.is_active = false")
       end
 
-      params[:order] ||= params.delete(:sort)
-      case params[:order]
-      when "name"
-        q = q.order("pools.name")
-      when "created_at"
-        q = q.order("pools.created_at desc")
-      when "post_count"
-        q = q.order("pools.post_count desc")
-      else
-        q = q.order("pools.updated_at desc")
-      end
-
       if params[:category] == "series"
         q = q.series
       elsif params[:category] == "collection"
@@ -97,6 +88,18 @@ class Pool < ApplicationRecord
         q = q.deleted
       else
         q = q.undeleted
+      end
+
+      params[:order] ||= params.delete(:sort)
+      case params[:order]
+      when "name"
+        q = q.order("pools.name")
+      when "created_at"
+        q = q.order("pools.created_at desc")
+      when "post_count"
+        q = q.order("pools.post_count desc").default_order
+      else
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/pool_archive.rb
+++ b/app/models/pool_archive.rb
@@ -16,7 +16,6 @@ class PoolArchive < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:updater_id].present?
         q = q.where(updater_id: params[:updater_id].split(",").map(&:to_i))
@@ -30,7 +29,7 @@ class PoolArchive < ApplicationRecord
         q = q.where(pool_id: params[:pool_id].split(",").map(&:to_i))
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/pool_version.rb
+++ b/app/models/pool_version.rb
@@ -14,7 +14,6 @@ class PoolVersion < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:updater_id].present?
         q = q.for_user(params[:updater_id].to_i)
@@ -28,7 +27,7 @@ class PoolVersion < ApplicationRecord
         q = q.where("pool_id = ?", params[:pool_id].to_i)
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -45,8 +45,6 @@ class PostAppeal < ApplicationRecord
 
     def search(params)
       q = super
-      q = q.order("post_appeals.id desc")
-      return q if params.blank?
 
       if params[:reason_matches].present?
         q = q.reason_matches(params[:reason_matches])
@@ -74,7 +72,7 @@ class PostAppeal < ApplicationRecord
         q = q.unresolved
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/post_archive.rb
+++ b/app/models/post_archive.rb
@@ -27,7 +27,6 @@ class PostArchive < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:updater_name].present?
         q = q.for_user_name(params[:updater_name])
@@ -45,7 +44,7 @@ class PostArchive < ApplicationRecord
         q = q.where("id <= ?", params[:start_id].to_i)
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -67,8 +67,6 @@ class PostFlag < ApplicationRecord
 
     def search(params)
       q = super
-      q = q.order("post_flags.id desc")
-      return q if params.blank?
 
       if params[:reason_matches].present?
         q = q.reason_matches(params[:reason_matches])
@@ -122,7 +120,7 @@ class PostFlag < ApplicationRecord
         q = q.duplicate
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -121,9 +121,7 @@ class PostReplacement < ApplicationRecord
         q = q.post_tags_match(params[:post_tags_match])
       end
 
-      q = q.order("created_at DESC")
-
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/post_version.rb
+++ b/app/models/post_version.rb
@@ -15,7 +15,6 @@ class PostVersion < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:updater_name].present?
         q = q.updater_name(params[:updater_name])
@@ -33,7 +32,7 @@ class PostVersion < ApplicationRecord
         q = q.where("id <= ?", params[:start_id].to_i)
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -872,7 +872,6 @@ class Tag < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:fuzzy_name_matches].present?
         q = q.fuzzy_name_matches(params[:fuzzy_name_matches])
@@ -909,15 +908,15 @@ class Tag < ApplicationRecord
       params[:order] ||= params.delete(:sort)
       case params[:order]
       when "name"
-        q = q.reorder("name")
+        q = q.order("name")
       when "date"
-        q = q.reorder("id desc")
+        q = q.order("id desc")
       when "count"
-        q = q.reorder("post_count desc")
+        q = q.order("post_count desc")
       when "similarity"
         q = q.order_similarity(params[:fuzzy_name_matches]) if params[:fuzzy_name_matches].present?
       else
-        q = q.reorder("id desc")
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/tag_relationship.rb
+++ b/app/models/tag_relationship.rb
@@ -72,6 +72,10 @@ class TagRelationship < ApplicationRecord
       where(status: %w[active processing queued])
     end
 
+    def default_order
+      pending_first
+    end
+
     def search(params)
       q = super
 
@@ -97,8 +101,6 @@ class TagRelationship < ApplicationRecord
 
       params[:order] ||= "status"
       case params[:order].downcase
-      when "status"
-        q = q.pending_first
       when "created_at"
         q = q.order("created_at desc")
       when "updated_at"
@@ -107,6 +109,8 @@ class TagRelationship < ApplicationRecord
         q = q.order("antecedent_name asc, consequent_name asc")
       when "tag_count"
         q = q.joins(:consequent_tag).order("tags.post_count desc, antecedent_name asc, consequent_name asc")
+      else
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/tag_subscription.rb
+++ b/app/models/tag_subscription.rb
@@ -40,7 +40,6 @@ class TagSubscription < ApplicationRecord
 
     def search(params)
       q = super
-      params = {} if params.blank?
 
       if params[:creator_id]
         q = q.where("creator_id = ?", params[:creator_id].to_i)
@@ -56,7 +55,7 @@ class TagSubscription < ApplicationRecord
 
       q = q.visible_to(CurrentUser.user)
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -495,7 +495,6 @@ class Upload < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:uploader_id].present?
         q = q.uploaded_by(params[:uploader_id].to_i)
@@ -509,7 +508,7 @@ class Upload < ApplicationRecord
         q = q.where("source = ?", params[:source])
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -815,7 +815,6 @@ class User < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:name].present?
         q = q.name_matches(params[:name].mb_chars.downcase.strip.tr(" ", "_"))
@@ -873,18 +872,14 @@ class User < ApplicationRecord
       case params[:order]
       when "name"
         q = q.order("name")
-
       when "post_upload_count"
         q = q.order("post_upload_count desc")
-
       when "note_count"
         q = q.order("note_update_count desc")
-
       when "post_update_count"
         q = q.order("post_update_count desc")
-
       else
-        q = q.order("created_at desc")
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -45,7 +45,6 @@ class UserFeedback < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:user_id].present?
         q = q.for_user(params[:user_id].to_i)
@@ -67,7 +66,7 @@ class UserFeedback < ApplicationRecord
         q = q.where("category = ?", params[:category])
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 

--- a/app/models/wiki_page.rb
+++ b/app/models/wiki_page.rb
@@ -59,9 +59,12 @@ class WikiPage < ApplicationRecord
       end
     end
 
+    def default_order
+      order(updated_at: :desc)
+    end
+
     def search(params = {})
       q = super
-      params = {} if params.blank?
 
       if params[:title].present?
         q = q.where("title LIKE ? ESCAPE E'\\\\'", params[:title].mb_chars.downcase.tr(" ", "_").to_escaped_for_sql_like)
@@ -95,14 +98,12 @@ class WikiPage < ApplicationRecord
 
       params[:order] ||= params.delete(:sort)
       case params[:order]
-      when "time"
-        q = q.order("updated_at desc")
       when "title"
         q = q.order("title")
       when "post_count"
         q = q.includes(:tag).order("tags.post_count desc nulls last").references(:tags)
       else
-        q = q.order("updated_at desc")
+        q = q.apply_default_order(params)
       end
 
       q

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -12,7 +12,6 @@ class WikiPageVersion < ApplicationRecord
 
     def search(params)
       q = super
-      return q if params.blank?
 
       if params[:updater_id].present?
         q = q.for_user(params[:updater_id].to_i)
@@ -22,7 +21,7 @@ class WikiPageVersion < ApplicationRecord
         q = q.where("wiki_page_id = ?", params[:wiki_page_id].to_i)
       end
 
-      q
+      q.apply_default_order(params)
     end
   end
 


### PR DESCRIPTION
I noticed that with the latest deployment that the bans index was [showing weird orderings](http://danbooru.donmai.us/bans), not being ordered by ID or expiration.  After looking into it, I found out that it was most likely broken by #3495 when it was changed to early return if the parameters are blank.  Also, the order logic was divided between either being specified in the controller or in the model.

After speaking with @evazion, we thought it would be best to standardize all of the models.  Since orders are frequently specified in the model as part of the **search** function, it would be easiest to move there.  When there was an **order** block, then that was moved to the end of the **search** function, and if not then the final action was to apply the default order to the query.  Also, when one of the order terms matched the default order then it was eliminated, such as ``order[time]`` for wiki pages.

There is a default for all models of ID DESC, however each model can specify its own default.  Additionally, we thought that having a custom ordering for records would be useful on occasion, so that was added to all models as well.