### PR TITLE
Clear results when a non-autocomplete metatag is used

### DIFF
--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -167,6 +167,7 @@
         <% TagCategory.short_name_list.each do |category| %>
           case "<%= category %>tags":
         <% end %>
+          resp([]);
           return;
 
         case "order":


### PR DESCRIPTION
From the [Danbooru forum](http://danbooru.donmai.us/forum_posts/142940):

> Laethiel said:
> 
> Enter is activating auto-complete, tested in both Firefox and Chrome. This is pretty awful, as, e.g., typing width:>3000 [Enter] just changes the search box contents to band-width instead of actually searching.

This is because nothing was being done with the **resp** object when a non-autocomplete metatag was being used, and instead [just returning from the function](https://github.com/r888888888/danbooru/blob/master/app/assets/javascripts/autocomplete.js.erb#L158-L177), which was causing the last autocomplete data to be used instead and therefore leading to incorrect results.

With this pull, when one of these metatags are used, it instead clears the results by returning a blank array with the **resp** object.  This causes the Tab/Return key to work as expected.