### PR TITLE
Fix #3633: Remove favorites meta tag

### DIFF
--- a/app/assets/javascripts/favorites.js
+++ b/app/assets/javascripts/favorites.js
@@ -8,7 +8,6 @@
   }
 
   Danbooru.Favorite.hide_or_show_add_to_favorites_link = function() {
-    var favorites = Danbooru.meta("favorites");
     var current_user_id = Danbooru.meta("current-user-id");
     if (current_user_id == "") {
       $("#add-to-favorites").hide();
@@ -17,8 +16,7 @@
       $("#remove-fav-button").hide();
       return;
     }
-    var regexp = new RegExp("\\bfav:" + current_user_id + "\\b");
-    if ((favorites != undefined) && (favorites.match(regexp))) {
+    if ($("#image-container").length && $("#image-container").data("is-favorited") == true) {
       $("#add-to-favorites").hide();
       $("#add-fav-button").hide();
     } else {

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -155,7 +155,6 @@
 <% content_for(:html_header) do %>
   <meta name="description" content="<%= @post.presenter.humanized_tag_string %>">
   <meta name="tags" content="<%= @post.tag_string %>">
-  <meta name="favorites" content="<%= @post.fav_string %>">
   <meta name="pools" content="<%= @post.pool_string %>">
   <meta name="post-id" content="<%= @post.id %>">
   <% if CurrentUser.can_approve_posts? %>


### PR DESCRIPTION
Fixes #3633 by continuing to remove publicly available instances of the favorites string.