### PR TITLE
Refactor comments.js

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -70,7 +70,6 @@ private
   def index_for_post
     @post = Post.find(params[:post_id])
     @comments = @post.comments
-    @comments = @comments.visible(CurrentUser.user) unless params[:include_below_threshold]
     render :action => "index_for_post"
   end
 

--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -8,7 +8,6 @@ Comment.initialize_all = function() {
     $(document).on("click", ".reply-link", Comment.quote);
     $(document).on("click", ".edit_comment_link", Comment.show_edit_form);
     $(document).on("click", ".expand-comment-response", Comment.show_new_comment_form);
-    this.initialize_expand_links();
   }
 
   $(window).on("danbooru:index_for_post", (_event, post_id, current_comment_section) => {
@@ -36,16 +35,6 @@ Comment.quote = function(e) {
   e.preventDefault();
 }
 
-Comment.initialize_expand_links = function() {
-  $(".comment-section form").hide();
-  $(".comment-section input.expand-comment-response").click(function(e) {
-    var post_id = $(this).closest(".comment-section").data("post-id");
-    $(this).hide();
-    $(".comment-section[data-post-id=" + post_id + "] form").slideDown("fast");
-    e.preventDefault();
-  });
-}
-
 Comment.show_new_comment_form = function(e) {
   $(e.target).hide();
   var $form = $(e.target).closest("div.new-comment").find("form");
@@ -57,17 +46,6 @@ Comment.show_new_comment_form = function(e) {
 Comment.show_edit_form = function(e) {
   $(this).closest(".comment").find(".edit_comment").show();
   e.preventDefault();
-}
-
-Comment.hide_threshold_comments = function(post_id) {
-  var threshold = parseInt(Utility.meta("user-comment-threshold"));
-  var articles = $("article.comment[data-post-id=" + post_id + "]");
-  articles.each(function(i, v) {
-    var $comment = $(v);
-    if (parseInt($comment.data("score")) < threshold) {
-      $comment.hide();
-    }
-  });
 }
 
 $(document).ready(function() {

--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -8,7 +8,6 @@ Comment.initialize_all = function() {
     this.initialize_response_link();
     this.initialize_reply_links();
     this.initialize_expand_links();
-    this.initialize_vote_links();
 
     if (!$("#a-edit").length) {
       this.initialize_edit_links();
@@ -27,7 +26,6 @@ Comment.initialize_all = function() {
     }
     Comment.initialize_reply_links(current_comment_section);
     Comment.initialize_edit_links(current_comment_section);
-    Comment.initialize_vote_links(current_comment_section);
     Dtext.initialize_expandables(current_comment_section);
   });
 }
@@ -74,13 +72,10 @@ Comment.initialize_response_link = function() {
     Utility.scroll_to($form);
     e.preventDefault();
   });
-
-  $("div.new-comment form").hide();
 }
 
 Comment.initialize_edit_links = function($parent) {
   $parent = $parent || $(document);
-  $parent.find(".edit_comment").hide();
   $parent.find(".edit_comment_link").click(function(e) {
     var link_id = $(this).attr("id");
     var comment_id = link_id.match(/^edit_comment_link_(\d+)$/)[1];
@@ -109,11 +104,6 @@ Comment.hide_threshold_comments = function(post_id) {
       $comment.hide();
     }
   });
-}
-
-Comment.initialize_vote_links = function($parent) {
-  $parent = $parent || $(document);
-  $parent.find(".unvote-comment-link").hide();
 }
 
 $(document).ready(function() {

--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -5,13 +5,10 @@ let Comment = {};
 
 Comment.initialize_all = function() {
   if ($("#c-posts").length || $("#c-comments").length) {
-    this.initialize_response_link();
-    this.initialize_reply_links();
+    $(document).on("click", ".reply-link", Comment.quote);
+    $(document).on("click", ".edit_comment_link", Comment.show_edit_form);
+    $(document).on("click", ".expand-comment-response", Comment.show_new_comment_form);
     this.initialize_expand_links();
-
-    if (!$("#a-edit").length) {
-      this.initialize_edit_links();
-    }
   }
 
   if ($("#c-posts").length && $("#a-show").length) {
@@ -24,8 +21,6 @@ Comment.initialize_all = function() {
     } else {
       Comment.highlight_threshold_comments(post_id);
     }
-    Comment.initialize_reply_links(current_comment_section);
-    Comment.initialize_edit_links(current_comment_section);
     Dtext.initialize_expandables(current_comment_section);
   });
 }
@@ -49,11 +44,6 @@ Comment.quote = function(e) {
   e.preventDefault();
 }
 
-Comment.initialize_reply_links = function($parent) {
-  $parent = $parent || $(document);
-  $parent.find(".reply-link").click(Comment.quote);
-}
-
 Comment.initialize_expand_links = function() {
   $(".comment-section form").hide();
   $(".comment-section input.expand-comment-response").click(function(e) {
@@ -64,24 +54,17 @@ Comment.initialize_expand_links = function() {
   });
 }
 
-Comment.initialize_response_link = function() {
-  $("a.expand-comment-response").click(function(e) {
-    $(e.target).hide();
-    var $form = $(e.target).closest("div.new-comment").find("form");
-    $form.show();
-    Utility.scroll_to($form);
-    e.preventDefault();
-  });
+Comment.show_new_comment_form = function(e) {
+  $(e.target).hide();
+  var $form = $(e.target).closest("div.new-comment").find("form");
+  $form.show();
+  Utility.scroll_to($form);
+  e.preventDefault();
 }
 
-Comment.initialize_edit_links = function($parent) {
-  $parent = $parent || $(document);
-  $parent.find(".edit_comment_link").click(function(e) {
-    var link_id = $(this).attr("id");
-    var comment_id = link_id.match(/^edit_comment_link_(\d+)$/)[1];
-    $("#edit_comment_" + comment_id).fadeToggle("fast");
-    e.preventDefault();
-  });
+Comment.show_edit_form = function(e) {
+  $(this).closest(".comment").find(".edit_comment").show();
+  e.preventDefault();
 }
 
 Comment.highlight_threshold_comments = function(post_id) {

--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -11,16 +11,8 @@ Comment.initialize_all = function() {
     this.initialize_expand_links();
   }
 
-  if ($("#c-posts").length && $("#a-show").length) {
-    Comment.highlight_threshold_comments(Utility.meta("post-id"));
-  }
-
-  $(window).on("danbooru:index_for_post", (_event, post_id, current_comment_section, include_below_threshold) => {
-    if (include_below_threshold) {
-      $("#threshold-comments-notice-for-" + post_id).hide();
-    } else {
-      Comment.highlight_threshold_comments(post_id);
-    }
+  $(window).on("danbooru:index_for_post", (_event, post_id, current_comment_section) => {
+    $("#threshold-comments-notice-for-" + post_id).hide();
     Dtext.initialize_expandables(current_comment_section);
   });
 }
@@ -65,17 +57,6 @@ Comment.show_new_comment_form = function(e) {
 Comment.show_edit_form = function(e) {
   $(this).closest(".comment").find(".edit_comment").show();
   e.preventDefault();
-}
-
-Comment.highlight_threshold_comments = function(post_id) {
-  var threshold = parseInt(Utility.meta("user-comment-threshold"));
-  var articles = $("article.comment[data-post-id=" + post_id + "]");
-  articles.each(function(i, v) {
-    var $comment = $(v);
-    if (parseInt($comment.data("score")) < threshold) {
-      $comment.addClass("below-threshold");
-    }
-  });
 }
 
 Comment.hide_threshold_comments = function(post_id) {

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -189,6 +189,10 @@ class Comment < ApplicationRecord
     true
   end
 
+  def below_threshold?(user = CurrentUser.user)
+    score < user.comment_threshold
+  end
+
   def editable_by?(user)
     creator_id == user.id || user.is_moderator?
   end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,6 @@
 <%= error_messages_for :comment %>
 
-<%= simple_form_for(comment, :html => {:class => "edit_comment"}) do |f| %>
+<%= simple_form_for(comment, :html => {:style => ("display: none;" if local_assigns[:hidden]), :class => "edit_comment"}) do |f| %>
   <%= f.hidden_field :post_id %>
   <%= dtext_field "comment", "body", :classes => "autocomplete-mentions", :value => comment.body, :input_id => "comment_body_for_#{comment.id}", :preview_id => "dtext-preview-for-#{comment.id}" %>
   <%= f.button :submit, "Submit" %>

--- a/app/views/comments/edit.html.erb
+++ b/app/views/comments/edit.html.erb
@@ -2,7 +2,7 @@
   <div id="a-edit">
     <h1>Edit Comment</h1>
 
-    <%= render "comments/form", :post => @comment.post, :comment => @comment %>
+    <%= render "comments/form", comment: @comment %>
   </div>
 </div>
 

--- a/app/views/comments/index_for_post.js.erb
+++ b/app/views/comments/index_for_post.js.erb
@@ -2,4 +2,4 @@ $("#hidden-comments-notice-for-<%= @post.id %>").hide();
 
 var current_comment_section = $("div.comments-for-post[data-post-id=<%= @post.id %>] div.list-of-comments");
 current_comment_section.html("<%= j(render(:partial => 'comments/partials/show/comment', :collection => @comments))%>");
-$(window).trigger("danbooru:index_for_post", [<%= @post.id %>, current_comment_section, <%= ActiveModel::Type::Boolean.new.cast(params[:include_below_threshold]) %>]);
+$(window).trigger("danbooru:index_for_post", [<%= @post.id %>, current_comment_section]);

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -6,7 +6,7 @@
   <div class="row notices">
     <% if post.comments.hidden(CurrentUser.user).count > 0 || (params[:controller] == "comments" && post.comments.count > 6) %>
       <span class="info" id="threshold-comments-notice-for-<%= post.id %>">
-        <%= link_to "Show all comments", comments_path(:post_id => post.id, :include_below_threshold => true), :remote => true %>
+        <%= link_to "Show all comments", comments_path(:post_id => post.id), :remote => true %>
       </span>
     <% end %>
   </div>

--- a/app/views/comments/partials/index/_list.html.erb
+++ b/app/views/comments/partials/index/_list.html.erb
@@ -28,7 +28,7 @@
   <% if CurrentUser.is_member? %>
     <div class="new-comment">
       <p><%= link_to "Post comment", new_comment_path, :class => "expand-comment-response" %></p>
-      <%= render "comments/form", :post => post, :comment => post.comments.new %>
+      <%= render "comments/form", comment: post.comments.new, hidden: true %>
     </div>
   <% end %>
 </div>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if CurrentUser.is_moderator? || (params[:search] && params[:search][:is_deleted] =~ /t/) || !comment.is_deleted? %>
   <a name="comment-<%= comment.id %>"></a>
-  <article class="comment" data-post-id="<%= comment.post_id %>" data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>" data-creator="<%= comment.creator_name %>" data-is-sticky="<%= comment.is_sticky %>">
+  <article class="comment <%= "below-threshold" if comment.below_threshold? %>" data-post-id="<%= comment.post_id %>" data-comment-id="<%= comment.id %>" data-score="<%= comment.score %>" data-creator="<%= comment.creator_name %>" data-is-sticky="<%= comment.is_sticky %>">
     <div class="author">
       <h1>
         <%= link_to_user comment.creator %>

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -35,7 +35,7 @@
             <% end %>
             <li id="comment-vote-up-link-for-<%= comment.id %>"><%= link_to "Vote up", comment_votes_path(:comment_id => comment.id, :score => "up"), :method => :post, :remote => true %></li>
             <li id="comment-vote-down-link-for-<%= comment.id %>"><%= link_to "Vote down", comment_votes_path(:comment_id => comment.id, :score => "down"), :method => :post, :remote => true %></li>
-            <li id="comment-unvote-link-for-<%= comment.id %>" class="unvote-comment-link"><%= link_to "Unvote", comment_votes_path(:comment_id => comment.id), :method => :delete, :remote => true %></li>
+            <li style="display: none;" id="comment-unvote-link-for-<%= comment.id %>" class="unvote-comment-link"><%= link_to "Unvote", comment_votes_path(:comment_id => comment.id), :method => :delete, :remote => true %></li>
             <% if CurrentUser.is_moderator? %>
               <li>|</li>
               <li>
@@ -46,7 +46,7 @@
           <% end %>
         </menu>
         <% if comment.editable_by?(CurrentUser.user) %>
-          <%= render "comments/form", :post => comment.post, :comment => comment %>
+          <%= render "comments/form", comment: comment, hidden: true %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
This cleans up `comments.js` and fixes a couple issues along the way:

* Fix comment edit forms flickering on page load. Mark these forms as hidden by default in the html, instead of showing them by default then hiding them later in Javascript after the page loads.

* Use [event delegation](https://learn.jquery.com/events/event-delegation/) to bind click handlers so that they only have to be bound once, and don't have to be bound again when comments are dynamically loaded by "Show all comments".

* Restore the behavior of thresholded comments being greyed out (this was lost in 6fa0ae2). Set the `below-threshold` class for thresholded comments in the html, instead of setting it in Javascript.

* Remove some dead code.