### PR TITLE
Fix #3603: Unable to view images on Hijiribe/Sonohara when Danbooru is blocked

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -172,6 +172,7 @@ class ApplicationController < ActionController::Base
   def reset_current_user
     CurrentUser.user = nil
     CurrentUser.ip_addr = nil
+    CurrentUser.root_url = root_url
   end
 
   def set_started_at_session

--- a/app/logical/current_user.rb
+++ b/app/logical/current_user.rb
@@ -48,6 +48,14 @@ class CurrentUser
     Thread.current[:current_ip_addr]
   end
 
+  def self.root_url
+    Thread.current[:current_root_url] || "http://#{Danbooru.config.hostname}/"
+  end
+
+  def self.root_url=(root_url)
+    Thread.current[:current_root_url] = root_url
+  end
+
   def self.id
     if user.nil?
       nil

--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -14,7 +14,7 @@ class StorageManager
   end
 
   def default_base_url
-    Rails.application.routes.url_helpers.root_url + "data"
+    CurrentUser.root_url + "data"
   end
 
   # Store the given file at the given path. If a file already exists at that

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -230,7 +230,7 @@ module Danbooru
       # base_url - where to serve files from (default: http://#{hostname}/data)
       # hierarchical: false - store files in a single directory
       # hierarchical: true - store files in a hierarchical directory structure, based on the MD5 hash
-      StorageManager::Local.new(base_dir: "#{Rails.root}/public/data", hierarchical: false)
+      StorageManager::Local.new(base_url: CurrentUser.root_url + "data", base_dir: "#{Rails.root}/public/data", hierarchical: false)
 
       # Store files on one or more remote host(s). Configure SSH settings in
       # ~/.ssh_config or in the ssh_options param (ref: http://net-ssh.github.io/net-ssh/Net/SSH.html#method-c-start)


### PR DESCRIPTION
Potential fix for #3603. This saves the `root_url` for the current request in `CurrentUser.root_url`. This lets you say

```
StorageManager:SFTP.new(*all_server_hosts, base_url: CurrentUser.root_url + "data")
```

and it will set the base url to whichever protocol + domain the current user is on. This is kind of hacky, but I couldn't find a better way to pass this information in.