### PR TITLE
Fix #3709: Provide OR capability for blacklist items

### DIFF
--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -70,6 +70,7 @@ Blacklist.update_sidebar = function() {
 
     link.text(entry.tags);
     link.attr("href", `/posts?tags=${encodeURIComponent(entry.tags)}`);
+    link.attr("title", entry.tags);
     link.click(Blacklist.toggle_entry);
     count.html(entry.hits);
     count.addClass("count");

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -55,6 +55,7 @@ Blacklist.toggle_entry = function(e) {
     }
   }
   Blacklist.apply();
+  e.preventDefault();
 }
 
 Blacklist.update_sidebar = function() {
@@ -68,6 +69,7 @@ Blacklist.update_sidebar = function() {
     var count = $("<span/>");
 
     link.text(entry.tags);
+    link.attr("href", `/posts?tags=${encodeURIComponent(entry.tags)}`);
     link.click(Blacklist.toggle_entry);
     count.html(entry.hits);
     count.addClass("count");

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -3,13 +3,27 @@
 #blacklist-box {
   display: none;
 
-  a.blacklisted-active {
-    text-decoration: line-through;
+  #blacklist-list {
+    a {
+      display: inline-block;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      vertical-align: bottom;
+    }
+
+    a.blacklisted-active {
+      text-decoration: line-through;
+    }
   }
 
   &.sidebar-blacklist ul li {
     list-style-type: disc;
     list-style-position: inside;
+
+    a {
+      max-width: 75%;
+    }
   }
 
   &.inline-blacklist {
@@ -21,6 +35,10 @@
       li {
         display: inline;
         margin-right: 1em;
+
+        a {
+          max-width: 25%;
+        }
       }
     }
   }

--- a/app/javascript/src/styles/common/blacklists.scss
+++ b/app/javascript/src/styles/common/blacklists.scss
@@ -1,0 +1,31 @@
+@import "../base/000_vars.scss";
+
+#blacklist-box {
+  display: none;
+
+  a.blacklisted-active {
+    text-decoration: line-through;
+  }
+
+  &.sidebar-blacklist ul li {
+    list-style-type: disc;
+    list-style-position: inside;
+  }
+
+  &.inline-blacklist {
+    margin-bottom: 1em;
+
+    #blacklist-list {
+      display: inline;
+
+      li {
+        display: inline;
+        margin-right: 1em;
+      }
+    }
+  }
+}
+
+.post-preview.blacklisted-active, #image-container.blacklisted-active, #c-comments .post.blacklisted-active {
+  display: none;
+}

--- a/app/javascript/src/styles/common/main_layout.scss
+++ b/app/javascript/src/styles/common/main_layout.scss
@@ -65,23 +65,6 @@ div#page {
     margin-bottom: 1em;
   }
 
-  aside#sidebar > section#blacklist-box ul {
-    margin-left: 1em;
-
-    li {
-      list-style-type: disc;
-    }
-
-    a {
-      color: $link_color;
-      cursor: pointer;
-    }
-
-    span {
-      color: #AAA;
-    }
-  }
-
   section#content {
     overflow: visible;
     margin-left: 15em;

--- a/app/javascript/src/styles/specific/comments.scss
+++ b/app/javascript/src/styles/specific/comments.scss
@@ -123,10 +123,6 @@ div#c-comments {
         }
       }
     }
-
-    div.post.blacklisted.blacklisted-active {
-      display: none;
-    }
   }
 }
 

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -51,14 +51,6 @@ article.post-preview {
   margin-top: 1em;
 }
 
-a.blacklisted-active {
-  text-decoration: line-through;
-}
-
-.post-preview.blacklisted-active, #image-container.blacklisted-active {
-  display: none;
-}
-
 #excerpt p.links {
   margin-top: 1em;
 }
@@ -494,33 +486,6 @@ div#c-explore-posts {
     margin: 0 5em;
 
     &:first-child {
-      margin-left: 0;
-    }
-  }
-}
-
-#blacklist-box {
-  display: none;
-}
-
-#blacklist-box.inline-blacklist {
-  margin-bottom: 1em;
-
-  #blacklist-list {
-    display: inline;
-  }
-
-  #blacklist-list li {
-    display: inline;
-    margin-right: 1em;
-
-    a {
-      color: $link_color;
-      cursor: pointer;
-    }
-
-    span.count {
-      color: #AAA;
       margin-left: 0;
     }
   }

--- a/app/views/posts/partials/index/_blacklist.html.erb
+++ b/app/views/posts/partials/index/_blacklist.html.erb
@@ -1,7 +1,7 @@
-<section id="blacklist-box">
+<div id="blacklist-box" class="sidebar-blacklist">
   <h1>Blacklisted (<%= link_to "Help", wiki_pages_path(:title => "help:blacklists") %>)</h1>
   <ul id="blacklist-list">
   </ul>
   <%= link_to "Disable all", "#", :id => "disable-all-blacklists", :style => "display: none;" %>
   <%= link_to "Re-enable all", "#", :id => "re-enable-all-blacklists", :style => "display: none;" %>
-</section>
+</div>

--- a/app/views/wiki_pages/_sidebar.html.erb
+++ b/app/views/wiki_pages/_sidebar.html.erb
@@ -1,9 +1,4 @@
 <aside id="sidebar">
+  <%= render "posts/partials/index/blacklist" %>
   <%= render "wiki_pages/recent_changes" %>
-
-  <section id="blacklist-box">
-    <h1>Blacklisted</h1>
-    <ul id="blacklist-list">
-    </ul>
-  </section>
 </aside>


### PR DESCRIPTION
Fixes #3709. Allows one to use OR searches in blacklists ( `~tag1 ~tag2`). Also truncates long blacklist rules to fit on one line, like this:

![image](https://user-images.githubusercontent.com/8430473/44443191-1b854480-a59c-11e8-8ee5-858bb9dd6533.png)