### PR TITLE
Fix #3657: Add improvements to the uploads interface

### DIFF
--- a/app/assets/stylesheets/common/simple_form.scss
+++ b/app/assets/stylesheets/common/simple_form.scss
@@ -71,6 +71,17 @@ form.inline-form {
   }
 }
 
+form.one-line-form {
+  > input, > div.input {
+    display: inline;
+
+    label {
+      display: inline;
+      margin-right: 1em;
+    }
+  }
+}
+
 div.ui-dialog {
   div.input {
     input[type="text"] {

--- a/app/assets/stylesheets/common/tables.scss
+++ b/app/assets/stylesheets/common/tables.scss
@@ -54,6 +54,10 @@ table.autofit {
     white-space: normal;
     width: 100%;
   }
+
+  .col-normal {
+    white-space: normal;
+  }
 }
 
 table.search {

--- a/app/assets/stylesheets/specific/uploads.scss
+++ b/app/assets/stylesheets/specific/uploads.scss
@@ -36,6 +36,12 @@ div#c-uploads {
     }
   }
 
+  div#a-index {
+    .info {
+      margin-right: 1.5em;
+    }
+  }
+
   div.upload-preview {
     display: inline-block;
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -37,8 +37,7 @@ class UploadsController < ApplicationController
   end
 
   def index
-    @search = Upload.search(search_params)
-    @uploads = @search.paginate(params[:page], :limit => params[:limit])
+    @uploads = Upload.search(search_params).includes(:post, :uploader).paginate(params[:page], :limit => params[:limit])
     respond_with(@uploads) do |format|
       format.xml do
         render :xml => @uploads.to_xml(:root => "uploads")

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -20,9 +20,15 @@ class UploadsController < ApplicationController
   end
 
   def batch
-    @source = Sources::Site.new(params[:url], :referer_url => params[:ref])
-    @source.get
-    @urls = @source.image_urls
+    @url = params.dig(:batch, :url) || params[:url]
+    @source = nil
+
+    if @url
+      @source = Sources::Site.new(@url, :referer_url => params[:ref])
+      @source.get
+    end
+
+    respond_with(@source)
   end
 
   def image_proxy

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -3,7 +3,7 @@ class PostPresenter < Presenter
 
   def self.preview(post, options = {})
     if post.nil?
-      return "Expunged"
+      return "<em>none</em>".html_safe
     end
 
     if !options[:show_deleted] && post.is_deleted? && options[:tags] !~ /status:(?:all|any|deleted|banned)/ && !options[:raw]

--- a/app/views/uploads/_search.html.erb
+++ b/app/views/uploads/_search.html.erb
@@ -1,0 +1,8 @@
+<%= simple_form_for(:search, url: uploads_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+  <%= f.input :uploader_name, label: "Uploader", input_html: { value: params[:search][:uploader_name] } %>
+  <%= f.input :post_tags_match, label: "Post Tags", input_html: { value: params[:search][:post_tags_match] } %>
+  <%= f.input :source_matches, label: "Source", input_html: { value: params[:search][:source_matches] } %>
+  <%= f.input :status, collection: [%w[Completed completed], %w[Processing processing], %w[Pending pending], %w[Duplicate *duplicate*], %w[Error error*]], include_blank: true, selected: params[:search][:status] %>
+
+  <%= f.submit "Search" %>
+<% end %>

--- a/app/views/uploads/_secondary_links.html.erb
+++ b/app/views/uploads/_secondary_links.html.erb
@@ -1,0 +1,9 @@
+<% content_for(:secondary_links) do %>
+  <menu>
+    <li><%= link_to "Listing", uploads_path %></li>
+    <li><%= link_to "New", new_upload_path %></li>
+    <li><%= link_to "Batch Upload", batch_uploads_path %></li>
+    <li><%= link_to "IQDB", check_iqdb_queries_path %></li>
+    <li><%= link_to "Help", wiki_pages_path(search: { title: "help:upload" }) %></li>
+  </menu>
+<% end %>

--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -49,4 +49,4 @@
   </script>
 <% end %>
 
-<%= render "posts/partials/common/secondary_links" %>
+<%= render "uploads/secondary_links" %>

--- a/app/views/uploads/batch.html.erb
+++ b/app/views/uploads/batch.html.erb
@@ -2,27 +2,34 @@
   <div id="a-batch">
     <h1>Batch Upload</h1>
 
-    <section>
-      <% @urls.each.with_index do |url, i| %>
-        <div class="upload-preview">
-          <p class="caption-top">
-            <%= link_to "Image ##{i}", new_upload_path(url: url, ref: params[:url]), target: "_blank" %>
-          </p>
+    <%= simple_form_for(:batch, url: batch_uploads_path, method: :get, defaults: { required: false }, html: { class: "one-line-form" }) do |f| %>
+      <%= f.input :url, label: "URL", input_html: { size: 70, value: @url, placeholder: "https://www.pixiv.net/member_illust.php?mode=medium&illust_id=65981746" } %>
+      <%= f.submit "Fetch" %>
+    <% end %>
 
-          <%= link_to new_upload_path(url: url, ref: params[:url]), target: "_blank" do %>
-            <% if ImageProxy.needs_proxy?(url) %>
-              <%= image_tag(image_proxy_uploads_path(url: url)) %>
-            <% elsif url.is_a?(String) %>
-              <%= image_tag url %>
-            <% else %>
-              Direct Link
+    <% if @source.present? %>
+      <section>
+        <% @source.image_urls.each.with_index do |url, i| %>
+          <div class="upload-preview">
+            <p class="caption-top">
+              <%= link_to "Image ##{i}", new_upload_path(url: url, ref: @url), target: "_blank" %>
+            </p>
+
+            <%= link_to new_upload_path(url: url, ref: @url), target: "_blank" do %>
+              <% if ImageProxy.needs_proxy?(url) %>
+                <%= image_tag(image_proxy_uploads_path(url: url)) %>
+              <% elsif url.is_a?(String) %>
+                <%= image_tag url %>
+              <% else %>
+                Direct Link
+              <% end %>
             <% end %>
-          <% end %>
-        </div>
-      <% end %>
-    </section>
+          </div>
+        <% end %>
 
-    <p><%= link_to "Open all links in new windows", "#", :id => "link" %></p>
+        <p><%= link_to "Open all links in new windows", "#", :id => "link" %></p>
+      </section>
+    <% end %>
   </div>
 </div>
 

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -27,7 +27,7 @@
   </div>
 </div>
 
-<%= render "posts/partials/common/secondary_links" %>
+<%= render "uploads/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Uploads - <%= Danbooru.config.app_name %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,25 +1,65 @@
 <div id="c-uploads">
   <div id="a-index">
     <%= render "uploads/search" %>
+    <%= render "posts/partials/common/inline_blacklist" %>
 
-    <table width="100%" class="striped">
+    <table width="100%" class="striped autofit">
       <thead>
         <tr>
-          <th></th>
+          <th>Upload</th>
+          <th>Info</th>
           <th>Uploader</th>
           <th>Status</th>
-          <th>Date</th>
-          <th>Tags</th>
         </tr>
       </thead>
       <tbody>
         <% @uploads.each do |upload| %>
           <tr>
-            <td><%= link_to upload.id, upload_path(upload) %></td>
-            <td><%= link_to_user upload.uploader %></td>
-            <td><%= upload.presenter.status(self) %></td>
-            <td><%= compact_time upload.created_at %></td>
-            <td><%= upload.tag_string %></td>
+            <td>
+              <%= PostPresenter.preview(upload.post, tags: "user:#{upload.uploader_name}", show_deleted: true) %>
+            </td>
+            <td class="col-expand upload-info">
+              <span class="info">
+                <strong>Upload</strong>
+                <%= link_to "##{upload.id}", upload %>
+              </span>
+
+              <span class="info">
+                <strong>Rating</strong>
+                <%= upload.rating %>
+              </span>
+
+              <% if upload.post.present? %>
+                <span class="info">
+                  <strong>Size</strong>
+                  <%= link_to "#{upload.post.file_size.to_s(:human_size, precision: 4)} #{upload.post.file_ext}", upload.post.file_url %>
+                  <% if upload.post.has_dimensions? %>
+                    (<%= upload.post.image_width %>x<%= upload.post.image_height %>)
+                  <% end %>
+                </span>
+              <% end %>
+              <br>
+
+              <span class="info">
+                <strong>Source</strong>
+                <%= link_to_if (upload.source =~ %r!\Ahttps?://!i), (upload.source.presence || content_tag(:em, "none")), upload.source %>
+                <%= link_to "»", uploads_path(search: params[:search].merge(source_matches: upload.source)) %>
+              </span>
+              <br>
+
+              <span class="info">
+                <strong>Tags</strong>
+                <%= TagSetPresenter.new(upload.tag_string.split).inline_tag_list(self) %>
+              </span>
+            </td>
+            <td>
+              <%= link_to_user upload.uploader %>
+              <%= link_to "»", uploads_path(search: params[:search].merge(uploader_name: upload.uploader_name)) %>
+              <br><%= time_ago_in_words_tagged  upload.created_at %>
+            </td>
+            <td class="col-normal">
+              <%= link_to upload.presenter.status(self), uploads_path(search: params[:search].merge(status: upload.status)) %>
+            </td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,5 +1,7 @@
 <div id="c-uploads">
   <div id="a-index">
+    <%= render "uploads/search" %>
+
     <table width="100%" class="striped">
       <thead>
         <tr>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -143,4 +143,4 @@
   Upload - <%= Danbooru.config.app_name %>
 <% end %>
 
-<%= render "posts/partials/common/secondary_links" %>
+<%= render "uploads/secondary_links" %>

--- a/app/views/uploads/show.html.erb
+++ b/app/views/uploads/show.html.erb
@@ -36,7 +36,7 @@
   </div>
 </div>
 
-<%= render "posts/partials/common/secondary_links" %>
+<%= render "uploads/secondary_links" %>
 
 <% content_for(:page_title) do %>
   Upload - <%= Danbooru.config.app_name %>

--- a/test/functional/uploads_controller_test.rb
+++ b/test/functional/uploads_controller_test.rb
@@ -63,18 +63,28 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
     context "index action" do
       setup do
         as_user do
-          @upload = create(:source_upload)
+          @upload = create(:source_upload, tag_string: "foo bar")
         end
       end
 
       should "render" do
-        get_auth uploads_path, @user
+        get uploads_path
         assert_response :success
       end
 
       context "with search parameters" do
         should "render" do
-          get_auth uploads_path, @user, params: {:search => {:source => @upload.source}}
+          search_params = {
+            uploader_name: @upload.uploader_name,
+            source_matches: @upload.source,
+            rating: @upload.rating,
+            has_post: "yes",
+            post_tags_match: @upload.tag_string,
+            status: @upload.status,
+            server: @upload.server,
+          }
+
+          get uploads_path, params: { search: search_params }
           assert_response :success
         end
       end

--- a/test/functional/uploads_controller_test.rb
+++ b/test/functional/uploads_controller_test.rb
@@ -23,6 +23,13 @@ class UploadsControllerTest < ActionDispatch::IntegrationTest
           assert_no_match(/59523577_ugoira0\.jpg/, response.body)
         end
       end
+
+      context "for a blank source" do
+        should "render" do
+          get_auth batch_uploads_path, @user
+          assert_response :success
+        end
+      end
     end
 
     context "new action" do


### PR DESCRIPTION
Fixes #3657:

* Add more search options to the `/uploads` page. Most columns in the uploads table are now searchable, but only the most useful ones are exposed in the UI.
* Revamp the `/uploads` listing to add thumbnails, colorize tags, show source/size/dimension info, and add `»` search drilldown links where relevant.
* Link the batch uploads page and the IQDB search page in the subnav bar.
* Fix the batch upload page to be usable without the bookmarklet.

Screenshots:

![image](https://user-images.githubusercontent.com/8430473/39073796-ab4c9c4c-44b4-11e8-8102-8cb39f60fd7e.png)

![image](https://user-images.githubusercontent.com/8430473/39073819-bab2e59c-44b4-11e8-9368-c5f51910c7aa.png)