### PR TITLE
Fix mod actions

### DIFF
--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -29,6 +29,7 @@ class ModAction < ApplicationRecord
     post_ban: 44,
     post_unban: 45,
     post_permanent_delete: 46,
+    post_move_favorites: 47,
     pool_delete: 62,
     pool_undelete: 63,
     artist_ban: 184,

--- a/app/models/user_name_change_request.rb
+++ b/app/models/user_name_change_request.rb
@@ -47,7 +47,7 @@ class UserNameChangeRequest < ApplicationRecord
     body = "Your name change request has been approved. Be sure to log in with your new user name."
     Dmail.create_automated(:title => "Name change request approved", :body => body, :to_id => user_id)
     UserFeedback.create(:user_id => user_id, :category => "neutral", :body => "Name changed from #{original_name} to #{desired_name}")
-    ModAction.log("Name changed from #{original_name} to #{desired_name}")
+    ModAction.log("Name changed from #{original_name} to #{desired_name}",:user_name_change)
   end
   
   def reject!(reason)


### PR DESCRIPTION
I checked the moderator actions and noticed that name changes were being set to the **other** category because it wasn't being set by the **ModAction.log** function.  Seems like that's one that was missed in #3496.

Besides the above, it was also asked by an approver to add a mod action for moving a post's favorites.