### PR TITLE
Restyle search button to match rest of the UI

### DIFF
--- a/app/assets/stylesheets/common/main_layout.scss
+++ b/app/assets/stylesheets/common/main_layout.scss
@@ -4,6 +4,17 @@ div#search {
   margin-bottom: 1em;
 }
 
+div#search-box button {
+  -webkit-appearance: button;
+  border: 1px solid $link_color;
+  background-color: $link_color;
+  color: #FFF;
+  &:hover, &:focus {
+    border: 1px solid $link_hover_color;
+    background-color: $link_hover_color;
+  }
+}
+
 div#page {
   overflow: visible;
   margin: 0 20px;
@@ -101,4 +112,3 @@ div#more-links {
   padding: 0.2em 0.6em;
   @include box-shadow(2px 2px 2px #ccc);
 }
-


### PR DESCRIPTION
Especially in Safari, the search button as of a recent version has been looking pretty bad.

![screen shot 2018-07-24 at 6 50 29 pm](https://user-images.githubusercontent.com/188480/43168124-7dae164a-8f72-11e8-8f72-81b3cdfb3a95.png)

This commit restyles the button to use the same link colours for normal and hover/focus and make it somewhat more consistent with other elements. A rough idea of what it'll look like:

![image](https://user-images.githubusercontent.com/188480/43168443-a7cd822a-8f73-11e8-99a1-8aef71bc60ad.png)