### PR TITLE
Add jump to first & last pagination buttons

### DIFF
--- a/app/helpers/pagination_helper.rb
+++ b/app/helpers/pagination_helper.rb
@@ -29,7 +29,8 @@ module PaginationHelper
     window = 4
 
     if records.current_page >= 2
-      html << "<li class='arrow'>" + link_to("<<", nav_params_for(records.current_page - 1), :rel => "prev") + "</li>"
+      html << "<li class='arrow'>" + link_to("<<", nav_params_for(1), :rel => "first") + "</li>"
+      html << "<li class='arrow'>" + link_to("<", nav_params_for(records.current_page - 1), :rel => "prev") + "</li>"
     else
       html << "<li class='arrow'><span>" + "&lt;&lt;" + "</span></li>"
     end
@@ -69,7 +70,8 @@ module PaginationHelper
     end
 
     if records.current_page < records.total_pages && records.size > 0
-      html << "<li class='arrow'>" + link_to(">>", nav_params_for(records.current_page + 1), :rel => "next") + "</li>"
+      html << "<li class='arrow'>" + link_to(">", nav_params_for(records.current_page + 1), :rel => "next") + "</li>"
+      html << "<li class='arrow'>" + link_to(">>", nav_params_for(records.total_pages), :rel => "last") + "</li>"
     else
       html << "<li class='arrow'><span>" + "&gt;&gt;" + "</span></li>"
     end


### PR DESCRIPTION
Most websites follow this convention:

* << and >> jump to the very first and last pages, respectively
* On non last pages, < and > jump to the previous and next pages

Danbooru didn't do this. This is only somewhat annoying on desktop, as you can just jump to the last numbered page or the first numbered page, but on responsive mode you can't see numbered pages -- you can only see the arrows. This means that if you're in a forum thread or on a page in responsive mode, you can't jump to the beginning or the end directly.

With this change, the chevrons behave as expected on both responsive and desktop layouts. I toyed with hiding the "first" and "last" pages (i.e., 1 and the last number), but that removes context for the start and the end (and just looks wrong to me).

![screen shot 2018-06-21 at 20 17 56](https://user-images.githubusercontent.com/532647/41754601-36dfd1be-7590-11e8-8f68-f874d771be9f.png)
![screen shot 2018-06-21 at 20 18 14](https://user-images.githubusercontent.com/532647/41754603-385efd94-7590-11e8-80f1-33deb17c0e61.png)
