### PR TITLE
Fix #3260: Exception when uploading certain DeviantArt posts

### DIFF
--- a/app/logical/deviant_art_api_client.rb
+++ b/app/logical/deviant_art_api_client.rb
@@ -1,0 +1,76 @@
+# Authentication is via OAuth2 with the client credentials grant. Register a
+# new app at https://www.deviantart.com/developers/ to obtain a client_id and
+# client_secret. The app doesn't need to be published.
+#
+# API requests must send a user agent and must use gzip compression, otherwise
+# 403 errors will be returned.
+#
+# API calls operate on UUIDs. The deviation ID in the URL is not the UUID. UUIDs
+# are obtained by scraping the HTML page for the <meta property="da:appurl"> element.
+#
+# * https://www.deviantart.com/developers/
+# * https://www.deviantart.com/developers/authentication
+# * https://www.deviantart.com/developers/errors
+# * https://www.deviantart.com/developers/http/v1/20160316
+
+class DeviantArtApiClient
+  class Error < StandardError; end
+  BASE_URL = "https://www.deviantart.com/api/v1/oauth2"
+
+  attr_reader :client_id, :client_secret, :httparty_options
+
+  def initialize(client_id, client_secret, httparty_options = {})
+    @client_id, @client_secret, @httparty_options = client_id, client_secret, httparty_options
+  end
+
+  # https://www.deviantart.com/developers/http/v1/20160316/deviation_single/bcc296bdf3b5e40636825a942a514816
+  def deviation(uuid)
+    request("/deviation/#{uuid}")
+  end
+
+  # https://www.deviantart.com/developers/http/v1/20160316/deviation_download/bed6982b88949bdb08b52cd6763fcafd
+  def download(uuid, mature_content: "1")
+    request("/deviation/download/#{uuid}", mature_content: mature_content)
+  end
+
+  # https://www.deviantart.com/developers/http/v1/20160316/deviation_metadata/7824fc14d6fba6acbacca1cf38c24158
+  def metadata(*uuids, mature_content: "1", ext_submission: "1", ext_camera: "1", ext_stats: "1")
+    params = {
+      deviationids: uuids.flatten,
+      mature_content: mature_content,
+      ext_submission: ext_submission,
+      ext_camera: ext_camera,
+      ext_stats: ext_stats,
+    }
+
+    request("/deviation/metadata", params)
+  end
+
+  def request(url, **params)
+    options = httparty_options.deep_merge(
+      base_uri: BASE_URL,
+      query: { access_token: access_token.token, **params },
+      headers: { "Accept-Encoding" => "gzip" },
+      format: :plain,
+    )
+
+    resp = HTTParty.get(url, **options)
+    json = JSON.parse(Zlib.gunzip(resp.body), symbolize_names: true)
+
+    raise Error, "HTTP error #{resp.code}: #{json}" unless resp.success?
+    json
+  end
+
+  def oauth
+    OAuth2::Client.new(client_id, client_secret, site: "https://www.deviantart.com", token_url: "/oauth2/token")
+  end
+
+  def access_token
+    @access_token = oauth.client_credentials.get_token if @access_token.nil? || @access_token.expired?
+    @access_token
+  end
+
+  def access_token=(hash)
+    @access_token = OAuth2::AccessToken.from_hash(oauth, hash)
+  end
+end

--- a/config/danbooru_default_config.rb
+++ b/config/danbooru_default_config.rb
@@ -487,11 +487,12 @@ module Danbooru
       nil
     end
 
-    def deviantart_login
+    # Register at https://www.deviantart.com/developers/.
+    def deviantart_client_id
       nil
     end
 
-    def deviantart_password
+    def deviantart_client_secret
       nil
     end
 

--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -13,6 +13,13 @@ module Sources
       end
     end
 
+    context "The source for a download-disabled DeviantArt artwork page" do
+      should "get the image url" do
+        @site = Sources::Site.new("https://noizave.deviantart.com/art/test-no-download-697415967")
+        assert_equal(["https://img00.deviantart.net/56ee/i/2017/219/2/3/test__no_download_by_noizave-dbj81lr.jpg"], @site.image_urls)
+      end
+    end
+
     context "The source for an DeviantArt artwork page" do
       setup do
         @site = Sources::Site.new("http://noizave.deviantart.com/art/test-post-please-ignore-685436408")
@@ -20,11 +27,11 @@ module Sources
       end
 
       should "get the image url" do
-        assert_match(%r!https://orig\d+.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png!, @site.image_url)
+        assert_match(%r!https://origin-orig.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png!, @site.image_url)
       end
 
       should "get the profile" do
-        assert_equal("https://noizave.deviantart.com/", @site.profile_url)
+        assert_equal("https://noizave.deviantart.com", @site.profile_url)
       end
 
       should "get the artist name" do
@@ -37,7 +44,7 @@ module Sources
 
       should "get the artist commentary" do
         title = "test post please ignore"
-        desc = "<div align=\"center\"><span>blah blah<br><div align=\"left\">\n<a class=\"external\" href=\"https://www.deviantart.com/users/outgoing?http://www.google.com\">test link</a><br>\n</div></span></div>\n<br><h1>lol</h1>\n<br><br><b>blah</b> <i>blah</i> <u>blah</u> <strike>blah</strike><br>herp derp<br><br><blockquote>this is a quote</blockquote>\n<ol>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ol>\n<ul>\n<li>one</li>\n<li>two</li>\n<li>three</li>\n</ul>\n<img src=\"https://e.deviantart.net/emoticons/h/heart.gif\" alt=\"Heart\" style=\"width: 15px; height: 13px;\" data-embed-type=\"emoticon\" data-embed-id=\"357\">  "
+        desc = "<div align=\"center\"><span>blah blah<br /><div align=\"left\"><a class=\"external\" href=\"https://www.deviantart.com/users/outgoing?http://www.google.com\">test link</a><br /></div></span></div><br /><h1>lol</h1><br /><br /><b>blah</b>&nbsp;<i>blah</i>&nbsp;<u>blah</u>&nbsp;<strike>blah</strike><br />herp derp<br /><br /><blockquote>this is a quote</blockquote><ol><li>one</li><li>two</li><li>three</li></ol><ul><li>one</li><li>two</li><li>three</li></ul><img src=\"https://e.deviantart.net/emoticons/h/heart.gif\" alt=\"Heart\" style=\"width: 15px; height: 13px;\" data-embed-type=\"emoticon\" data-embed-id=\"357\">&nbsp;&nbsp;"
 
         assert_equal(title, @site.artist_commentary_title)
         assert_equal(desc, @site.artist_commentary_desc)
@@ -79,7 +86,7 @@ module Sources
       end
 
       should "get the image url" do
-        assert_match(%r!https://orig\d+\.deviantart\.net/cb25/f/2017/160/1/9/hidden_work_by_noizave-dbc3r29\.png!, @site.image_url)
+        assert_match(%r!https://origin-orig\.deviantart\.net/cb25/f/2017/160/1/9/hidden_work_by_noizave-dbc3r29\.png!, @site.image_url)
       end
     end
 


### PR DESCRIPTION
Fixes #3260. This switches from scraping the HTML to using DeviantArt's API. This should fix the problem of getting captcha'd randomly.

The API is documented here: https://www.deviantart.com/developers/. You'll need to register an app there to get the `client_id` and `client_secret`. The app doesn't need to be published.

The basic flow of the API is as follows:

* Login using OAuth2 with the client credentials grant type to get an access token.

* Scrape the work's HTML page to get its UUID from the `<meta property="da:appurl">` element. The API operates only on UUIDs and AFAIK this is the only way to get a work's UUID.

* Call `/deviation/{uuid}`, `/deviation/metadata`, and `/deviation/download/{uuid}` to get the info we need.

Sample API responses:

* Work: https://grivetart.deviantart.com/art/Alone-on-the-Road-V2-282374631
* UUID: F0D640D2-BEE4-8797-AD80-1DBD824B8F65
* [GET /deviation/F0D640D2-BEE4-8797-AD80-1DBD824B8F65](https://gist.github.com/evazion/8f45bc08ddac63d995e990d01966c40c)
* [GET /deviation/metadata?deviationids[]=F0D640D2-BEE4-8797-AD80-1DBD824B8F65](https://gist.github.com/evazion/3f20b60cb2723788b363c9ab0dcd8232)
* [GET /deviation/download/F0D640D2-BEE4-8797-AD80-1DBD824B8F65]( https://gist.github.com/evazion/88479b176230e7d165bcc546d63da126)