### PR TITLE
Autocomplete: Fix issues with Enter key

### DIFF
--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -53,20 +53,10 @@
         return false;
       },
       select: function(event, ui) {
-        var before_caret_text = this.value.substring(0, this.selectionStart).replace(/\S+$/, ui.item.value + " ");
-        var after_caret_text = this.value.substring(this.selectionStart);
-        this.value = before_caret_text;
+        Danbooru.Autocomplete.insert_completion(this, ui.item.value);
 
-        // Preserve original caret position to prevent it from jumping to the end
-        var original_start = this.selectionStart;
-        this.value += after_caret_text;
-        this.selectionStart = this.selectionEnd = original_start;
-
-        // Prevent the enter key from submitting the tag edit form (Danbooru.Upload.initialize_enter_on_tags).
-        event.stopImmediatePropagation();
         // Prevent the tab key from moving the focus to the next element.
         event.preventDefault();
-
         return false;
       },
       source: function(req, resp) {
@@ -115,16 +105,7 @@
           return false;
         }
 
-        var before_caret_text = this.value.substring(0, this.selectionStart);
-        var after_caret_text = this.value.substring(this.selectionStart);
-        var prefixes = "-|~|" + "<%= TagCategory.mapping.keys.map {|category| category + ':'}.join('|') %>";
-        var regexp = new RegExp("(" + prefixes + ")?\\S+$", "g");
-        this.value = before_caret_text.replace(regexp, "$1" + ui.item.value + " ");
-
-        // Preserve original caret position to prevent it from jumping to the end
-        var original_start = this.selectionStart;
-        this.value += after_caret_text;
-        this.selectionStart = this.selectionEnd = original_start;
+        Danbooru.Autocomplete.insert_completion(this, ui.item.value);
 
         event.stopImmediatePropagation();
         event.preventDefault();
@@ -279,6 +260,20 @@
     }
 
     return { metatag: metatag, term: term };
+  };
+
+  // Update the input field with the item currently focused in the
+  // autocomplete menu, then position the caret just after the inserted completion.
+  Danbooru.Autocomplete.insert_completion = function(input, completion) {
+    var before_caret_text = input.value.substring(0, input.selectionStart).trim();
+    var after_caret_text = input.value.substring(input.selectionStart).trim();
+
+    var prefixes = "-|~|" + "<%= TagCategory.mapping.keys.map {|category| category + ':'}.join('|') %>";
+    var regexp = new RegExp("(" + prefixes + ")?\\S+$", "g");
+    before_caret_text = before_caret_text.replace(regexp, "$1") + completion + " ";
+
+    input.value = before_caret_text + after_caret_text;
+    input.selectionStart = input.selectionEnd = before_caret_text.length;
   };
 
   Danbooru.Autocomplete.render_item = function(list, item) {

--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -45,18 +45,17 @@
 
   Danbooru.Autocomplete.initialize_mention_autocomplete = function() {
     var $fields = $(".autocomplete-mentions textarea");
+
+    $fields.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
     $fields.autocomplete({
       delay: 500,
       minLength: 2,
-      autoFocus: true,
+      autoFocus: false,
       focus: function() {
         return false;
       },
       select: function(event, ui) {
         Danbooru.Autocomplete.insert_completion(this, ui.item.value);
-
-        // Prevent the tab key from moving the focus to the next element.
-        event.preventDefault();
         return false;
       },
       source: function(req, resp) {
@@ -92,23 +91,21 @@
     var $fields_multiple = $('[data-autocomplete="tag-query"], [data-autocomplete="tag-edit"]');
     var $fields_single = $('[data-autocomplete="tag"]');
 
+    $fields_multiple.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
     $fields_multiple.autocomplete({
       delay: 100,
-      autoFocus: true,
+      autoFocus: false,
       focus: function() {
         return false;
       },
       select: function(event, ui) {
-        var query = Danbooru.Autocomplete.parse_query(this.value, this.selectionStart);
-        if (event.key === "Enter" && query.term === ui.item.value) {
-          $(this).parents("form").submit();
-          return false;
+        // Prevent Danbooru.Upload.initialize_enter_on_tags from running if the
+        // Enter key is used to select a tag from the autocomplete menu.
+        if (event.key === "Enter") {
+          event.stopImmediatePropagation();
         }
 
         Danbooru.Autocomplete.insert_completion(this, ui.item.value);
-
-        event.stopImmediatePropagation();
-        event.preventDefault();
         return false;
       },
       source: function(req, resp) {
@@ -274,6 +271,29 @@
 
     input.value = before_caret_text + after_caret_text;
     input.selectionStart = input.selectionEnd = before_caret_text.length;
+  };
+
+  // If we press tab while the autocomplete menu is open but nothing is
+  // focused, complete the first item and close the menu.
+  Danbooru.Autocomplete.on_tab = function(event) {
+    var input = this;
+    var autocomplete = $(input).autocomplete("instance");
+    var $autocomplete_menu = autocomplete.menu.element;
+
+    if (!$autocomplete_menu.is(":visible")) {
+      return;
+    }
+
+    if ($autocomplete_menu.has(".ui-state-focus").length === 0) {
+      var $first_item = $autocomplete_menu.find(".ui-menu-item").first();
+      var completion = $first_item.data().uiAutocompleteItem.value;
+
+      Danbooru.Autocomplete.insert_completion(input, completion);
+      autocomplete.close();
+    }
+
+    // Prevent the tab key from moving focus to the next element.
+    event.preventDefault();
   };
 
   Danbooru.Autocomplete.render_item = function(list, item) {


### PR DESCRIPTION
This is a better fix than #3546 for the problems with the Enter key during autocomplete. This fixes these issues:

* `abs<Enter>` inserts `absurdres` instead of searching for `abs`.
* `black_*<Enter>` inserts `black_hair` instead of searching for `black_*`.
* `rating:s<Enter>` inserts `rating:safe` instead of searching for `rating:s`.
* Pressing Enter while the cursor is in the middle of a tag behaves incorrectly (see [forum #142995](https://danbooru.donmai.us/forum_posts/142995)).

The root problem is enabling `autoFocus` on the autocomplete widget. Autofocus causes the first item in the autocomplete menu to be automatically selected when autocomplete opens. This interferes with the Enter key, since the Enter key inserts the selected item from the autocomplete menu. We only want that to happen when we explicitly use up/down to move into the autocomplete menu.

The fix is just to disable autofocus. The reason it was enabled was so you could use Tab to complete tags without having to press Down to select them in the menu first. So to make up for this, a handler for the Tab key is added that completes the tag as normal when nothing is selected in the menu.

The net result is that Tab and Enter work as they normally do, and using Enter to select tags from the autocomplete menu works as it should.