### PR TITLE
Fix #3678: "Access denied" when adding commentary.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,7 @@ gem 'rakismet'
 gem 'recaptcha', require: "recaptcha/rails"
 gem 'activemodel-serializers-xml'
 gem 'ptools'
+gem 'jquery-rails'
 
 # needed for looser jpeg header compat
 gem 'ruby-imagespec', :require => "image_spec", :git => "https://github.com/r888888888/ruby-imagespec.git", :branch => "exif-fixes"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,6 +182,10 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
+    jquery-rails (4.3.3)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     json (2.1.0)
     jwt (1.5.6)
     kgio (2.11.2)
@@ -450,6 +454,7 @@ DEPENDENCIES
   google-api-client
   highline
   httparty
+  jquery-rails
   listen
   mechanize
   memcache-client

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,6 @@
 //= require jquery.qtip.js
 //= require ugoira_player.js
 //= require stupidtable.js
-//= require rails-ujs
+//= require jquery_ujs
 //= require common.js
 //= require_tree .


### PR DESCRIPTION
Fixes #3678. Apparently we need to include `jquery_ujs` instead of `rails-ujs`. To be honest I'm not sure why rails-ujs isn't enough.