### PR TITLE
Cleanup utility.js

### DIFF
--- a/app/javascript/src/javascripts/comments.js
+++ b/app/javascript/src/javascripts/comments.js
@@ -39,7 +39,7 @@ Comment.show_new_comment_form = function(e) {
   $(e.target).hide();
   var $form = $(e.target).closest("div.new-comment").find("form");
   $form.show();
-  Utility.scroll_to($form);
+  $form[0].scrollIntoView(false);
   e.preventDefault();
 }
 

--- a/app/javascript/src/javascripts/common.js
+++ b/app/javascript/src/javascripts/common.js
@@ -2,10 +2,6 @@ import Cookie from './cookie'
 import Utility from './utility'
 
 $(function() {
-  // Table striping
-  $(".striped tbody tr:even").addClass("even");
-  $(".striped tbody tr:odd").addClass("odd");
-
   // Account notices
   $("#hide-sign-up-notice").click(function(e) {
     $("#sign-up-notice").hide();

--- a/app/javascript/src/javascripts/notes.js
+++ b/app/javascript/src/javascripts/notes.js
@@ -145,7 +145,7 @@ let Note = {
       Note.Body.show(note_id);
       $(".note-box-highlighted").removeClass("note-box-highlighted");
       $note_box.addClass("note-box-highlighted");
-      Utility.scroll_to($note_box);
+      $note_box[0].scrollIntoView(false);
     },
 
     resize_inner_border: function($note_box) {

--- a/app/javascript/src/javascripts/saved_searches.js
+++ b/app/javascript/src/javascripts/saved_searches.js
@@ -1,10 +1,8 @@
-import Utility from './utility'
-
 let SavedSearch = {};
 
 SavedSearch.initialize_all = function() {
   if ($("#c-saved-searches").length) {
-    Utility.sorttable($("#c-saved-searches table"));
+    $("#c-saved-searches table").stupidtable();
   }
 }
 

--- a/app/javascript/src/javascripts/shortcuts.js
+++ b/app/javascript/src/javascripts/shortcuts.js
@@ -43,16 +43,11 @@ Shortcuts.initialize_data_shortcuts = function() {
 };
 
 Shortcuts.nav_scroll_down = function() {
-  var scroll_top = $(window).scrollTop() + ($(window).height() * 0.15);
-  $(window).scrollTop(scroll_top);
+  window.scrollBy(0, $(window).height() * 0.15);
 }
 
 Shortcuts.nav_scroll_up = function() {
-  var scroll_top = $(window).scrollTop() - ($(window).height() * 0.15);
-  if (scroll_top < 0) {
-    scroll_top = 0;
-  }
-  $(window).scrollTop(scroll_top);
+  window.scrollBy(0, $(window).height() * -0.15);
 }
 
 $(document).ready(function() {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -12,24 +12,6 @@ Utility.test_max_width = function(width) {
   return mq.matches;
 }
 
-Utility.scrolling = false;
-
-Utility.scroll_to = function(element) {
-  if (Utility.scrolling) {
-    return;
-  } else {
-    Utility.scrolling = true;
-  }
-
-  var top = null;
-  if (typeof element === "number") {
-    top = element;
-  } else {
-    top = element.offset().top - 10;
-  }
-  $('html, body').animate({scrollTop: top}, 300, "linear", function() {Utility.scrolling = false;});
-}
-
 Utility.notice_timeout_id = undefined;
 
 Utility.notice = function(msg, permanent) {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -85,26 +85,11 @@ Utility.regexp_escape = function(string) {
   return string.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 }
 
-$.fn.selectRange = function(start, end) {
-  return this.each(function() {
-    if (this.setSelectionRange) {
-      this.focus();
-      this.setSelectionRange(start, end);
-    } else if (this.createTextRange) {
-      var range = this.createTextRange();
-      range.collapse(true);
-      range.moveEnd('character', end);
-      range.moveStart('character', start);
-      range.select();
-    }
-  });
-};
-
 $.fn.selectEnd = function() {
-  if (this.length) {
-    this.selectRange(this.val().length, this.val().length);
-  }
-  return this;
+  return this.each(function() {
+    this.focus();
+    this.setSelectionRange(this.value.length, this.value.length);
+  })
 }
 
 $(function() {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -103,15 +103,6 @@ Utility.regexp_escape = function(string) {
   return string.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 }
 
-Utility.sorttable = function(table) {
-  table.stupidtable();
-  table.bind("aftertablesort", function(event, data) {
-    $("#c-saved-searches table tbody tr").removeClass("even odd");
-    $("#c-saved-searches table tbody tr:even").addClass("even");
-    $("#c-saved-searches table tbody tr:odd").addClass("odd");
-  });
-};
-
 $.fn.selectRange = function(start, end) {
   return this.each(function() {
     if (this.setSelectionRange) {

--- a/app/javascript/src/javascripts/utility.js
+++ b/app/javascript/src/javascripts/utility.js
@@ -71,16 +71,6 @@ Utility.intersect = function(a, b) {
   return result;
 }
 
-Utility.without = function(array, element) {
-  var temp = [];
-  $.each(array, function(i, v) {
-    if (v !== element) {
-      temp.push(v);
-    }
-  });
-  return temp;
-}
-
 Utility.regexp_escape = function(string) {
   return string.replace(/([.?*+^$[\]\\(){}|-])/g, "\\$1");
 }

--- a/app/javascript/src/styles/common/tables.scss
+++ b/app/javascript/src/styles/common/tables.scss
@@ -35,7 +35,7 @@ table.striped {
     }
   }
 
-  tr.even {
+  tr:nth-child(even) {
     background-color: #FAFAFA;
   }
 }

--- a/app/views/artist_versions/_revert_listing.html.erb
+++ b/app/views/artist_versions/_revert_listing.html.erb
@@ -19,7 +19,7 @@
     </thead>
     <tbody>
       <% @artist_versions.each do |artist_version| %>
-        <tr class="<%= cycle 'even', 'odd' %>">
+        <tr>
           <% if artist_version.visible? %>
             <td><%= link_to artist_version.name, artist_path(artist_version.artist_id) %></td>
             <td class="col-expand"><%= artist_version_other_names_diff(artist_version) %></td>

--- a/app/views/artist_versions/_standard_listing.html.erb
+++ b/app/views/artist_versions/_standard_listing.html.erb
@@ -16,7 +16,7 @@
     </thead>
     <tbody>
       <% @artist_versions.each do |artist_version| %>
-        <tr class="<%= cycle 'even', 'odd' %>">
+        <tr>
           <% if artist_version.visible? %>
             <td>
               <%= link_to artist_version.name, artist_path(artist_version.artist_id) %>

--- a/app/views/forum_posts/new.js.erb
+++ b/app/views/forum_posts/new.js.erb
@@ -4,7 +4,5 @@ if ($("#forum_post_body").val().length > 0) {
 }
 $("#forum_post_body").val(msg);
 $("#topic-response").show();
-$('html, body').animate({
-    scrollTop: $("#forum_post_body").offset().top - 100
-}, 500);
+document.body.scrollIntoView(false);
 $("#forum_post_body").selectEnd();

--- a/app/views/forum_topics/show.html.erb
+++ b/app/views/forum_topics/show.html.erb
@@ -49,11 +49,7 @@
     $(function() {
       $("#new-response-link").click(function(e) {
         $("#topic-response").show();
-
-        $('html, body').animate({
-            scrollTop: $("#forum_post_body").offset().top - 100
-        }, 500);
-
+        document.body.scrollIntoView(false);
         e.preventDefault();
       })
     });


### PR DESCRIPTION
This is just some miscellaneous code cleanups for `utility.js`:

* Simplify even/odd table row striping.
* Simplify `$.fn.selectEnd()`.
* Simplify the "W to scroll up" / "S to scroll down" hotkeys.
* Replace `Utility.scroll_to` with `Element.scrollIntoView`.
* Remove `Utility.without`.