### PR TITLE
Refactor searching text attributes

### DIFF
--- a/app/models/ban.rb
+++ b/app/models/ban.rb
@@ -44,9 +44,7 @@ class Ban < ApplicationRecord
       q = q.where("user_id = ?", params[:user_id].to_i)
     end
 
-    if params[:reason_matches].present?
-      q = q.reason_matches(params[:reason_matches])
-    end
+    q = q.attribute_matches(:reason, params[:reason_matches])
 
     q = q.expired if params[:expired].to_s.truthy?
     q = q.unexpired if params[:expired].to_s.falsy?

--- a/app/models/bulk_update_request.rb
+++ b/app/models/bulk_update_request.rb
@@ -58,6 +58,9 @@ class BulkUpdateRequest < ApplicationRecord
         q = q.where(status: params[:status].split(","))
       end
 
+      q = q.attribute_matches(:title, params[:title_matches])
+      q = q.attribute_matches(:script, params[:script_matches])
+
       params[:order] ||= "status_desc"
       case params[:order]
       when "id_desc"

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -27,14 +27,6 @@ class Comment < ApplicationRecord
       reorder("comments.id desc").limit(6)
     end
 
-    def body_matches(query)
-      if query =~ /\*/ && CurrentUser.user.is_builder?
-        where("body ILIKE ? ESCAPE E'\\\\'", query.to_escaped_for_sql_like)
-      else
-        where("body_index @@ plainto_tsquery(?)", query.to_escaped_for_tsquery_split).order("comments.id DESC")
-      end
-    end
-
     def hidden(user)
       if user.is_moderator?
         where("(score < ? and is_sticky = false) or is_deleted = true", user.comment_threshold)
@@ -74,9 +66,7 @@ class Comment < ApplicationRecord
     def search(params)
       q = super
 
-      if params[:body_matches].present?
-        q = q.body_matches(params[:body_matches])
-      end
+      q = q.attribute_matches(:body, params[:body_matches], index_column: :body_index)
 
       if params[:post_id].present?
         q = q.where("post_id in (?)", params[:post_id].split(",").map(&:to_i))

--- a/app/models/forum_topic.rb
+++ b/app/models/forum_topic.rb
@@ -51,14 +51,6 @@ class ForumTopic < ApplicationRecord
   end
 
   module SearchMethods
-    def title_matches(title)
-      if title =~ /\*/ && CurrentUser.user.is_builder?
-        where("title ILIKE ? ESCAPE E'\\\\'", title.to_escaped_for_sql_like)
-      else
-        where("text_index @@ plainto_tsquery(E?)", title.to_escaped_for_tsquery_split)
-      end
-    end
-
     def active
       where("is_deleted = false")
     end
@@ -83,9 +75,7 @@ class ForumTopic < ApplicationRecord
         q = q.where("min_level >= ?", MIN_LEVELS[:Moderator])
       end
 
-      if params[:title_matches].present?
-        q = q.title_matches(params[:title_matches])
-      end
+      q = q.attribute_matches(:title, params[:title_matches], index_column: :text_index)
 
       if params[:category_id].present?
         q = q.for_category_id(params[:category_id])

--- a/app/models/mod_action.rb
+++ b/app/models/mod_action.rb
@@ -56,6 +56,8 @@ class ModAction < ApplicationRecord
   def self.search(params)
     q = super
 
+    q = q.attribute_matches(:description, params[:description_matches])
+
     if params[:creator_id].present?
       q = q.where("creator_id = ?", params[:creator_id].to_i)
     end

--- a/app/models/note_version.rb
+++ b/app/models/note_version.rb
@@ -18,6 +18,7 @@ class NoteVersion < ApplicationRecord
     end
 
     q = q.attribute_matches(:is_active, params[:is_active])
+    q = q.attribute_matches(:body, params[:body_matches])
 
     q.apply_default_order(params)
   end

--- a/app/models/pool.rb
+++ b/app/models/pool.rb
@@ -58,9 +58,7 @@ class Pool < ApplicationRecord
         q = q.name_matches(params[:name_matches])
       end
 
-      if params[:description_matches].present?
-        q = q.where("lower(pools.description) like ? escape E'\\\\'", "%" + params[:description_matches].mb_chars.downcase.to_escaped_for_sql_like + "%")
-      end
+      q = q.attribute_matches(:description, params[:description_matches])
 
       if params[:creator_name].present?
         q = q.where("pools.creator_id = (select _.id from users _ where lower(_.name) = ?)", params[:creator_name].tr(" ", "_").mb_chars.downcase)

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -27,6 +27,13 @@ class PostReplacement < ApplicationRecord
       def search(params = {})
         q = super
 
+        q = q.attribute_matches(:replacement_url, params[:replacement_url])
+        q = q.attribute_matches(:original_url, params[:original_url])
+        q = q.attribute_matches(:file_ext_was, params[:file_ext_was])
+        q = q.attribute_matches(:file_ext, params[:file_ext])
+        q = q.attribute_matches(:md5_was, params[:md5_was])
+        q = q.attribute_matches(:md5, params[:md5])
+
         if params[:creator_id].present?
           q = q.where(creator_id: params[:creator_id].split(",").map(&:to_i))
         end

--- a/app/models/user_feedback.rb
+++ b/app/models/user_feedback.rb
@@ -48,6 +48,8 @@ class UserFeedback < ApplicationRecord
     def search(params)
       q = super
 
+      q = q.attribute_matches(:body, params[:body_matches])
+
       if params[:user_id].present?
         q = q.for_user(params[:user_id].to_i)
       end

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -20,6 +20,8 @@ class WikiPageVersion < ApplicationRecord
         q = q.where("wiki_page_id = ?", params[:wiki_page_id].to_i)
       end
 
+      q = q.attribute_matches(:title, params[:title])
+      q = q.attribute_matches(:body, params[:body])
       q = q.attribute_matches(:is_locked, params[:is_locked])
       q = q.attribute_matches(:is_deleted, params[:is_deleted])
 

--- a/app/views/bulk_update_requests/_search.html.erb
+++ b/app/views/bulk_update_requests/_search.html.erb
@@ -1,6 +1,8 @@
 <%= simple_form_for(:search, url: bulk_update_requests_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :user_name, label: "Creator", input_html: { value: params[:search][:user_name] } %>
   <%= f.input :approver_name, label: "Approver", input_html: { value: params[:search][:approver_name] } %>
+  <%= f.input :title_matches, label: "Title", input_html: { value: params[:search][:title_matches] } %>
+  <%= f.input :script_matches, label: "Script", input_html: { value: params[:search][:script_matches] } %>
   <%= f.input :status, label: "Status", collection: %w[pending approved rejected], include_blank: true, selected: params[:search][:status] %>
   <%= f.input :order, collection: [%w[Status status_desc], %w[Last\ updated updated_at_desc], %w[Newest id_desc], %w[Oldest id_asc]], include_blank: false, selected: params[:search][:order] %>
   <%= f.submit "Search" %>

--- a/app/views/mod_actions/_search.html.erb
+++ b/app/views/mod_actions/_search.html.erb
@@ -1,5 +1,6 @@
 <%= simple_form_for(:search, method: :get, url: mod_actions_path, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
   <%= f.input :creator_name, label: "Creator", input_html: { value: params[:search][:creator_name] } %>
+  <%= f.input :description_matches, label: "Description" %>
   <%= f.input :category, label: "Category", collection: ModAction.categories.map {|k,v| [k.capitalize.tr("_"," "), v]}, include_blank: true,selected: params[:search][:category] %>
   <%= f.submit "Search" %>
 <% end %>

--- a/app/views/user_feedbacks/search.html.erb
+++ b/app/views/user_feedbacks/search.html.erb
@@ -7,6 +7,8 @@
 
       <%= search_field "creator_name", :label => "Creator" %>
 
+      <%= search_field "body_matches", :label => "Message" %>
+
       <div class="input">
         <label for="search_category">Category</label>
         <%= select "search", "category", %w(positive negative neutral), :include_blank => true %>

--- a/test/unit/comment_test.rb
+++ b/test/unit/comment_test.rb
@@ -218,7 +218,7 @@ class CommentTest < ActiveSupport::TestCase
         c2 = FactoryBot.create(:comment, :body => "aaa ddd")
         c3 = FactoryBot.create(:comment, :body => "eee")
 
-        matches = Comment.body_matches("aaa")
+        matches = Comment.search(body_matches: "aaa")
         assert_equal(2, matches.count)
         assert_equal(c2.id, matches.all[0].id)
         assert_equal(c1.id, matches.all[1].id)

--- a/test/unit/dmail_test.rb
+++ b/test/unit/dmail_test.rb
@@ -103,10 +103,10 @@ class DmailTest < ActiveSupport::TestCase
       should "return results based on title contents" do
         dmail = FactoryBot.create(:dmail, :title => "xxx", :owner => @user)
 
-        matches = Dmail.search(title_matches: "x")
+        matches = Dmail.search(title_matches: "x*")
         assert_equal([dmail.id], matches.map(&:id))
 
-        matches = Dmail.search(title_matches: "X")
+        matches = Dmail.search(title_matches: "X*")
         assert_equal([dmail.id], matches.map(&:id))
 
         matches = Dmail.search(message_matches: "xxx")
@@ -118,9 +118,9 @@ class DmailTest < ActiveSupport::TestCase
 
       should "return results based on body contents" do
         dmail = FactoryBot.create(:dmail, :body => "xxx", :owner => @user)
-        matches = Dmail.search_message("xxx")
+        matches = Dmail.search(message_matches: "xxx")
         assert(matches.any?)
-        matches = Dmail.search_message("aaa")
+        matches = Dmail.search(message_matches: "aaa")
         assert(matches.empty?)
       end
     end

--- a/test/unit/forum_post_test.rb
+++ b/test/unit/forum_post_test.rb
@@ -164,8 +164,8 @@ class ForumPostTest < ActiveSupport::TestCase
 
     should "be searchable by body content" do
       post = FactoryBot.create(:forum_post, :topic_id => @topic.id, :body => "xxx")
-      assert_equal(1, ForumPost.body_matches("xxx").count)
-      assert_equal(0, ForumPost.body_matches("aaa").count)
+      assert_equal(1, ForumPost.search(body_matches: "xxx").count)
+      assert_equal(0, ForumPost.search(body_matches: "aaa").count)
     end
 
     should "initialize its creator" do

--- a/test/unit/note_test.rb
+++ b/test/unit/note_test.rb
@@ -196,13 +196,13 @@ class NoteTest < ActiveSupport::TestCase
 
       context "where the body contains the string 'aaa'" do
         should "return a hit" do
-          assert_equal(1, Note.body_matches("aaa").count)
+          assert_equal(1, Note.search(body_matches: "aaa").count)
         end
       end
 
       context "where the body contains the string 'bbb'" do
         should "return no hits" do
-          assert_equal(0, Note.body_matches("bbb").count)
+          assert_equal(0, Note.search(body_matches: "bbb").count)
         end
       end
     end


### PR DESCRIPTION
This standardizes how text attributes are searched inside model `#search` methods:

* Allow using `ApplicationRecord#attribute_matches` to search text attributes, and standardize models on using this instead of duplicating code.

* Remove restrictions that limited wildcard searches to Builders only in various places. I think originally this was restricted because of performance concerns, but these searches aren't necessarily always slow, and even if they are, they'll just timeout like anything else. There were also inconsistencies in which things were Builder-only and which weren't.

Also allows searching various fields that weren't previously searchable:

* Wiki page versions: title, body
* User feedbacks: body
* Post replacements: original url, replacement url, file ext, md5
* Note versions: body
* Bulk update requests: title, script
* Mod actions: description (fixes #3857)