### PR TITLE
#3554: Allow admins to edit BUR forum topic/post ids

### DIFF
--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -5,12 +5,12 @@ class BulkUpdateRequestsController < ApplicationController
   before_filter :load_bulk_update_request, :except => [:new, :create, :index]
 
   def new
-    @bulk_update_request = BulkUpdateRequest.new(:user_id => CurrentUser.user.id)
+    @bulk_update_request = BulkUpdateRequest.new
     respond_with(@bulk_update_request)
   end
 
   def create
-    @bulk_update_request = BulkUpdateRequest.create(params[:bulk_update_request])
+    @bulk_update_request = BulkUpdateRequest.create(bur_params(:create))
     respond_with(@bulk_update_request, :location => bulk_update_requests_path)
   end
 
@@ -23,7 +23,7 @@ class BulkUpdateRequestsController < ApplicationController
 
   def update
     if @bulk_update_request.editable?(CurrentUser.user)
-      @bulk_update_request.update_attributes(params[:bulk_update_request])
+      @bulk_update_request.update(bur_params(:update))
       flash[:notice] = "Bulk update request updated"
       respond_with(@bulk_update_request, :location => bulk_update_requests_path)
     else
@@ -55,5 +55,12 @@ class BulkUpdateRequestsController < ApplicationController
 
   def load_bulk_update_request
     @bulk_update_request = BulkUpdateRequest.find(params[:id])
+  end
+
+  def bur_params(context)
+    permitted_params = %i[script skip_secondary_validations]
+    permitted_params += %i[title reason forum_topic_id] if context == :create
+
+    params.require(:bulk_update_request).permit(permitted_params)
   end
 end

--- a/app/controllers/bulk_update_requests_controller.rb
+++ b/app/controllers/bulk_update_requests_controller.rb
@@ -60,6 +60,7 @@ class BulkUpdateRequestsController < ApplicationController
   def bur_params(context)
     permitted_params = %i[script skip_secondary_validations]
     permitted_params += %i[title reason forum_topic_id] if context == :create
+    permitted_params += %i[forum_topic_id forum_post_id] if context == :update && CurrentUser.is_admin?
 
     params.require(:bulk_update_request).permit(permitted_params)
   end

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -13,8 +13,6 @@ class BulkUpdateRequest < ApplicationRecord
   validate :script_formatted_correctly
   validate :forum_topic_id_not_invalid
   validate :validate_script, :on => :create
-  attr_accessible :user_id, :forum_topic_id, :forum_post_id, :script, :title, :reason, :skip_secondary_validations
-  attr_accessible :status, :approver_id, :as => [:admin]
   before_validation :initialize_attributes, :on => :create
   before_validation :normalize_text
   after_create :create_forum_topic
@@ -94,7 +92,7 @@ class BulkUpdateRequest < ApplicationRecord
     def approve!(approver)
       CurrentUser.scoped(approver) do
         AliasAndImplicationImporter.new(script, forum_topic_id, "1", true).process!
-        update({ :status => "approved", :approver_id => CurrentUser.id, :skip_secondary_validations => true }, :as => CurrentUser.role)
+        update(status: "approved", approver: CurrentUser.user, skip_secondary_validations: true)
         forum_updater.update("The #{bulk_update_request_link} (forum ##{forum_post.id}) has been approved by @#{approver.name}.", "APPROVED")
       end
 

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -1,7 +1,9 @@
 <%= simple_form_for(@bulk_update_request) do |f| %>
   <%= error_messages_for("bulk_update_request") %>
 
-  <%= f.input :title, :as => :string %>
+  <% if @bulk_update_request.new_record? %>
+    <%= f.input :title, :as => :string %>
+  <% end %>
 
   <div class="input">
     <label class="text optional" for="bulk_update_request_script">Script</label>
@@ -17,9 +19,11 @@ category tag_name -> category_name
     <%= text_area :bulk_update_request, :script, :size => "50x10" %>
   </div>
 
-  <div class="input">
-    <%= dtext_field "bulk_update_request", "reason", :name => "Reason" %>
-  </div>
+  <% if @bulk_update_request.new_record? %>
+    <div class="input">
+      <%= dtext_field "bulk_update_request", "reason", :name => "Reason" %>
+    </div>
+  <% end %>
 
   <% if @bulk_update_request.errors.any? %>
     <div class="input">
@@ -31,7 +35,9 @@ category tag_name -> category_name
     </div>
   <% end %>
 
-  <%= f.input :forum_topic_id, :hint => " (optional)" %>
+  <% if @bulk_update_request.new_record? %>
+    <%= f.input :forum_topic_id, :hint => " (optional)" %>
+  <% end %>
   <%= f.button :submit, :value => "Submit", :data => { :disable_with => "Submitting..." } %>
   <%= dtext_preview_button "bulk_update_request", "reason" %>
 <% end %>

--- a/app/views/bulk_update_requests/_form.html.erb
+++ b/app/views/bulk_update_requests/_form.html.erb
@@ -37,7 +37,11 @@ category tag_name -> category_name
 
   <% if @bulk_update_request.new_record? %>
     <%= f.input :forum_topic_id, :hint => " (optional)" %>
+  <% elsif @bulk_update_request.persisted? && CurrentUser.is_admin? %>
+    <%= f.input :forum_topic_id %>
+    <%= f.input :forum_post_id %>
   <% end %>
+
   <%= f.button :submit, :value => "Submit", :data => { :disable_with => "Submitting..." } %>
   <%= dtext_preview_button "bulk_update_request", "reason" %>
 <% end %>


### PR DESCRIPTION
Partial fix for #3554. Allows admins to edit a BUR's forum post id, so that BURs with a nil `forum_post_id` can be corrected before approval / rejection. This does take extra work, but in the long run I think it's better to fix the missing data than to work around it.