### PR TITLE
Fix #3528: Add method to prevent image-hosting CloudFlare sites from altering the image

### DIFF
--- a/app/logical/downloads/file.rb
+++ b/app/logical/downloads/file.rb
@@ -36,7 +36,7 @@ module Downloads
       url, headers, @data = before_download(@source, @data)
 
       ::File.open(@file_path, "wb") do |out|
-        http_get_streaming(url, headers) do |response|
+        http_get_streaming(uncached_url(url), headers) do |response|
           out.write(response)
         end
       end
@@ -53,6 +53,13 @@ module Downloads
       end
 
       return [url, headers, datums]
+    end
+
+    # Prevent transparent proxies (namely Cloudflare) from potentially mangling the image. See issue #3528.
+    def uncached_url(url)
+      url = Addressable::URI.parse(url)
+      url.query_values = (url.query_values || {}).merge(danbooru_no_cache: SecureRandom.uuid)
+      url
     end
 
     def after_download(src)

--- a/test/unit/downloads/art_station_test.rb
+++ b/test/unit/downloads/art_station_test.rb
@@ -28,6 +28,13 @@ module Downloads
       end
     end
 
+    context "a download for an ArtStation image hosted on CloudFlare" do
+      should "return the original file, not the polished file" do
+        @source = "https://cdnb.artstation.com/p/assets/images/images/003/716/071/large/aoi-ogata-hate-city.jpg?1476754974"
+        assert_downloaded(517_706, @source) # polished size: 502_052
+      end
+    end
+
     context "a download for a https://$artist.artstation.com/projects/$id page" do
       setup do
         @source = "https://dantewontdie.artstation.com/projects/YZK5q"


### PR DESCRIPTION
Fixes #3528. Adds a random URL param when downloading files to bypass any transparent caches that may  potentially alter the file.