### PR TITLE
Fix the auto resize in desktop mode (ref: a95af95e)

### DIFF
--- a/app/assets/javascripts/posts.js
+++ b/app/assets/javascripts/posts.js
@@ -27,7 +27,7 @@
       this.initialize_replace_image_dialog();
       this.initialize_gestures();
 
-      if ((Danbooru.meta("always-resize-images") === "true") || ((Danbooru.Cookie.get("dm") !== "1") && (window.screen.width <= 660))) {
+      if ((Danbooru.meta("always-resize-images") === "true") || (Danbooru.meta("viewport") && (window.screen.width <= 660))) {
         $("#image-resize-to-window-link").click();
       }
     }


### PR DESCRIPTION
From the [Danbooru forum](http://danbooru.donmai.us/forum_posts/142755):

> Laethiel said:
> 
> On mobile (Android Chrome) but not on desktop (Windows 7, Firefox or Chrome), I'm having two issues.
> 
> 1. Images are automatically resized. I have to tap "Resize to window" to return them to full size. In settings, I have "Default image width" set to original and "Fit images to window" set to No.
> ......

This was caused by commit a95af95e when the **dm** cookie was removed.  It now uses the meta "viewport", which only gets set when ``disable_responsive_mode`` is true.