### PR TITLE
Possible fix for #3597: Poor performance since last deploy

### DIFF
--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -48,18 +48,19 @@ class StorageManager
     open(file_path(post.md5, post.file_ext, type))
   end
 
-  def file_url(post, type)
+  def file_url(post, type, tagged_filenames: false)
     subdir = subdir_for(post.md5)
     file = file_name(post.md5, post.file_ext, type)
+    seo_tags = seo_tags(post) if tagged_filenames
 
     if type == :preview && !post.has_preview?
       "#{base_url}/images/download-preview.png"
     elsif type == :preview
       "#{base_url}/preview/#{subdir}#{file}"
     elsif type == :large && post.has_large?
-      "#{base_url}/sample/#{subdir}#{seo_tags(post)}#{file}"
+      "#{base_url}/sample/#{subdir}#{seo_tags}#{file}"
     else
-      "#{base_url}/#{subdir}#{seo_tags(post)}#{post.md5}.#{post.file_ext}"
+      "#{base_url}/#{subdir}#{seo_tags}#{post.md5}.#{post.file_ext}"
     end
   end
 
@@ -100,8 +101,8 @@ class StorageManager
     end
   end
 
-  def seo_tags(post, user = CurrentUser.user)
-    return "" if !tagged_filenames || user.disable_tagged_filenames?
+  def seo_tags(post)
+    return "" if !tagged_filenames
 
     tags = post.humanized_essential_tag_string.gsub(/[^a-z0-9]+/, "_").gsub(/(?:^_+)|(?:_+$)/, "").gsub(/_{2,}/, "_")
     "__#{tags}__"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -145,6 +145,14 @@ class Post < ApplicationRecord
       storage_manager.open_file(self, type)
     end
 
+    def tagged_file_url
+      storage_manager.file_url(self, :original, tagged_filenames: !CurrentUser.user.disable_tagged_filenames?)
+    end
+
+    def tagged_large_file_url
+      storage_manager.file_url(self, :large, tagged_filenames: !CurrentUser.user.disable_tagged_filenames?)
+    end
+
     def file_url
       storage_manager.file_url(self, :original)
     end
@@ -171,9 +179,9 @@ class Post < ApplicationRecord
 
     def file_url_for(user)
       if user.default_image_size == "large" && image_width > Danbooru.config.large_image_width
-        large_file_url
+        tagged_large_file_url
       else
-        file_url
+        tagged_file_url
       end
     end
 

--- a/app/views/posts/partials/show/_download.html.erb
+++ b/app/views/posts/partials/show/_download.html.erb
@@ -1,1 +1,1 @@
-<p><%= link_to "Save this file (right click and save)", post.file_url %></p>
+<p><%= link_to "Save this file (right click and save)", post.tagged_file_url %></p>

--- a/app/views/posts/partials/show/_flash.html.erb
+++ b/app/views/posts/partials/show/_flash.html.erb
@@ -1,6 +1,6 @@
 <%= content_tag(:object, :width => post.image_width, :height => post.image_height) do %>
-  <%= tag :params, :name => "movie", :value => post.file_url %>
-  <%= tag :embed, :src => post.file_url, :width => post.image_width, :height => post.image_height, :allowScriptAccess => "never" %>
+  <%= tag :params, :name => "movie", :value => post.tagged_file_url %>
+  <%= tag :embed, :src => post.tagged_file_url, :width => post.image_width, :height => post.image_height, :allowScriptAccess => "never" %>
 <% end %>
 
-<p><%= link_to "Save this flash (right click and save)", post.file_url %></p>
+<p><%= link_to "Save this flash (right click and save)", post.tagged_file_url %></p>

--- a/app/views/posts/partials/show/_information.html.erb
+++ b/app/views/posts/partials/show/_information.html.erb
@@ -12,7 +12,7 @@
     <li>Approver: <%= link_to_user(post.approver) %></li>
   <% end %>
   <li>
-    Size: <%= link_to_if post.visible?, number_to_human_size(post.file_size), post.file_url %>
+    Size: <%= link_to_if post.visible?, number_to_human_size(post.file_size), post.tagged_file_url %>
     <% if post.has_dimensions? %>
       (<span itemprop="width"><%= post.image_width %></span>x<span itemprop="height"><%= post.image_height %></span>)
     <% end %>

--- a/app/views/posts/partials/show/_notices.html.erb
+++ b/app/views/posts/partials/show/_notices.html.erb
@@ -78,7 +78,7 @@
 
 <% if post.visible? && post.has_large? && !post.is_ugoira? %>
   <div class="ui-corner-all ui-state-highlight notice notice-resized" id="image-resize-notice" style="<%= CurrentUser.default_image_size == "original" ? "display: none;" : "" %>">
-    <span>Resized to <%= number_to_percentage post.resize_percentage.floor, :precision => 0 %> of original (<%= link_to "view original", post.file_url, :id => "image-resize-link" %>)</span>
+    <span>Resized to <%= number_to_percentage post.resize_percentage.floor, :precision => 0 %> of original (<%= link_to "view original", post.tagged_file_url, :id => "image-resize-link" %>)</span>
     <span style="display: none;">Loading...</span>
   </div>
 <% end %>

--- a/app/views/posts/partials/show/_options.html.erb
+++ b/app/views/posts/partials/show/_options.html.erb
@@ -4,7 +4,7 @@
   <% if CurrentUser.is_member? %>
     <li><%= link_to "Favorite", favorites_path(:post_id => post.id), :remote => true, :method => :post, :id => "add-to-favorites", :title => "Shortcut is F" %></li>
     <li><%= link_to "Unfavorite", favorite_path(post), :remote => true, :method => :delete, :id => "remove-from-favorites" %></li>
-    <li><%= link_to_if post.visible?, "Download", post.file_url, download: post.presenter.filename_for_download %></li>
+    <li><%= link_to_if post.visible?, "Download", post.tagged_file_url, download: post.presenter.filename_for_download %></li>
     <li id="add-to-pool-list"><%= link_to "Add to pool", "#", :id => "pool" %></li>
     <% if post.is_note_locked? %>
       <li id="add-notes-list"><span id="note-locked-notice">Note locked</span></li>

--- a/app/views/posts/partials/show/_ugoira_original.html.erb
+++ b/app/views/posts/partials/show/_ugoira_original.html.erb
@@ -29,7 +29,7 @@
   </div>
   <p id="save-video-link">
     <% if post.has_ugoira_webm? %>
-      <%= link_to "Save as video (right click and save)", post.large_file_url %>
+      <%= link_to "Save as video (right click and save)", post.tagged_large_file_url %>
     <% else %>
       WebM conversion pending
     <% end %>

--- a/app/views/posts/partials/show/_ugoira_webm.html.erb
+++ b/app/views/posts/partials/show/_ugoira_webm.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag(:video, nil, :id => "image", :width => post.image_width, :height => post.image_height, :autoplay => true, :loop => true, :controls => "controls", :src => post.large_file_url) %>
+<%= content_tag(:video, nil, :id => "image", :width => post.image_width, :height => post.image_height, :autoplay => true, :loop => true, :controls => "controls", :src => post.tagged_large_file_url) %>
 
-<p><%= link_to "Save this video (right click and save)", post.large_file_url %> | <%= link_to "View original", post_path(post, :original => 1) %></p>
+<p><%= link_to "Save this video (right click and save)", post.tagged_large_file_url %> | <%= link_to "View original", post_path(post, :original => 1) %></p>

--- a/app/views/posts/partials/show/_video.html.erb
+++ b/app/views/posts/partials/show/_video.html.erb
@@ -1,3 +1,3 @@
-<%= content_tag(:video, nil, :id => "image", :width => post.image_width, :height => post.image_height, :autoplay => true, :loop => !post.has_tag?("video_with_sound"), :controls => "controls", :src => post.file_url) %>
+<%= content_tag(:video, nil, :id => "image", :width => post.image_width, :height => post.image_height, :autoplay => true, :loop => !post.has_tag?("video_with_sound"), :controls => "controls", :src => post.tagged_file_url) %>
 
-<p><%= link_to "Save this video (right click and save)", post.file_url %></p>
+<p><%= link_to "Save this video (right click and save)", post.tagged_file_url %></p>


### PR DESCRIPTION
Possible fix for #3597. Generating tagged filenames requires a memcache fetch to get the `humanized_essential_tag_string`. Since thumbnails include `data-file-url` / `data-large-file-url` attributes, that meant we were doing a memcache fetch for each thumbnail. Changes things so that tagged filenames are only used for URLs on the post show page.