### PR TITLE
Revert "Fix #3528: Add method to prevent image-hosting CloudFlare sites from altering the image"

### DIFF
--- a/test/unit/downloads/art_station_test.rb
+++ b/test/unit/downloads/art_station_test.rb
@@ -28,13 +28,6 @@ module Downloads
       end
     end
 
-    context "a download for an ArtStation image hosted on CloudFlare" do
-      should "return the original file, not the polished file" do
-        @source = "https://cdnb.artstation.com/p/assets/images/images/003/716/071/large/aoi-ogata-hate-city.jpg?1476754974"
-        assert_downloaded(517_706, @source) # polished size: 502_052
-      end
-    end
-
     context "a download for a https://$artist.artstation.com/projects/$id page" do
       setup do
         @source = "https://dantewontdie.artstation.com/projects/YZK5q"


### PR DESCRIPTION
Reverts r888888888/danbooru#3551