### PR TITLE
Add status:<unmoderated|modqueue>, disapproval:<type> metatags

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -128,6 +128,7 @@ Autocomplete.initialize_tag_autocomplete = function() {
       case "child":
       case "parent":
       case "filetype":
+      case "disapproval":
         Autocomplete.static_metatag_source(term, resp, metatag);
         return;
       case "user":
@@ -415,6 +416,9 @@ Autocomplete.static_metatags = {
   filetype: [
     "jpg", "png", "gif", "swf", "zip", "webm", "mp4"
   ],
+  disapproval: [
+    "any", "none", "disinterest", "poor_quality", "breaks_rules"
+  ]
 }
 
 Autocomplete.static_metatag_source = function(term, resp, metatag) {

--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -399,7 +399,7 @@ Autocomplete.static_metatags = {
     "custom"
   ].concat(<%= TagCategory.short_name_list.map {|category| [category + "tags", category + "tags_asc"]}.flatten %>),
   status: [
-    "any", "deleted", "active", "pending", "flagged", "banned"
+    "any", "deleted", "active", "pending", "flagged", "banned", "modqueue", "unmoderated"
   ],
   rating: [
     "safe", "questionable", "explicit"

--- a/app/logical/anonymous_user.rb
+++ b/app/logical/anonymous_user.rb
@@ -229,8 +229,12 @@ class AnonymousUser
     false
   end
 
+  def post_disapprovals
+    PostDisapproval.none
+  end
+
   def saved_searches
-    SavedSearch.where(false)
+    SavedSearch.none
   end
 
   def has_saved_searches?

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -222,6 +222,34 @@ class PostQueryBuilder
       end
     end
 
+    if q[:disapproval]
+      q[:disapproval].each do |disapproval|
+        disapprovals = CurrentUser.user.post_disapprovals.select(:post_id)
+
+        if disapproval.in?(%w[none false])
+          relation = relation.where.not("posts.id": disapprovals)
+        elsif disapproval.in?(%w[any all true])
+          relation = relation.where("posts.id": disapprovals)
+        else
+          relation = relation.where("posts.id": disapprovals.where(reason: disapproval))
+        end
+      end
+    end
+
+    if q[:disapproval_neg]
+      q[:disapproval_neg].each do |disapproval|
+        disapprovals = CurrentUser.user.post_disapprovals.select(:post_id)
+
+        if disapproval.in?(%w[none false])
+          relation = relation.where("posts.id": disapprovals)
+        elsif disapproval.in?(%w[any all true])
+          relation = relation.where.not("posts.id": disapprovals)
+        else
+          relation = relation.where.not("posts.id": disapprovals.where(reason: disapproval))
+        end
+      end
+    end
+
     if q[:flagger_ids_neg]
       q[:flagger_ids_neg].each do |flagger_id|
         if CurrentUser.can_view_flagger?(flagger_id)

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -131,18 +131,24 @@ class PostQueryBuilder
       relation = relation.where("posts.is_pending = TRUE")
     elsif q[:status] == "flagged"
       relation = relation.where("posts.is_flagged = TRUE")
+    elsif q[:status] == "modqueue"
+      relation = relation.where("posts.is_pending = TRUE OR posts.is_flagged = TRUE")
     elsif q[:status] == "deleted"
       relation = relation.where("posts.is_deleted = TRUE")
     elsif q[:status] == "banned"
       relation = relation.where("posts.is_banned = TRUE")
     elsif q[:status] == "active"
       relation = relation.where("posts.is_pending = FALSE AND posts.is_deleted = FALSE AND posts.is_banned = FALSE AND posts.is_flagged = FALSE")
+    elsif q[:status] == "unmoderated"
+      relation = relation.merge(Post.pending_or_flagged.available_for_moderation)
     elsif q[:status] == "all" || q[:status] == "any"
       # do nothing
     elsif q[:status_neg] == "pending"
       relation = relation.where("posts.is_pending = FALSE")
     elsif q[:status_neg] == "flagged"
       relation = relation.where("posts.is_flagged = FALSE")
+    elsif q[:status_neg] == "modqueue"
+      relation = relation.where("posts.is_pending = FALSE AND posts.is_flagged = FALSE")
     elsif q[:status_neg] == "deleted"
       relation = relation.where("posts.is_deleted = FALSE")
     elsif q[:status_neg] == "banned"

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1645,7 +1645,9 @@ class Post < ApplicationRecord
       where("uploader_id = ?", user_id)
     end
 
-    def available_for_moderation(hidden, user = CurrentUser.user)
+    def available_for_moderation(hidden = false, user = CurrentUser.user)
+      return none if user.is_anonymous?
+
       approved_posts = user.post_approvals.select(:post_id)
       disapproved_posts = user.post_disapprovals.select(:post_id)
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,6 @@
 class Tag < ApplicationRecord
   COSINE_SIMILARITY_RELATED_TAG_THRESHOLD = 300
-  METATAGS = "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-pool|pool|ordpool|-favgroup|favgroup|-fav|fav|ordfav|md5|-rating|rating|-locked|locked|width|height|mpixels|ratio|score|favcount|filesize|source|-source|id|-id|date|age|order|limit|-status|status|tagcount|parent|-parent|child|pixiv_id|pixiv|search|upvote|downvote|filetype|-filetype|flagger|-flagger|appealer|-appealer|" +
+  METATAGS = "-user|user|-approver|approver|commenter|comm|noter|noteupdater|artcomm|-pool|pool|ordpool|-favgroup|favgroup|-fav|fav|ordfav|md5|-rating|rating|-locked|locked|width|height|mpixels|ratio|score|favcount|filesize|source|-source|id|-id|date|age|order|limit|-status|status|tagcount|parent|-parent|child|pixiv_id|pixiv|search|upvote|downvote|filetype|-filetype|flagger|-flagger|appealer|-appealer|disapproval|-disapproval|" +
     TagCategory.short_name_list.map {|x| "#{x}tags"}.join("|")
   SUBQUERY_METATAGS = "commenter|comm|noter|noteupdater|artcomm|flagger|-flagger|appealer|-appealer"
   has_one :wiki_page, :foreign_key => "title", :primary_key => "name"
@@ -576,6 +576,14 @@ class Tag < ApplicationRecord
             q[:artcomm_ids] ||= []
             user_id = User.name_to_id(g2)
             q[:artcomm_ids] << user_id unless user_id.blank?
+
+          when "disapproval"
+            q[:disapproval] ||= []
+            q[:disapproval] << g2
+
+          when "-disapproval"
+            q[:disapproval_neg] ||= []
+            q[:disapproval_neg] << g2
 
           when "-pool"
             if g2.downcase == "none"

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2308,6 +2308,24 @@ class PostTest < ActiveSupport::TestCase
       end
     end
 
+    should "return posts for a disapproval:<type> metatag" do
+      CurrentUser.scoped(FactoryBot.create(:mod_user)) do
+        pending     = FactoryBot.create(:post, is_pending: true)
+        disapproved = FactoryBot.create(:post, is_pending: true)
+        disapproval = FactoryBot.create(:post_disapproval, post: disapproved, reason: "disinterest")
+
+        assert_tag_match([pending],     "disapproval:none")
+        assert_tag_match([disapproved], "disapproval:any")
+        assert_tag_match([disapproved], "disapproval:disinterest")
+        assert_tag_match([],            "disapproval:breaks_rules")
+
+        assert_tag_match([disapproved],          "-disapproval:none")
+        assert_tag_match([pending],              "-disapproval:any")
+        assert_tag_match([pending],              "-disapproval:disinterest")
+        assert_tag_match([disapproved, pending], "-disapproval:breaks_rules")
+      end
+    end
+
     should "return posts ordered by a particular attribute" do
       posts = (1..2).map do |n|
         tags = ["tagme", "gentag1 gentag2 artist:arttag char:chartag copy:copytag"]

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2130,6 +2130,7 @@ class PostTest < ActiveSupport::TestCase
       banned  = FactoryBot.create(:post, is_banned: true)
       all = [banned, deleted, flagged, pending]
 
+      assert_tag_match([flagged, pending], "status:modqueue")
       assert_tag_match([pending], "status:pending")
       assert_tag_match([flagged], "status:flagged")
       assert_tag_match([deleted], "status:deleted")
@@ -2138,11 +2139,23 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(all, "status:any")
       assert_tag_match(all, "status:all")
 
+      assert_tag_match(all - [flagged, pending], "-status:modqueue")
       assert_tag_match(all - [pending], "-status:pending")
       assert_tag_match(all - [flagged], "-status:flagged")
       assert_tag_match(all - [deleted], "-status:deleted")
       assert_tag_match(all - [banned],  "-status:banned")
       assert_tag_match(all, "-status:active")
+    end
+
+    should "return posts for the status:unmoderated metatag" do
+      flagged = FactoryBot.create(:post, is_flagged: true)
+      pending = FactoryBot.create(:post, is_pending: true)
+      disapproved = FactoryBot.create(:post, is_pending: true)
+
+      FactoryBot.create(:post_flag, post: flagged)
+      FactoryBot.create(:post_disapproval, post: disapproved, reason: "disinterest")
+
+      assert_tag_match([pending, flagged], "status:unmoderated")
     end
 
     should "respect the 'Deleted post filter' option when using the status:banned metatag" do


### PR DESCRIPTION
Fixes #3753. Adds the following metatags:

* `status:modqueue` - all posts that are pending or flagged.
* `status:unmoderated` - all posts that are pending or flagged and that you haven't disapproved yet. Same thing as the modqueue page.
* `disapproval:any` - all posts that you have disapproved.
* `disapproval:none` - all posts that you haven't disapproved.
* `disapproval:<disinterest|poor_quality|breaks_rules>` - all posts that you have disapproved with the given reason.