### PR TITLE
Fix #3583: Copying notes should also change meta tags in the destination post 

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1415,29 +1415,31 @@ class Post < ApplicationRecord
     end
 
     def copy_notes_to(other_post)
-      if id == other_post.id
-        errors.add :base, "Source and destination posts are the same"
-        return false
-      end
-      unless has_notes?
-        errors.add :post, "has no notes"
-        return false
-      end
+      transaction do
+        if id == other_post.id
+          errors.add :base, "Source and destination posts are the same"
+          return false
+        end
+        unless has_notes?
+          errors.add :post, "has no notes"
+          return false
+        end
 
-      notes.active.each do |note|
-        note.copy_to(other_post)
-      end
+        notes.active.each do |note|
+          note.copy_to(other_post)
+        end
 
-      dummy = Note.new
-      if notes.active.length == 1
-        dummy.body = "Copied 1 note from post ##{id}."
-      else
-        dummy.body = "Copied #{notes.active.length} notes from post ##{id}."
+        dummy = Note.new
+        if notes.active.length == 1
+          dummy.body = "Copied 1 note from post ##{id}."
+        else
+          dummy.body = "Copied #{notes.active.length} notes from post ##{id}."
+        end
+        dummy.is_active = false
+        dummy.post_id = other_post.id
+        dummy.x = dummy.y = dummy.width = dummy.height = 0
+        dummy.save
       end
-      dummy.is_active = false
-      dummy.post_id = other_post.id
-      dummy.x = dummy.y = dummy.width = dummy.height = 0
-      dummy.save
     end
   end
 

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2663,6 +2663,32 @@ class PostTest < ActiveSupport::TestCase
     end
   end
 
+  context "Notes:" do
+    context "#copy_notes_to" do
+      setup do
+        @src = FactoryGirl.create(:post, image_width: 100, image_height: 100, tag_string: "translated partially_translated", has_embedded_notes: true)
+        @dst = FactoryGirl.create(:post, image_width: 200, image_height: 200, tag_string: "translation_request")
+
+        @src.notes.create(x: 10, y: 10, width: 10, height: 10, body: "test")
+        @src.notes.create(x: 10, y: 10, width: 10, height: 10, body: "deleted", is_active: false)
+        @src.reload
+
+        @src.copy_notes_to(@dst)
+      end
+
+      should "copy notes and tags" do
+        assert_equal(1, @dst.notes.active.length)
+        assert_equal(true, @dst.has_embedded_notes)
+        assert_equal("lowres partially_translated translated", @dst.tag_string)
+      end
+
+      should "rescale notes" do
+        note = @dst.notes.active.first
+        assert_equal([20, 20, 20, 20], [note.x, note.y, note.width, note.height])
+      end
+    end
+  end
+
   context "Mass assignment: " do
     should_not allow_mass_assignment_of(:last_noted_at).as(:member)
   end


### PR DESCRIPTION
Fixes #3583. Copies `translated`, `partially_translated`, `check_translation`, `translation_request`, and `reverse_translation` to the destination post. Also copies the embedded notes flag.