### PR TITLE
implement post keepers

### DIFF
--- a/app/logical/google_big_query/post_version.rb
+++ b/app/logical/google_big_query/post_version.rb
@@ -20,6 +20,13 @@ module GoogleBigQuery
       "regexp_match(removed_tags, \"(?:^| )#{es}(?:$| )\")"
     end
 
+    def find_for_post(post_id, created_at)
+      post_id = post_id.to_i
+      btime = created_at.strftime("%Y-%m-%d 00:00:00", created_at)
+      etime = 1.day.from(created_at).strftime("%Y-%m-%d 00:00:00")
+      "select updater_id, added_tag from [danbooru_#{Rails.env}].post_versions_flat_part where _partitiontime >= #{btime} and _partitiontime <= #{etime} and post_id = #{post_id}"
+    end
+
     def find(user_id, added_tags, removed_tags, min_version_id, max_version_id, limit = 1_000)
       constraints = []
 

--- a/app/logical/post_keeper_manager.rb
+++ b/app/logical/post_keeper_manager.rb
@@ -1,0 +1,103 @@
+class PostKeeperManager
+  def self.enabled?
+    PostArchive.enabled?
+  end
+
+  def self.queue_check(post_id)
+    delay(queue: "default").check_and_update(post_id)
+  end
+
+  def self.evaluate(post_ids)
+    total = 0
+    matches = 0
+    keeper_dist = {}
+    uploader_dist = {}
+    Post.where(id: post_ids).find_each do |post|
+      keeper = check(post)
+      total += 1
+      if keeper != post.uploader_id
+        matches += 1
+        keeper_dist[keeper] ||= 0
+        keeper_dist[keeper] += 1
+        uploader_dist[post.uploader_id] ||= 0
+        uploader_dist[post.uploader_id] += 1
+      end
+    end
+
+    puts "total: #{total}"
+    puts "changes: #{matches}"
+    # puts "keepers:"
+    # keeper_dist.each do |k, v|
+    #   puts "  #{k}: #{v}"
+    # end
+    # puts "uploaders:"
+    # uploader_dist.each do |k, v|
+    #   puts "  #{k}: #{v}"
+    # end
+  end
+
+  def self.check_and_update(post_id)
+    post = Post.find(post_id)
+    keeper_id = check(post)
+    CurrentUser.as_system do
+      post.update_column(:keeper_data, {uid: keeper_id})
+    end
+  end
+
+  def self.check(post)
+    changes = {}
+    final_tags = Set.new(post.tag_array)
+
+    # build a mapping of who added a tag first
+    PostArchive.where(post_id: post.id).order("updated_at").each do |pa|
+      # Rails.logger.debug "archive #{pa.id}"
+      pa.added_tags.each do |at|
+        # Rails.logger.debug "  checking #{at}"
+        if pa.updater_id
+          if !changes.has_key?(at) && final_tags.include?(at)
+            # Rails.logger.debug "    adding #{at} for #{pa.updater_id}"
+            changes[at] = pa.updater_id 
+          end
+
+          if pa.source_changed? && pa.source == post.source
+            # Rails.logger.debug "    adding source for #{pa.updater_id}"
+            changes[" source"] = pa.updater_id
+          end
+        else
+          # Rails.logger.debug "    no updater"
+        end
+      end
+
+      # easy to double count trivial changes if a user is just fixing mistakes
+      # pa.removed_tags.each do |rt|
+      #   Rails.logger.debug "  checking -#{rt}"
+      #   if pa.updater_id
+      #     if !changes.has_key?("-#{rt}") && !final_tags.include?(rt)
+      #       Rails.logger.debug "    adding -#{rt} for #{pa.updater_id}"
+      #       changes["-#{rt}"] = pa.updater_id
+      #     end
+      #   else
+      #     Rails.logger.debug "    no updater"
+      #   end
+      # end
+    end
+
+    # add up how many changes each user has made
+    ranking = changes.values.uniq.inject({}) do |h, user_id|
+      # h[user_id] = changes.select {|k, v| v == user_id}.map do |tag, user_id|
+      #   count = Tag.find_by_name(tag).try(:post_count) || 0
+      #   1.0 / (1000 + count)
+      # end.sum
+      h[user_id] = changes.select {|k, v| v == user_id}.size
+      h
+    end
+
+    # ranking.sort_by {|k, v| v}.each do |user_id, score|
+    #   user = User.find(user_id)
+    #   sum = changes.select {|k, v| v == user_id}.size
+    #   Rails.logger.debug "#{user.name}: %.4f (%d)" % [score, sum]
+    # end
+
+    ranking.max_by {|k, v| v}.first
+  end
+end

--- a/app/logical/post_keeper_manager.rb
+++ b/app/logical/post_keeper_manager.rb
@@ -7,9 +7,13 @@ class PostKeeperManager
     delay(queue: "default").check_and_update(post_id)
   end
 
+  # in general, unweighted changes attribution 5% of the time,
+  # weighted changes attribution 12% of the time at w=1000,
+  # up to 17% of the time at w=100.
   def self.evaluate(post_ids)
     total = 0
     matches = 0
+    weighted_matches = 0
     keeper_dist = {}
     uploader_dist = {}
     Post.where(id: post_ids).find_each do |post|
@@ -17,15 +21,20 @@ class PostKeeperManager
       total += 1
       if keeper != post.uploader_id
         matches += 1
-        keeper_dist[keeper] ||= 0
-        keeper_dist[keeper] += 1
-        uploader_dist[post.uploader_id] ||= 0
-        uploader_dist[post.uploader_id] += 1
+        # keeper_dist[keeper] ||= 0
+        # keeper_dist[keeper] += 1
+        # uploader_dist[post.uploader_id] ||= 0
+        # uploader_dist[post.uploader_id] += 1
+      end
+      if check_weighted(post) != post.uploader_id
+        puts post.id
+        weighted_matches += 1
       end
     end
 
     puts "total: #{total}"
-    puts "changes: #{matches}"
+    puts "unweighted changes: #{matches}"
+    puts "weighted changes: #{weighted_matches}"
     # puts "keepers:"
     # keeper_dist.each do |k, v|
     #   puts "  #{k}: #{v}"
@@ -42,6 +51,72 @@ class PostKeeperManager
     CurrentUser.as_system do
       post.update_column(:keeper_data, {uid: keeper_id})
     end
+  end
+
+  def self.print_weighted(post, w = 1000)
+    changes = {}
+    final_tags = Set.new(post.tag_array)
+
+    # build a mapping of who added a tag first
+    PostArchive.where(post_id: post.id).order("updated_at").each do |pa|
+      pa.added_tags.each do |at|
+        if pa.updater_id
+          if !changes.has_key?(at) && final_tags.include?(at)
+            changes[at] = pa.updater_id 
+          end
+
+          if pa.source_changed? && pa.source == post.source
+            changes[" source"] = pa.updater_id
+          end
+        end
+      end
+    end
+
+    # add up how many changes each user has made
+    ranking = changes.values.uniq.inject({}) do |h, user_id|
+      h[user_id] = changes.select {|k, v| v == user_id}.map do |tag, user_id|
+        count = Tag.find_by_name(tag).try(:post_count) || 0
+        1.0 / (w + count)
+      end.sum
+      h
+    end
+
+    ranking.sort_by {|k, v| v}.each do |user_id, score|
+      user = User.find(user_id)
+      sum = changes.select {|k, v| v == user_id}.size
+      Rails.logger.debug "#{user.name}: %.4f (%d)" % [score, sum]
+    end
+  end
+
+  def self.check_weighted(post, w = 1000)
+    changes = {}
+    final_tags = Set.new(post.tag_array)
+
+    # build a mapping of who added a tag first
+    PostArchive.where(post_id: post.id).order("updated_at").each do |pa|
+      pa.added_tags.each do |at|
+        if pa.updater_id
+          if !changes.has_key?(at) && final_tags.include?(at)
+            changes[at] = pa.updater_id 
+          end
+
+          if pa.source_changed? && pa.source == post.source
+            changes[" source"] = pa.updater_id
+          end
+        end
+      end
+    end
+
+    # add up how many changes each user has made
+    ranking = changes.values.uniq.inject({}) do |h, user_id|
+      h[user_id] = changes.select {|k, v| v == user_id}.map do |tag, user_id|
+        count = Tag.find_by_name(tag).try(:post_count) || 0
+        1.0 / (w + count)
+      end.sum
+      h
+    end
+
+    ranking.max_by {|k, v| v}.first
   end
 
   def self.check(post)
@@ -84,19 +159,9 @@ class PostKeeperManager
 
     # add up how many changes each user has made
     ranking = changes.values.uniq.inject({}) do |h, user_id|
-      # h[user_id] = changes.select {|k, v| v == user_id}.map do |tag, user_id|
-      #   count = Tag.find_by_name(tag).try(:post_count) || 0
-      #   1.0 / (1000 + count)
-      # end.sum
       h[user_id] = changes.select {|k, v| v == user_id}.size
       h
     end
-
-    # ranking.sort_by {|k, v| v}.each do |user_id, score|
-    #   user = User.find(user_id)
-    #   sum = changes.select {|k, v| v == user_id}.size
-    #   Rails.logger.debug "#{user.name}: %.4f (%d)" % [score, sum]
-    # end
 
     ranking.max_by {|k, v| v}.first
   end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -57,14 +57,36 @@ class Post < ApplicationRecord
   has_many :favorites
   has_many :replacements, class_name: "PostReplacement", :dependent => :destroy
 
+  if PostKeeperManager.enabled?
+    serialize :keeper_data, JSON
+  end
+
   if PostArchive.enabled?
     has_many :versions, lambda {order("post_versions.updated_at ASC")}, :class_name => "PostArchive", :dependent => :destroy
   end
 
   attr_accessible :source, :rating, :tag_string, :old_tag_string, :old_parent_id, :old_source, :old_rating, :parent_id, :has_embedded_notes, :as => [:member, :builder, :gold, :platinum, :moderator, :admin, :default]
-  attr_accessible :is_rating_locked, :is_note_locked, :has_cropped, :as => [:builder, :moderator, :admin]
-  attr_accessible :is_status_locked, :as => [:admin]
+  attr_accessible :is_rating_locked, :is_note_locked, :has_cropped, :keeper_data, :as => [:builder, :moderator, :admin]
+  attr_accessible :is_status_locked, :keeper_data, :as => [:admin]
   attr_accessor :old_tag_string, :old_parent_id, :old_source, :old_rating, :has_constraints, :disable_versioning, :view_count
+
+  concerning :KeeperMethods do
+    included do
+      before_create :initialize_keeper
+    end
+
+    def keeper_id
+      keeper_data ? keeper_data[:uid] : uploader_id
+    end
+
+    def keeper
+      User.find(keeper_id)
+    end
+
+    def initialize_keeper
+      self.keeper_data = {uid: uploader_id}
+    end
+  end
 
   module FileMethods
     extend ActiveSupport::Concern
@@ -631,6 +653,11 @@ class Post < ApplicationRecord
       end
       if decrement_tags.any?
         Tag.decrement_post_counts(decrement_tags)
+      end
+
+      if PostKeeperManager.enabled? && persisted?
+        # no need to do this check on the initial create
+        PostKeeperManager.queue_check(id)
       end
     end
 

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -1,6 +1,9 @@
 <ul itemscope itemtype="http://schema.org/ImageObject">
   <li>ID: <%= post.id %></li>
   <li>Tagger: <%= link_to_user(post.keeper) %></li>
+  <% if CurrentUser.is_moderator? %>
+    <li>Uploader: <%= link_to_user(post.uploader) %></li>
+  <% end %>
   <li>
     Date: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -1,6 +1,6 @@
 <ul itemscope itemtype="http://schema.org/ImageObject">
   <li>ID: <%= post.id %></li>
-  <li>Uploader: <%= link_to_user(post.uploader) + "&nbsp;".html_safe + link_to("&raquo;".html_safe, posts_path(:tags => "user:#{post.uploader.name}"), :rel => "nofollow") %></li>
+  <li>Keeper: <%= link_to_user(post.keeper) %></li>
   <li>
     Date: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -1,6 +1,6 @@
 <ul itemscope itemtype="http://schema.org/ImageObject">
   <li>ID: <%= post.id %></li>
-  <li>Keeper: <%= link_to_user(post.keeper) %></li>
+  <li>Tagger: <%= link_to_user(post.keeper) %></li>
   <li>
     Date: <%= link_to time_ago_in_words_tagged(post.created_at), posts_path(:tags => "date:#{post.created_at.to_date}"), :rel => "nofollow" %>
     <meta itemprop="uploadDate" content="<%= post.created_at.iso8601 %>">

--- a/db/migrate/20180116001101_add_keeper_data_to_posts.rb
+++ b/db/migrate/20180116001101_add_keeper_data_to_posts.rb
@@ -1,0 +1,5 @@
+class AddKeeperDataToPosts < ActiveRecord::Migration
+  def change
+    add_column :posts, :keeper_data, :text
+  end
+end

--- a/test/models/post_keeper_manager_test.rb
+++ b/test/models/post_keeper_manager_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+class PostKeeperManagerTest < ActiveSupport::TestCase
+  subject { PostKeeperManager }
+
+  context "#check_and_update" do
+    setup do
+      Timecop.travel(1.month.ago) do
+        @system = FactoryGirl.create(:user)
+        User.stubs(:system).returns(@system)
+        @alice = FactoryGirl.create(:user)
+        @bob = FactoryGirl.create(:user)
+        @carol = FactoryGirl.create(:user)
+      end
+      PostArchive.sqs_service.stubs(:merge?).returns(false)
+
+      CurrentUser.scoped(@alice) do
+        @post = FactoryGirl.create(:post)
+      end
+      CurrentUser.scoped(@bob) do
+        Timecop.travel(2.hours.from_now) do
+          @post.update_attributes(tag_string: "aaa bbb ccc")
+        end
+      end
+      CurrentUser.scoped(@carol) do
+        Timecop.travel(4.hours.from_now) do
+          @post.update_attributes(tag_string: "ccc ddd eee fff ggg")
+        end
+      end
+    end
+
+    should "update the post" do
+      subject.check_and_update(@post.id)
+      @post.reload
+      assert_equal({"uid" => @carol.id}, @post.keeper_data)
+    end
+  end
+
+  context "#check" do
+    setup do
+      Timecop.travel(1.month.ago) do
+        @system = FactoryGirl.create(:user)
+        User.stubs(:system).returns(@system)
+        @alice = FactoryGirl.create(:user)
+        @bob = FactoryGirl.create(:user)
+        @carol = FactoryGirl.create(:user)
+      end
+
+      CurrentUser.scoped(@alice) do
+        @post = FactoryGirl.create(:post)
+      end
+    end
+
+    should "find the most frequent tagger for a post" do
+      assert_equal(@alice.id, subject.check(@post))
+    end
+
+    context "that is updated" do
+      setup do
+        CurrentUser.scoped(@bob) do
+          Timecop.travel(2.hours.from_now) do
+            @post.update_attributes(tag_string: "aaa bbb ccc")
+          end
+        end
+        CurrentUser.scoped(@carol) do
+          Timecop.travel(4.hours.from_now) do
+            @post.update_attributes(tag_string: "ccc ddd eee fff ggg")
+          end
+        end
+      end
+
+      should "find the most frequent tagger for a post" do
+        assert_equal(@carol.id, subject.check(@post))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hide uploader information (still visible in post history) and add a new field for keeper (most frequent tagger)