### PR TITLE
Add limits on max dimensions of uploads

### DIFF
--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -66,6 +66,18 @@ class Upload < ApplicationRecord
       end
     end
 
+    def validate_dimensions
+      resolution = image_width * image_height
+
+      if resolution > Danbooru.config.max_image_resolution
+        raise "image resolution is too large (resolution: #{(resolution / 1_000_000.0).round(1)} megapixels (#{image_width}x#{image_height}); max: #{Danbooru.config.max_image_resolution / 1_000_000} megapixels)"
+      elsif image_width > Danbooru.config.max_image_width
+        raise "image width is too large (width: #{image_width}; max width: #{Danbooru.config.max_image_width})"
+      elsif image_height > Danbooru.config.max_image_height
+        raise "image height is too large (height: #{image_height}; max height: #{Danbooru.config.max_image_height})"
+      end
+    end
+
     def rating_given
       if rating.present?
         return true
@@ -120,6 +132,7 @@ class Upload < ApplicationRecord
 
         self.tag_string = "#{tag_string} #{automatic_tags}"
         self.image_width, self.image_height = calculate_dimensions
+        validate_dimensions
 
         save
       end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -179,6 +179,21 @@ module Danbooru
       35.megabytes
     end
 
+    # Maximum resolution (width * height) of an upload. Default: 441 megapixels (21000x21000 pixels).
+    def max_image_resolution
+      21000 * 21000
+    end
+
+    # Maximum width of an upload.
+    def max_image_width
+      40000
+    end
+
+    # Maximum height of an upload.
+    def max_image_height
+      40000
+    end
+
     def member_comment_time_threshold
       1.week.ago
     end

--- a/test/unit/upload_test.rb
+++ b/test/unit/upload_test.rb
@@ -212,6 +212,15 @@ class UploadTest < ActiveSupport::TestCase
           assert_equal("", @upload.automatic_tags)
         end
       end
+
+      context "that is too large" do
+        should "should fail validation" do
+          Danbooru.config.stubs(:max_image_resolution).returns(31*31)
+          @upload = FactoryGirl.create(:upload, file: upload_file("test/files/test-static-32x32.gif"))
+          @upload.process!
+          assert_match(/image resolution is too large/, @upload.status)
+        end
+      end
     end
 
     should "process completely for a pixiv ugoira" do


### PR DESCRIPTION
Related to #3570. Adds these limits to uploads:

* Max image width: 40000
* Max image height: 40000
* Max image resolution (width * height): 441 megapixels (equivalent to a 21000x21000 image)

These values were chosen to be slightly bigger than the current biggest images on the site. [post #442772](https://danbooru.donmai.us/posts/442772) is the tallest at 500x39401 and [post #2889454](https://danbooru.donmai.us/posts/2889454) is the highest resolution at 408 megapixels (16918x24138).

These limits are to prevent a DoS attack on the image resizer. Excessively large images can require hundreds of gigabytes of memory to resize. See [here](https://www.bamsoftware.com/hacks/deflate.html) for an example of a 6MB, 225000x225000 PNG file that would take 141GB of memory to decompress and resize.
