### PR TITLE
Improve IQDB error handling

### DIFF
--- a/app/assets/javascripts/common.js
+++ b/app/assets/javascripts/common.js
@@ -39,6 +39,11 @@ $(function() {
       location.reload();
     });
   });
+
+  // triggered by rails when a `link_to ..., remote: true` call fails.
+  $(document).on("ajax:error", function (event, xhr, status, error) {
+    Danbooru.error("Error: " + xhr.status + " " + xhr.statusText);
+  });
 });
 
 var Danbooru = {};

--- a/app/logical/iqdb/download.rb
+++ b/app/logical/iqdb/download.rb
@@ -16,35 +16,31 @@ module Iqdb
     end
 
     def self.find_similar(source)
-      if Danbooru.config.iqdbs_server
-        url, ref = get_referer(source)
-        params = {
-          "key" => Danbooru.config.iqdbs_auth_key,
-          "url" => url,
-          "ref" => ref
-        }
-        uri = URI.parse("#{Danbooru.config.iqdbs_server}/similar")
-        uri.query = URI.encode_www_form(params)
+      raise NotImplementedError, "the IQDBs service isn't configured. Similarity searches are not available." unless enabled?
 
-        resp = HTTParty.get(uri, Danbooru.config.httparty_options)
-        if resp.success?
-          json = JSON.parse(resp.body)
-          if json.is_a?(Array)
-            post_ids = json.map { |match| match["post_id"] }
-            posts = Post.find(post_ids)
+      url, ref = get_referer(source)
+      params = {
+        "key" => Danbooru.config.iqdbs_auth_key,
+        "url" => url,
+        "ref" => ref
+      }
+      uri = URI.parse("#{Danbooru.config.iqdbs_server}/similar")
+      uri.query = URI.encode_www_form(params)
 
-            json.map do |match|
-              post = posts.find { |post| post.id == match["post_id"] }
-              match.with_indifferent_access.merge({ post: post })
-            end
-          else
-            []
-          end
-        else
-          raise "HTTP error code: #{resp.code} #{resp.message}"
+      resp = HTTParty.get(uri, Danbooru.config.httparty_options)
+      raise "HTTP error code: #{resp.code} #{resp.message}" unless resp.success?
+
+      json = JSON.parse(resp.body)
+      if json.is_a?(Array)
+        post_ids = json.map { |match| match["post_id"] }
+        posts = Post.find(post_ids)
+
+        json.map do |match|
+          post = posts.find { |post| post.id == match["post_id"] }
+          match.with_indifferent_access.merge({ post: post })
         end
       else
-        raise NotImplementedError, "the IQDBs service isn't configured. Similarity searches are not available." unless enabled?
+        []
       end
     end
   end


### PR DESCRIPTION
Related to #3605. Adds better error handling when iqdb lookups fail:

* Raise an error instead of returning no matches when iqdbs returns an error response.
* Include the api response returned by iqdbs in error messages.
* Display an error message when the `Find similar` link in the sidebar fails.
* Simplify the show / check actions in the controller (unrelated code cleanup).