### PR TITLE
 Fix #3813: Favorite limit can be bypassed.

### DIFF
--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -26,6 +26,7 @@ class FavoritesController < ApplicationController
   def create
     @post = Post.find(params[:post_id])
     @post.add_favorite!(CurrentUser.user)
+    flash[:notice] = "You have favorited this post"
 
     respond_with(@post)
   end
@@ -39,6 +40,7 @@ class FavoritesController < ApplicationController
       Favorite.remove(post_id: params[:id], user: CurrentUser.user)
     end
 
+    flash[:notice] = "You have unfavorited this post"
     respond_with(@post)
   end
 end

--- a/app/controllers/favorites_controller.rb
+++ b/app/controllers/favorites_controller.rb
@@ -1,6 +1,6 @@
 class FavoritesController < ApplicationController
   before_action :member_only, except: [:index]
-  respond_to :html, :xml, :json
+  respond_to :html, :xml, :json, :js
   skip_before_action :api_check
 
   def index
@@ -24,23 +24,10 @@ class FavoritesController < ApplicationController
   end
 
   def create
-    if CurrentUser.favorite_limit.nil? || CurrentUser.favorite_count < CurrentUser.favorite_limit
-      @post = Post.find(params[:post_id])
-      @post.add_favorite!(CurrentUser.user)
-    else
-      @error_msg = "You can only keep up to #{CurrentUser.favorite_limit} favorites. Upgrade your account to save more."
-    end
+    @post = Post.find(params[:post_id])
+    @post.add_favorite!(CurrentUser.user)
 
-    respond_with(@post) do |format|
-      format.js
-      format.json do
-        if @post
-          render :json => {:success => true}.to_json
-        else
-          render :json => {:success => false, :reason => @error_msg}.to_json, :status => 422
-        end
-      end
-    end
+    respond_with(@post)
   end
 
   def destroy
@@ -52,11 +39,6 @@ class FavoritesController < ApplicationController
       Favorite.remove(post_id: params[:id], user: CurrentUser.user)
     end
 
-    respond_with(@post) do |format|
-      format.js
-      format.json do
-        render :json => {:success => true}.to_json
-      end
-    end
+    respond_with(@post)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -108,6 +108,7 @@ class User < ApplicationRecord
   has_many :forum_posts, -> {order("forum_posts.created_at, forum_posts.id")}, :foreign_key => "creator_id"
   has_many :user_name_change_requests, -> {visible.order("user_name_change_requests.created_at desc")}
   has_many :favorite_groups, -> {order(name: :asc)}, foreign_key: :creator_id
+  has_many :favorites, ->(rec) {where("user_id % 100 = #{rec.id % 100} and user_id = #{rec.id}").order("id desc")}
   belongs_to :inviter, class_name: "User", optional: true
   after_update :create_mod_action
   accepts_nested_attributes_for :dmail_filter
@@ -294,20 +295,6 @@ class User < ApplicationRecord
       def sha1(pass)
         Digest::SHA1.hexdigest("#{Danbooru.config.password_salt}--#{pass}--")
       end
-    end
-  end
-
-  module FavoriteMethods
-    def favorites
-      Favorite.where("user_id % 100 = #{id % 100} and user_id = #{id}").order("id desc")
-    end
-
-    def add_favorite!(post)
-      Favorite.add(post: post, user: self)
-    end
-
-    def remove_favorite!(post)
-      Favorite.remove(post: post, user: self)
     end
   end
 
@@ -917,7 +904,6 @@ class User < ApplicationRecord
   include NameMethods
   include PasswordMethods
   include AuthenticationMethods
-  include FavoriteMethods
   include LevelMethods
   include EmailMethods
   include BlacklistMethods

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -605,7 +605,7 @@ class User < ApplicationRecord
 
     def favorite_limit
       if is_platinum?
-        nil
+        Float::INFINITY
       elsif is_gold?
         20_000
       else

--- a/app/views/favorites/_update.js.erb
+++ b/app/views/favorites/_update.js.erb
@@ -1,0 +1,16 @@
+$("#add-to-favorites, #add-fav-button, #remove-from-favorites, #remove-fav-button").toggle();
+$("#score-for-post-<%= @post.id %>").text(<%= @post.score %>);
+$("#favcount-for-post-<%= @post.id %>").text(<%= @post.fav_count %>);
+
+<% if CurrentUser.is_gold? %>
+  var fav_count = <%= @post.fav_count %>;
+  $("#favlist").html("<%= j post_favlist(@post) %>");
+
+  if (fav_count === 0) {
+    $("#show-favlist-link, #hide-favlist-link, #favlist").hide();
+  } else if (!$("#favlist").is(":visible")) {
+    $("#show-favlist-link").show();
+  }
+<% end %>
+
+Danbooru.Utility.notice("<%= j flash[:notice] %>");

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,13 +1,1 @@
-$("#add-to-favorites").hide();
-$("#add-fav-button").hide();
-$("#remove-from-favorites").show();
-$("#remove-fav-button").show();
-$("#score-for-post-<%= @post.id %>").html(<%= @post.score %>);
-$("#favcount-for-post-<%= @post.id %>").html(<%= @post.fav_count %>);
-<% if CurrentUser.is_gold? %>
-  $("#favlist").html("<%= escape_javascript(post_favlist(@post)) %>");
-  if (!$("#favlist").is(":visible")) {
-    $("#show-favlist-link").show();
-  }
-<% end %>
-$(window).trigger("danbooru:notice", "You have favorited this post");
+_update.js.erb

--- a/app/views/favorites/create.js.erb
+++ b/app/views/favorites/create.js.erb
@@ -1,17 +1,13 @@
-<% if @error_msg %>
-  $(window).trigger("danbooru:error", "<%= @error_msg %>");
-<% else %>
-  $("#add-to-favorites").hide();
-  $("#add-fav-button").hide();
-  $("#remove-from-favorites").show();
-  $("#remove-fav-button").show();
-  $("#score-for-post-<%= @post.id %>").html(<%= @post.score %>);
-  $("#favcount-for-post-<%= @post.id %>").html(<%= @post.fav_count %>);
-  <% if CurrentUser.is_gold? %>
-    $("#favlist").html("<%= escape_javascript(post_favlist(@post)) %>");
-    if (!$("#favlist").is(":visible")) {
-      $("#show-favlist-link").show();
-    }
-  <% end %>
-  $(window).trigger("danbooru:notice", "You have favorited this post");
+$("#add-to-favorites").hide();
+$("#add-fav-button").hide();
+$("#remove-from-favorites").show();
+$("#remove-fav-button").show();
+$("#score-for-post-<%= @post.id %>").html(<%= @post.score %>);
+$("#favcount-for-post-<%= @post.id %>").html(<%= @post.fav_count %>);
+<% if CurrentUser.is_gold? %>
+  $("#favlist").html("<%= escape_javascript(post_favlist(@post)) %>");
+  if (!$("#favlist").is(":visible")) {
+    $("#show-favlist-link").show();
+  }
 <% end %>
+$(window).trigger("danbooru:notice", "You have favorited this post");

--- a/app/views/favorites/destroy.js.erb
+++ b/app/views/favorites/destroy.js.erb
@@ -1,13 +1,1 @@
-$("#add-to-favorites").show();
-$("#add-fav-button").show();
-$("#remove-from-favorites").hide();
-$("#remove-fav-button").hide();
-$("#score-for-post-<%= @post.id %>").html(<%= @post.score %>);
-$("#favcount-for-post-<%= @post.id %>").html(<%= @post.fav_count %>);
-<% if CurrentUser.is_gold? %>
-  $("#favlist").html("<%= escape_javascript(post_favlist(@post)) %>");
-  <% if @post.fav_count == 0 %>
-    $("#show-favlist-link, #hide-favlist-link, #favlist").hide();
-  <% end %>
-<% end %>
-$(window).trigger("danbooru:notice", "You have unfavorited this post");
+_update.js.erb

--- a/app/views/static/error.js.erb
+++ b/app/views/static/error.js.erb
@@ -1,0 +1,2 @@
+var message = <%= raw @error_message.try(:to_json) || @exception.message.to_json %>;
+Danbooru.Utility.error(message);

--- a/test/unit/favorite_test.rb
+++ b/test/unit/favorite_test.rb
@@ -18,7 +18,7 @@ class FavoriteTest < ActiveSupport::TestCase
       user1 = FactoryBot.create(:user)
       p1 = FactoryBot.create(:post)
 
-      user1.add_favorite!(p1)
+      p1.add_favorite!(user1)
       assert_equal(1, Favorite.count)
 
       Favorite.where(:user_id => user1.id, :post_id => p1.id).delete_all
@@ -31,9 +31,9 @@ class FavoriteTest < ActiveSupport::TestCase
       p1 = FactoryBot.create(:post)
       p2 = FactoryBot.create(:post)
 
-      user1.add_favorite!(p1)
-      user1.add_favorite!(p2)
-      user2.add_favorite!(p1)
+      p1.add_favorite!(user1)
+      p2.add_favorite!(user1)
+      p1.add_favorite!(user2)
 
       favorites = user1.favorites.order("id desc")
       assert_equal(2, favorites.count)
@@ -49,8 +49,8 @@ class FavoriteTest < ActiveSupport::TestCase
       user1 = FactoryBot.create(:user)
       p1 = FactoryBot.create(:post)
       p2 = FactoryBot.create(:post)
-      user1.add_favorite!(p1)
-      user1.add_favorite!(p1)
+      p1.add_favorite!(user1)
+      p1.add_favorite!(user1)
 
       assert_equal(1, user1.favorites.count)
     end

--- a/test/unit/favorite_test.rb
+++ b/test/unit/favorite_test.rb
@@ -2,10 +2,13 @@ require 'test_helper'
 
 class FavoriteTest < ActiveSupport::TestCase
   setup do
-    user = FactoryBot.create(:user)
-    CurrentUser.user = user
+    @user1 = FactoryBot.create(:user)
+    @user2 = FactoryBot.create(:user)
+    @p1 = FactoryBot.create(:post)
+    @p2 = FactoryBot.create(:post)
+
+    CurrentUser.user = @user1
     CurrentUser.ip_addr = "127.0.0.1"
-    Favorite # need to force loading the favorite model
   end
 
   teardown do
@@ -15,44 +18,41 @@ class FavoriteTest < ActiveSupport::TestCase
 
   context "A favorite" do
     should "delete from all tables" do
-      user1 = FactoryBot.create(:user)
-      p1 = FactoryBot.create(:post)
+      @p1.add_favorite!(@user1)
+      assert_equal(1, @user1.favorite_count)
 
-      p1.add_favorite!(user1)
-      assert_equal(1, Favorite.count)
-
-      Favorite.where(:user_id => user1.id, :post_id => p1.id).delete_all
+      Favorite.where(:user_id => @user1.id, :post_id => @p1.id).delete_all
       assert_equal(0, Favorite.count)
     end
 
     should "know which table it belongs to" do
-      user1 = FactoryBot.create(:user)
-      user2 = FactoryBot.create(:user)
-      p1 = FactoryBot.create(:post)
-      p2 = FactoryBot.create(:post)
+      @p1.add_favorite!(@user1)
+      @p2.add_favorite!(@user1)
+      @p1.add_favorite!(@user2)
 
-      p1.add_favorite!(user1)
-      p2.add_favorite!(user1)
-      p1.add_favorite!(user2)
-
-      favorites = user1.favorites.order("id desc")
+      favorites = @user1.favorites.order("id desc")
       assert_equal(2, favorites.count)
-      assert_equal(p2.id, favorites[0].post_id)
-      assert_equal(p1.id, favorites[1].post_id)
+      assert_equal(@p2.id, favorites[0].post_id)
+      assert_equal(@p1.id, favorites[1].post_id)
 
-      favorites = user2.favorites.order("id desc")
+      favorites = @user2.favorites.order("id desc")
       assert_equal(1, favorites.count)
-      assert_equal(p1.id, favorites[0].post_id)
+      assert_equal(@p1.id, favorites[0].post_id)
     end
 
     should "not allow duplicates" do
-      user1 = FactoryBot.create(:user)
-      p1 = FactoryBot.create(:post)
-      p2 = FactoryBot.create(:post)
-      p1.add_favorite!(user1)
-      p1.add_favorite!(user1)
+      @p1.add_favorite!(@user1)
+      error = assert_raises(Favorite::Error) { @p1.add_favorite!(@user1) }
 
-      assert_equal(1, user1.favorites.count)
+      assert_equal("You have already favorited this post", error.message)
+      assert_equal(1, @user1.favorite_count)
+    end
+
+    should "not allow exceeding the user's favorite limit" do
+      @user1.stubs(:favorite_limit).returns(0)
+      error = assert_raises(Favorite::Error) { @p1.add_favorite!(@user1) }
+
+      assert_equal("You can only keep up to 0 favorites. Upgrade your account to save more.", error.message)
     end
   end
 end


### PR DESCRIPTION
Fixes #3813.

This also cleans up response handling in the favorites controller. As a side effect, the `POST /favorites.json?post_id=1` action now returns the updated post (instead of just `{ success: true }`), and the `DELETE /favorites/1.json` action now returns `204 No Content`.