### PR TITLE
Fix #3837: Remove expired bans.

### DIFF
--- a/app/logical/daily_maintenance.rb
+++ b/app/logical/daily_maintenance.rb
@@ -18,5 +18,6 @@ class DailyMaintenance
     TokenBucket.prune!
     TagChangeRequestPruner.warn_all
     TagChangeRequestPruner.reject_all
+    Ban.prune!
   end
 end

--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -61,6 +61,12 @@ class Ban < ApplicationRecord
     q
   end
 
+  def self.prune!
+    expired.includes(:user).find_each do |ban|
+      ban.user.unban! if ban.user.ban_expired?
+    end
+  end
+
   def initialize_banner_id
     self.banner_id = CurrentUser.id if self.banner_id.blank?
   end

--- a/test/unit/daily_maintenance_test.rb
+++ b/test/unit/daily_maintenance_test.rb
@@ -29,5 +29,18 @@ class DailyMaintenanceTest < ActiveSupport::TestCase
       assert(true, @pending.reload.is_deleted)
       assert(true, @flagged.reload.is_deleted)
     end
+
+    context "when pruning bans" do
+      should "clear the is_banned flag for users who are no longer banned" do
+        banner = FactoryBot.create(:admin_user)
+        user = FactoryBot.create(:user)
+
+        CurrentUser.as(banner) { FactoryBot.create(:ban, user: user, banner: banner, duration: 1) }
+
+        assert_equal(true, user.reload.is_banned)
+        travel_to(2.days.from_now) { DailyMaintenance.new.run }
+        assert_equal(false, user.reload.is_banned)
+      end
+    end
   end
 end


### PR DESCRIPTION
Fixes #3837. Adds a daily maintenance job that clears the `is_banned` flag for users who are no longer banned.