### PR TITLE
Make dropzone accept mp4, webm, and swf files

### DIFF
--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -170,7 +170,7 @@
         createImageThumbnails: false,
         addRemoveLinks: false,
         maxFiles: 1,
-        acceptedFiles: "image/jpeg,image/png,image/gif",
+        acceptedFiles: "image/jpeg,image/png,image/gif,video/mp4,video/webm,.swf",
         previewTemplate: '<div class="dz-preview dz-file-preview"><div class="dz-details"><div class="dz-filename"><span data-dz-name></span></div><div class="dz-size" data-dz-size></div></div><div class="dz-progress"><span class="dz-upload" data-dz-uploadprogress></span></div><div class="dz-error-message"><span data-dz-errormessage></span></div></div>',
         init: function() {
           $(".fallback").hide();


### PR DESCRIPTION
to match the rest of the code base

For flash files I've used the file extension ([doc](http://www.dropzonejs.com/#config-acceptedFiles)) because the mime type is browser
specific and I've found at least 3 different variations for .swf so far:
1. `application/vnd.adobe.flash-movie`: [wikipedia](https://en.wikipedia.org/wiki/SWF)
2. `application/vnd.adobe.flash.movie`: [mailcap](https://pagure.io/mailcap/blob/ec8c60e6b0b02b4af9081c6913746adb0da695f5/f/mime.types#_420), firefox
2. `application/x-shockwave-flash`: [sitepoint](https://www.sitepoint.com/mime-types-complete-list/), [mdn](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types)

I did not include .zip for Ugoiras (`application/zip`) because I got this error every time (it does work using the bookmarklet):
```
ActiveRecord::RecordInvalid exception raised

    Validation failed: Md5 confirmation doesn't match Md5
    app/logical/upload_service.rb:532:in `start!'
    app/controllers/uploads_controller.rb:54:in `create'
```

I couldn't find any reasoning for why this wasn't done in the first place, but:
1. it is very simple to bypass right now because
  * it's just client side javascript
  * you could upload the file on some random filehost and then use the source field
2. why _should_ there be an inconsistency between manual and automatic uploading?