### PR TITLE
Fix #3579: Add post approval index

### DIFF
--- a/app/controllers/post_approvals_controller.rb
+++ b/app/controllers/post_approvals_controller.rb
@@ -1,0 +1,8 @@
+class PostApprovalsController < ApplicationController
+  respond_to :html, :xml, :json
+
+  def index
+    @post_approvals = PostApproval.includes(:post, :user).search(search_params).paginate(params[:page], limit: params[:limit])
+    respond_with(@post_approvals)
+  end
+end

--- a/app/views/post_approvals/index.html.erb
+++ b/app/views/post_approvals/index.html.erb
@@ -1,0 +1,42 @@
+<div id="c-post-approvals">
+  <div id="a-index">
+    <h1>Approvals</h1>
+    <%= render "posts/partials/common/inline_blacklist" %>
+
+    <%= simple_form_for(:search, url: post_approvals_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+      <%= f.input :user_name, label: "Approver", input_html: { value: params[:search][:user_name] } %>
+      <%= f.input :post_tags_match, label: "Tags", input_html: { value: params[:search][:post_tags_match], data: { autocomplete: "tag-query" } } %>
+      <%= f.submit "Search" %>
+    <% end %>
+
+    <table width="100%" class="striped">
+      <thead>
+        <tr>
+          <th width="1%">Post</th>
+          <th width="15%">Approver</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @post_approvals.each do |post_approval| %>
+          <tr>
+            <td>
+              <%= PostPresenter.preview(post_approval.post, :tags => "status:any") %>
+            </td>
+
+            <td>
+              <%= link_to_user post_approval.user %>
+              <%= link_to "»", post_approvals_path(search: params[:search].merge(user_name: post_approval.user.name)) %>
+              <br><%= time_ago_in_words_tagged  post_approval.created_at %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= numbered_paginator(@post_approvals) %>
+  </div>
+</div>
+
+<% content_for(:page_title) do %>
+  Approvals - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/post_events/index.html.erb
+++ b/app/views/post_events/index.html.erb
@@ -1,15 +1,14 @@
 <div id="c-post-events">
   <div id="a-index">
-    <h1>Flags &amp; Appeals</h1>
+    <h1>Post Events</h1>
 
-    <table width="100%" class="striped">
+    <table width="100%" class="striped autofit">
       <thead>
         <tr>
-          <th width="5%">Type</th>
-          <th width="10%">Creator</th>
-          <th>Reason</th>
-          <th width="5%">Resolved?</th>
-          <th width="15%">Date</th>
+          <th>Type</th>
+          <th>User</th>
+          <th>Description</th>
+          <th>Resolved?</th>
         </tr>
       </thead>
       <tbody>
@@ -22,16 +21,10 @@
               <% else %>
                 <i>hidden</i>
               <% end %>
+              <br><%= time_ago_in_words_tagged event.created_at %>
             </td>
-            <td><%= format_text event.reason %></td>
-            <td>
-              <% if event.is_resolved %>
-                yes
-              <% else %>
-                no
-              <% end %>
-            </td>
-            <td><%= compact_time event.created_at %></td>
+            <td class="col-expand"><%= format_text event.reason %></td>
+            <td><%= event.is_resolved %></td>
           </tr>
         <% end %>
       </tbody>

--- a/app/views/static/site_map.html.erb
+++ b/app/views/static/site_map.html.erb
@@ -6,12 +6,8 @@
         <li><h1>Posts</h1></li>
         <li><%= link_to("Help", wiki_pages_path(:title => "help:posts")) %></li>
         <li><%= link_to("Listing", posts_path) %></li>
-        <li><%= link_to("Changes", post_versions_path) %></li>
         <li><%= link_to("Upload", new_upload_path) %></li>
         <li><%= link_to("Upload Listing", uploads_path) %></li>
-        <li><%= link_to("Appeals", post_appeals_path) %></li>
-        <li><%= link_to("Flags", post_flags_path) %></li>
-        <li><%= link_to("Replacements", post_replacements_path) %></li>
         <li><%= link_to("Popular", popular_explore_posts_path) %></li>
         <li><%= link_to("Most Viewed", viewed_explore_posts_path) %></li>
         <% if CurrentUser.can_approve_posts? %>
@@ -20,6 +16,14 @@
         <% if CurrentUser.is_moderator? %>
           <li><%= link_to("Mass Edit", edit_moderator_tag_path) %></li>
         <% end %>
+      </ul>
+      <ul>
+        <li><h1>Post Events</h1></li>
+        <li><%= link_to("Changes", post_versions_path) %></li>
+        <li><%= link_to("Approvals", post_approvals_path) %></li>
+        <li><%= link_to("Appeals", post_appeals_path) %></li>
+        <li><%= link_to("Flags", post_flags_path) %></li>
+        <li><%= link_to("Replacements", post_replacements_path) %></li>
       </ul>
       <ul>
         <li><h1>Tools</h1></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -220,6 +220,7 @@ Rails.application.routes.draw do
   end
   resources :post_appeals
   resources :post_flags
+  resources :post_approvals, only: [:index]
   resources :post_versions, :only => [:index, :search] do
     member do
       put :undo

--- a/test/factories/post_approval.rb
+++ b/test/factories/post_approval.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory(:post_approval) do
+    user factory: :moderator_user
+    post factory: :post, is_pending: true
+  end
+end

--- a/test/functional/post_approvals_controller_test.rb
+++ b/test/functional/post_approvals_controller_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class PostApprovalsControllerTest < ActionDispatch::IntegrationTest
+  context "The post approvals controller" do
+    setup do
+      @approval = FactoryBot.create(:post_approval)
+    end
+
+    context "index action" do
+      should "render" do
+        get post_approvals_path
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/functional/post_events_controller_test.rb
+++ b/test/functional/post_events_controller_test.rb
@@ -9,15 +9,16 @@ class PostEventsControllerTest < ActionDispatch::IntegrationTest
 
     as_user do
       @post = create(:post)
-      @post_flag = PostFlag.create(:post => @post, :reason => "aaa", :is_resolved => false)
-      @post_appeal = PostAppeal.create(:post => @post, :reason => "aaa")
+      @post.flag!("aaa")
+      @post.appeal!("aaa")
+      @post.approve!(@mod)
     end
   end
 
   context "get /posts/:post_id/events" do
     should "render" do
       get_auth post_events_path(post_id: @post.id), @user
-      assert_response :ok      
+      assert_response :ok
     end
 
     should "render for mods" do

--- a/test/unit/post_approval_test.rb
+++ b/test/unit/post_approval_test.rb
@@ -7,7 +7,7 @@ class PostApprovalTest < ActiveSupport::TestCase
       CurrentUser.user = @user
       CurrentUser.ip_addr = "127.0.0.1"
 
-      @post = FactoryBot.create(:post, uploader_id: @user.id, is_pending: true)
+      @post = FactoryBot.create(:post, uploader_id: @user.id, tag_string: "touhou", is_pending: true)
 
       @approver = FactoryBot.create(:user)
       @approver.can_approve_posts = true
@@ -56,6 +56,15 @@ class PostApprovalTest < ActiveSupport::TestCase
           approval = @post.approve!(@approver)
           assert_includes(approval.errors.full_messages, "You have previously approved this post and cannot approve it again")
         end
+      end
+    end
+
+    context "#search method" do
+      should "work" do
+        @approval = @post.approve!(@approver)
+        @approvals = PostApproval.search(user_name: @approver.name, post_tags_match: "touhou", post_id: @post.id)
+
+        assert_equal([@approval.id], @approvals.map(&:id))
       end
     end
   end


### PR DESCRIPTION
Fixes #3579:

* Adds a `/post_approvals` index.
* Adds approvals to the post events page (`/posts/:id/events`).
* Moves post events (approvals, flags, appeals, replacements) to their own section in the sitemap.

Screenshots:

![image](https://user-images.githubusercontent.com/8430473/39666702-aeeb05f4-506d-11e8-88e8-6bb5f19161e6.png)

![image](https://user-images.githubusercontent.com/8430473/39666725-f60ad52c-506d-11e8-908d-a4f504ff02ce.png)

![image](https://user-images.githubusercontent.com/8430473/39666694-99fc6a8e-506d-11e8-9173-66d8ac2587e3.png)
