### PR TITLE
Fix inconsistencies in autocomplete behavior

### DIFF
--- a/app/assets/javascripts/artists.js
+++ b/app/assets/javascripts/artists.js
@@ -5,10 +5,6 @@
     if ($("#c-artists").length) {
       Danbooru.Artist.initialize_check_name();
       Danbooru.Artist.initialize_shortcuts();
-
-      if (Danbooru.meta("enable-auto-complete") === "true") {
-        Danbooru.Artist.initialize_autocomplete();
-      }
     }
   }
 
@@ -43,45 +39,7 @@
       });
     }
   };
-
-  Danbooru.Artist.initialize_autocomplete = function() {
-    var $fields = $("#search_name,#quick_search_name");
-
-    $fields.autocomplete({
-      minLength: 1,
-      source: function(req, resp) {
-        $.ajax({
-          url: "/artists.json",
-          data: {
-            "search[name]": req.term + "*",
-            "search[is_active]": true,
-            "search[order]": "post_count",
-            "limit": 10
-          },
-          method: "get",
-          success: function(data) {
-            resp($.map(data, function(artist) {
-              return {
-                label: artist.name.replace(/_/g, " "),
-                value: artist.name
-              };
-            }));
-          }
-        });
-      }
-    });
-
-    var render_artist = function(list, artist) {
-      var $link = $("<a/>").addClass("tag-type-1").text(artist.label);
-      return $("<li/>").data("item.autocomplete", artist).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_artist;
-    });
-  }
 })();
-
 
 $(document).ready(function() {
   Danbooru.Artist.initialize_all();

--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -12,6 +12,16 @@
   Danbooru.Autocomplete.initialize_all = function() {
     if (Danbooru.meta("enable-auto-complete") === "true") {
       $.widget("ui.autocomplete", $.ui.autocomplete, {
+        options: {
+          delay: 100,
+          minLength: 1,
+          autoFocus: false,
+          focus: function() { return false; },
+        },
+        _create: function() {
+          this.element.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
+          this._super();
+        },
         _renderItem: Danbooru.Autocomplete.render_item,
       });
 
@@ -51,14 +61,7 @@
   }
 
   Danbooru.Autocomplete.initialize_mention_autocomplete = function($fields) {
-    $fields.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
     $fields.autocomplete({
-      delay: 500,
-      minLength: 2,
-      autoFocus: false,
-      focus: function() {
-        return false;
-      },
       select: function(event, ui) {
         Danbooru.Autocomplete.insert_completion(this, ui.item.value);
         return false;
@@ -96,13 +99,7 @@
     var $fields_multiple = $('[data-autocomplete="tag-query"], [data-autocomplete="tag-edit"]');
     var $fields_single = $('[data-autocomplete="tag"]');
 
-    $fields_multiple.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
     $fields_multiple.autocomplete({
-      delay: 100,
-      autoFocus: false,
-      focus: function() {
-        return false;
-      },
       select: function(event, ui) {
         // Prevent Danbooru.Upload.initialize_enter_on_tags from running if the
         // Enter key is used to select a tag from the autocomplete menu.
@@ -187,8 +184,6 @@
     });
 
     $fields_single.autocomplete({
-      minLength: 1,
-      autoFocus: true,
       source: function(req, resp) {
         Danbooru.Autocomplete.normal_source(req.term, resp);
       }
@@ -197,7 +192,6 @@
 
   Danbooru.Autocomplete.initialize_artist_autocomplete = function($fields) {
     $fields.autocomplete({
-      minLength: 1,
       source: function(req, resp) {
         $.ajax({
           url: "/artists.json",
@@ -225,7 +219,6 @@
 
   Danbooru.Autocomplete.initialize_pool_autocomplete = function($fields) {
     $fields.autocomplete({
-      minLength: 1,
       source: function(req, resp) {
         Danbooru.Autocomplete.pool_source(req.term, resp);
       },
@@ -234,7 +227,6 @@
 
   Danbooru.Autocomplete.initialize_wiki_autocomplete = function($fields) {
     $fields.autocomplete({
-      minLength: 1,
       source: function(req, resp) {
         $.ajax({
           url: "/wiki_pages.json",

--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -11,6 +11,10 @@
 
   Danbooru.Autocomplete.initialize_all = function() {
     if (Danbooru.meta("enable-auto-complete") === "true") {
+      $.widget("ui.autocomplete", $.ui.autocomplete, {
+        _renderItem: Danbooru.Autocomplete.render_item,
+      });
+
       Danbooru.Autocomplete.enable_local_storage = this.test_local_storage();
       this.initialize_tag_autocomplete();
       this.initialize_mention_autocomplete($(".autocomplete-mentions textarea"));
@@ -189,10 +193,6 @@
         Danbooru.Autocomplete.normal_source(req.term, resp);
       }
     });
-
-    $.merge($fields_multiple, $fields_single).each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = Danbooru.Autocomplete.render_item;
-    });
   }
 
   Danbooru.Autocomplete.initialize_artist_autocomplete = function($fields) {
@@ -211,22 +211,15 @@
           success: function(data) {
             resp($.map(data, function(artist) {
               return {
+                type: "tag",
                 label: artist.name.replace(/_/g, " "),
-                value: artist.name
+                value: artist.name,
+                category: <%= Tag.categories.artist %>,
               };
             }));
           }
         });
       }
-    });
-
-    var render_artist = function(list, artist) {
-      var $link = $("<a/>").addClass("tag-type-1").text(artist.label);
-      return $("<li/>").data("item.autocomplete", artist).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_artist;
     });
   };
 
@@ -234,33 +227,8 @@
     $fields.autocomplete({
       minLength: 1,
       source: function(req, resp) {
-        $.ajax({
-          url: "/pools.json",
-          data: {
-            "search[name_matches]": req.term,
-            "limit": 10
-          },
-          method: "get",
-          success: function(data) {
-            resp($.map(data, function(pool) {
-              return {
-                label: pool.name.replace(/_/g, " "),
-                value: pool.name,
-                category: pool.category
-              };
-            }));
-          }
-        });
-      }
-    });
-
-    var render_pool = function(list, pool) {
-      var $link = $("<a/>").addClass("pool-category-" + pool.category).text(pool.label);
-      return $("<li/>").data("item.autocomplete", pool).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_pool;
+        Danbooru.Autocomplete.pool_source(req.term, resp);
+      },
     });
   };
 
@@ -280,6 +248,7 @@
           success: function(data) {
             resp($.map(data, function(wiki_page) {
               return {
+                type: "tag",
                 label: wiki_page.title.replace(/_/g, " "),
                 value: wiki_page.title,
                 category: wiki_page.category_name
@@ -288,15 +257,6 @@
           }
         });
       }
-    });
-
-    var render_wiki_page = function(list, wiki_page) {
-      var $link = $("<a/>").addClass("tag-type-" + wiki_page.category).text(wiki_page.label);
-      return $("<li/>").data("item.autocomplete", wiki_page).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_wiki_page;
     });
   };
 
@@ -545,7 +505,7 @@
           return {
             type: "pool",
             label: pool.name.replace(/_/g, " "),
-            value: metatag + ":" + pool.name,
+            value: (metatag ? (metatag + ":" + pool.name) : pool.name),
             post_count: pool.post_count,
             category: pool.category
           };

--- a/app/assets/javascripts/autocomplete.js.erb
+++ b/app/assets/javascripts/autocomplete.js.erb
@@ -13,7 +13,10 @@
     if (Danbooru.meta("enable-auto-complete") === "true") {
       Danbooru.Autocomplete.enable_local_storage = this.test_local_storage();
       this.initialize_tag_autocomplete();
-      this.initialize_mention_autocomplete();
+      this.initialize_mention_autocomplete($(".autocomplete-mentions textarea"));
+      this.initialize_artist_autocomplete($('[data-autocomplete="artist"]'));
+      this.initialize_pool_autocomplete($('[data-autocomplete="pool"]'));
+      this.initialize_wiki_autocomplete($('[data-autocomplete="wiki-page"]'));
       this.prune_local_storage();
     }
   }
@@ -43,9 +46,7 @@
     }
   }
 
-  Danbooru.Autocomplete.initialize_mention_autocomplete = function() {
-    var $fields = $(".autocomplete-mentions textarea");
-
+  Danbooru.Autocomplete.initialize_mention_autocomplete = function($fields) {
     $fields.on("keydown.danbooru.autocomplete.tab", null, "tab", Danbooru.Autocomplete.on_tab);
     $fields.autocomplete({
       delay: 500,
@@ -193,6 +194,111 @@
       $(field).data("uiAutocomplete")._renderItem = Danbooru.Autocomplete.render_item;
     });
   }
+
+  Danbooru.Autocomplete.initialize_artist_autocomplete = function($fields) {
+    $fields.autocomplete({
+      minLength: 1,
+      source: function(req, resp) {
+        $.ajax({
+          url: "/artists.json",
+          data: {
+            "search[name]": req.term + "*",
+            "search[is_active]": true,
+            "search[order]": "post_count",
+            "limit": 10
+          },
+          method: "get",
+          success: function(data) {
+            resp($.map(data, function(artist) {
+              return {
+                label: artist.name.replace(/_/g, " "),
+                value: artist.name
+              };
+            }));
+          }
+        });
+      }
+    });
+
+    var render_artist = function(list, artist) {
+      var $link = $("<a/>").addClass("tag-type-1").text(artist.label);
+      return $("<li/>").data("item.autocomplete", artist).append($link).appendTo(list);
+    };
+
+    $fields.each(function(i, field) {
+      $(field).data("uiAutocomplete")._renderItem = render_artist;
+    });
+  };
+
+  Danbooru.Autocomplete.initialize_pool_autocomplete = function($fields) {
+    $fields.autocomplete({
+      minLength: 1,
+      source: function(req, resp) {
+        $.ajax({
+          url: "/pools.json",
+          data: {
+            "search[name_matches]": req.term,
+            "limit": 10
+          },
+          method: "get",
+          success: function(data) {
+            resp($.map(data, function(pool) {
+              return {
+                label: pool.name.replace(/_/g, " "),
+                value: pool.name,
+                category: pool.category
+              };
+            }));
+          }
+        });
+      }
+    });
+
+    var render_pool = function(list, pool) {
+      var $link = $("<a/>").addClass("pool-category-" + pool.category).text(pool.label);
+      return $("<li/>").data("item.autocomplete", pool).append($link).appendTo(list);
+    };
+
+    $fields.each(function(i, field) {
+      $(field).data("uiAutocomplete")._renderItem = render_pool;
+    });
+  };
+
+  Danbooru.Autocomplete.initialize_wiki_autocomplete = function($fields) {
+    $fields.autocomplete({
+      minLength: 1,
+      source: function(req, resp) {
+        $.ajax({
+          url: "/wiki_pages.json",
+          data: {
+            "search[title]": req.term + "*",
+            "search[hide_deleted]": "Yes",
+            "search[order]": "post_count",
+            "limit": 10
+          },
+          method: "get",
+          success: function(data) {
+            resp($.map(data, function(wiki_page) {
+              return {
+                label: wiki_page.title.replace(/_/g, " "),
+                value: wiki_page.title,
+                category: wiki_page.category_name
+              };
+            }));
+          }
+        });
+      }
+    });
+
+    var render_wiki_page = function(list, wiki_page) {
+      var $link = $("<a/>").addClass("tag-type-" + wiki_page.category).text(wiki_page.label);
+      return $("<li/>").data("item.autocomplete", wiki_page).append($link).appendTo(list);
+    };
+
+    $fields.each(function(i, field) {
+      $(field).data("uiAutocomplete")._renderItem = render_wiki_page;
+    });
+  };
 
   Danbooru.Autocomplete.normal_source = function(term, resp) {
     var key = "ac-" + term.replace(/\./g,'\uFFFF');

--- a/app/assets/javascripts/pools.js
+++ b/app/assets/javascripts/pools.js
@@ -4,9 +4,6 @@
   Danbooru.Pool.initialize_all = function() {
     if ($("#c-pools").length) {
       this.initialize_shortcuts();
-      if (Danbooru.meta("enable-auto-complete") === "true") {
-        this.initialize_autocomplete_for("#search_name_matches,#quick_search_name_matches");
-      }
     }
 
     if ($("#c-posts").length && $("#a-show").length) {
@@ -18,46 +15,8 @@
     }
   }
 
-  Danbooru.Pool.initialize_autocomplete_for = function(selector) {
-    var $fields = $(selector);
-
-    $fields.autocomplete({
-      minLength: 1,
-      source: function(req, resp) {
-        $.ajax({
-          url: "/pools.json",
-          data: {
-            "search[name_matches]": req.term,
-            "limit": 10
-          },
-          method: "get",
-          success: function(data) {
-            resp($.map(data, function(pool) {
-              return {
-                label: pool.name.replace(/_/g, " "),
-                value: pool.name,
-                category: pool.category
-              };
-            }));
-          }
-        });
-      }
-    });
-
-    var render_pool = function(list, pool) {
-      var $link = $("<a/>").addClass("pool-category-" + pool.category).text(pool.label);
-      return $("<li/>").data("item.autocomplete", pool).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_pool;
-    });
-  }
-
   Danbooru.Pool.initialize_add_to_pool_link = function() {
     $("#add-to-pool-dialog").dialog({autoOpen: false});
-
-    this.initialize_autocomplete_for("#add-to-pool-dialog input[type=text]");
 
     $("#pool").click(function(e) {
       e.preventDefault();

--- a/app/assets/javascripts/wiki_pages.js
+++ b/app/assets/javascripts/wiki_pages.js
@@ -3,50 +3,8 @@
 
   Danbooru.WikiPage.initialize_all = function() {
     if ($("#c-wiki-pages,#c-wiki-page-versions").length) {
-      if (Danbooru.meta("enable-auto-complete") === "true") {
-        this.initialize_autocomplete();
-      }
-
       this.initialize_shortcuts();
     }
-  }
-
-  Danbooru.WikiPage.initialize_autocomplete = function() {
-    var $fields = $("#search_title,#quick_search_title");
-
-    $fields.autocomplete({
-      minLength: 1,
-      source: function(req, resp) {
-        $.ajax({
-          url: "/wiki_pages.json",
-          data: {
-            "search[title]": req.term + "*",
-            "search[hide_deleted]": "Yes",
-            "search[order]": "post_count",
-            "limit": 10
-          },
-          method: "get",
-          success: function(data) {
-            resp($.map(data, function(wiki_page) {
-              return {
-                label: wiki_page.title.replace(/_/g, " "),
-                value: wiki_page.title,
-                category: wiki_page.category_name
-              };
-            }));
-          }
-        });
-      }
-    });
-
-    var render_wiki_page = function(list, wiki_page) {
-      var $link = $("<a/>").addClass("tag-type-" + wiki_page.category).text(wiki_page.label);
-      return $("<li/>").data("item.autocomplete", wiki_page).append($link).appendTo(list);
-    };
-
-    $fields.each(function(i, field) {
-      $(field).data("uiAutocomplete")._renderItem = render_wiki_page;
-    });
   }
 
   Danbooru.WikiPage.initialize_shortcuts = function() {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -163,14 +163,14 @@ module ApplicationHelper
     submit_tag("Preview", "data-input-id" => options[:input_id], "data-preview-id" => options[:preview_id])
   end
 
-  def search_field(method, options = {})
-    name = options[:label] || method.titleize
-    string = '<div class="input"><label for="search_' + method + '">' + name + '</label><input type="text" name="search[' + method + ']" id="search_'  + method + '">'
-    if options[:hint]
-      string += '<p class="hint">' + options[:hint] + '</p>'
+  def search_field(method, label: method.titleize, hint: nil, value: nil, **attributes)
+    content_tag(:div, class: "input") do
+      label_html = label_tag("search_#{method}", label)
+      input_html = text_field_tag(method, value, id: "search_#{method}", name: "search[#{method}]", **attributes)
+      hint_html = hint.present? ? content_tag(:p, hint, class: "hint") : ""
+
+      label_html + input_html + hint_html
     end
-    string += '</div>'
-    string.html_safe
   end
 
   def body_attributes(user = CurrentUser.user)

--- a/app/views/artist_versions/search.html.erb
+++ b/app/views/artist_versions/search.html.erb
@@ -5,7 +5,7 @@
     <div id="search">
       <%= form_tag(artist_versions_path, :method => :get, :class => "simple_form") do %>
         <%= search_field "updater_name", :label => "User" %>
-        <%= search_field "name", :label => "Name" %>
+        <%= search_field "name", :label => "Name", :data => { autocomplete: "artist" } %>
         <%= submit_tag "Search" %>
       <% end %>
     </div>

--- a/app/views/artists/_quick_search.html.erb
+++ b/app/views/artists/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(artists_path, :method => :get) do %>
-  <%= text_field "search", "name", :id => "quick_search_name", :placeholder => "Search artists" %>
+  <%= text_field "search", "name", id: "quick_search_name", placeholder: "Search artists", data: { autocomplete: "artist" } %>
 <% end %>

--- a/app/views/artists/_search.html.erb
+++ b/app/views/artists/_search.html.erb
@@ -1,5 +1,5 @@
 <%= simple_form_for(:search, url: artists_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
-  <%= f.input :name, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name] } %>
+  <%= f.input :name, label: "Name", hint: "Use * for wildcard", input_html: { value: params[:search][:name], data: { autocomplete: "artist" }} %>
   <%= f.input :url_matches, label: "URL", as: "string", input_html: { value: params[:search][:url_matches] } %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
   <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_active] %>

--- a/app/views/pool_elements/_new.html.erb
+++ b/app/views/pool_elements/_new.html.erb
@@ -3,7 +3,7 @@
 
   <div class="input">
     <label>Pool Name</label>
-    <span id="pool-name-container"><%= text_field_tag "pool_name", "", :size => 20 %></span>
+    <span id="pool-name-container"><%= text_field_tag "pool_name", "", :size => 20, :data => { autocomplete: "pool" } %></span>
     <span id="pool-name-hint" class="hint">Search for a pool containing (<%= link_to "see full list", all_select_pool_element_path, :remote => true %>)</span>
   </div>
 

--- a/app/views/pools/_quick_search.html.erb
+++ b/app/views/pools/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(pools_path, :method => :get) do %>
-  <%= text_field "search", "name_matches", :id => "quick_search_name_matches", :placeholder => "Search pools" %>
+  <%= text_field "search", "name_matches", id: "quick_search_name_matches", placeholder: "Search pools", data: { autocomplete: "pool" } %>
 <% end %>

--- a/app/views/pools/_search.html.erb
+++ b/app/views/pools/_search.html.erb
@@ -5,7 +5,7 @@
         <th><label for="search_name_matches">Name</label></th>
         <td>
           <div class="input">
-            <%= text_field "search", "name_matches", :value => params[:search][:name_matches] %>
+            <%= text_field "search", "name_matches", :value => params[:search][:name_matches], :data => { autocomplete: "pool" } %>
           </div>
         </td>
       </tr>

--- a/app/views/wiki_pages/_quick_search.html.erb
+++ b/app/views/wiki_pages/_quick_search.html.erb
@@ -1,3 +1,3 @@
 <%= form_tag(wiki_pages_path, :method => :get) do %>
-  <%= text_field "search", "title", :id => "quick_search_title", :placeholder => "Search wiki pages" %>
+  <%= text_field "search", "title", id: "quick_search_title", placeholder: "Search wiki pages", data: { autocomplete: "wiki-page" } %>
 <% end %>

--- a/app/views/wiki_pages/search.html.erb
+++ b/app/views/wiki_pages/search.html.erb
@@ -1,7 +1,7 @@
 <div id="c-wiki-pages">
   <div id="a-search">
     <%= form_tag(wiki_pages_path, :method => :get, :class => "simple_form") do %>
-      <%= search_field "title", :hint => "Use * for wildcard searches" %>
+      <%= search_field "title", :hint => "Use * for wildcard searches", :data => { :autocomplete => "wiki-page" } %>
       <%= search_field "creator_name" %>
       <%= search_field "body_matches", :label => "Body" %>
       <%= search_field "other_names_match", :label => "Other names", :hint => "Use * for wildcard searches" %>


### PR DESCRIPTION
This cleans up autocomplete to reduce some duplicated code. In doing so, it fixes several minor bugs and makes autocomplete behave more consistently sitewide:

* Moves the artist/pool/wiki autocomplete code to `autocomplete.js`, with all the rest of the autocomplete code.

* Marks autocompleted fields with `data-autocomplete="<type>"` attributes, instead of hardcoding the field IDs in Javascript.

* Uses `Danbooru.Autocomplete.render_item` to render all autocomplete menus. This fixes usernames not being colorized when completing mentions, and post counts not being shown when completing pools on the `/pools` page.

* Sets default options on the autocomplete widget so that autocomplete behaves consistently everywhere:

    1. Disables `autoFocus` everywhere (previously it was enabled on `/tags`, but not elsewhere).
    2. Sets the completion delay to 100ms everywhere (previously it either 100ms, 300ms, or 500ms).
    3. Makes the up/down keys not insert menu items immediately as you move through the autocomplete menu (see #3547; previously it did this on `/artists`, `/tags`, `/pools` but not elsewhere).