### PR TITLE
Fix #3552: Upload filesize limits can be bypassed

### DIFF
--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -187,7 +187,8 @@ module Danbooru
       1_000
     end
 
-    # Maximum size of an upload.
+    # Maximum size of an upload. If you change this, you must also change
+    # `client_max_body_size` in your nginx.conf.
     def max_file_size
       35.megabytes
     end

--- a/script/install/nginx.danbooru.conf
+++ b/script/install/nginx.danbooru.conf
@@ -7,7 +7,7 @@ server {
   index index.html;
   access_log /var/log/nginx/danbooru.access.log;
   error_log /var/log/nginx/danbooru.error.log;
-  client_max_body_size 30m;
+  client_max_body_size 35m;
   location /stylesheets {
     expires max;
     break;

--- a/test/unit/downloads/file_test.rb
+++ b/test/unit/downloads/file_test.rb
@@ -37,21 +37,14 @@ module Downloads
 
         should "retry three times" do
           assert_raises(Errno::ETIMEDOUT) do
-            @download.http_get_streaming(@source) {}
+            @download.http_get_streaming(@source, @tempfile)
           end
-        end
-      end
-
-      should "stream a file from an HTTP source" do
-        @download.http_get_streaming(@source) do |resp|
-          assert(resp.size > 0)
         end
       end
 
       should "throw an exception when the file is larger than the maximum" do
         assert_raise(Downloads::File::Error) do
-          @download.http_get_streaming(@source, {}, :max_size => 1) do |resp|
-          end
+          @download.http_get_streaming(@source, @tempfile, {}, max_size: 1)
         end
       end
 
@@ -60,29 +53,6 @@ module Downloads
         assert_equal(@source, @download.source)
         assert(::File.exists?(@tempfile.path), "temp file should exist")
         assert(::File.size(@tempfile.path) > 0, "should have data")
-      end
-
-      should "initialize the content type" do
-        @download.download!
-        assert_match(/image\/gif/, @download.content_type)
-      end
-    end
-
-    context "A post download with an HTTPS source" do
-      setup do
-        @source = "https://www.google.com/intl/en_ALL/images/logo.gif"
-        @tempfile = Tempfile.new("danbooru-test")
-        @download = Downloads::File.new(@source, @tempfile.path)
-      end
-
-      teardown do
-        @tempfile.close
-      end
-
-      should "stream a file from an HTTPS source" do
-        @download.http_get_streaming(@source) do |resp|
-          assert(resp.size > 0)
-        end
       end
     end
   end


### PR DESCRIPTION
Fixes #3552. Also fixes the max POST data limit in Nginx being lower than the max upload limit in the Danbooru config. This meant that files uploaded from your computer were limited to 30Mb instead of 35Mb.