### PR TITLE
Fix #3864: DeviantArt fetch source data failure

### DIFF
--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -15,14 +15,21 @@ module Sources
       should "work" do
         assert_equal(["http://origin-orig.deviantart.net/d533/f/2014/004/8/d/holiday_elincia_by_aeror404-d70rm0s.jpg"], @site.image_urls)
         assert_equal(@site.image_url, @site.canonical_url)
+        assert_equal("aeror404", @site.artist_name)
+        assert_equal("https://www.deviantart.com/aeror404", @site.profile_url)
       end
     end
 
     context "The source for a deleted DeviantArt image URL" do
       should "work" do
         @site = Sources::Strategies.find("https://pre00.deviantart.net/423b/th/pre/i/2017/281/e/0/mindflayer_girl01_by_nickbeja-dbpxdt8.png")
+        @artist = FactoryBot.create(:artist, name: "nickbeja", url_string: "https://nickbeja.deviantart.com")
+
         assert_equal("https://pre00.deviantart.net/423b/th/pre/i/2017/281/e/0/mindflayer_girl01_by_nickbeja-dbpxdt8.png", @site.image_url)
         assert_equal(@site.image_url, @site.canonical_url)
+        assert_equal("nickbeja", @site.artist_name)
+        assert_equal("https://www.deviantart.com/nickbeja", @site.profile_url)
+        assert_equal([@artist], @site.artists)
         assert_nothing_raised { @site.to_h }
       end
     end
@@ -79,6 +86,7 @@ module Sources
       setup do
         @url = "http://fc08.deviantart.net/files/f/2007/120/c/9/cool_like_me_by_47ness.jpg"
         @ref = "https://47ness.deviantart.com/art/Cool-Like-Me-54339311"
+        @artist = FactoryBot.create(:artist, name: "47ness", url_string: "https://www.deviantart.com/47ness")
       end
 
       context "without a referer" do
@@ -90,6 +98,7 @@ module Sources
           assert_equal("https://www.deviantart.com/47ness", @site.profile_url)
           assert_equal("", @site.page_url)
           assert_equal(@site.image_url, @site.canonical_url)
+          assert_equal([@artist], @site.artists)
           assert_nothing_raised { @site.to_h }
         end
       end
@@ -103,6 +112,7 @@ module Sources
           assert_equal("https://www.deviantart.com/47ness", @site.profile_url)
           assert_equal("https://www.deviantart.com/47ness/art/Cool-Like-Me-54339311", @site.page_url)
           assert_equal(@site.page_url, @site.canonical_url)
+          assert_equal([@artist], @site.artists)
           assert_nothing_raised { @site.to_h }
         end
       end
@@ -112,6 +122,7 @@ module Sources
       setup do
         @url = "http://pre06.deviantart.net/8497/th/pre/f/2009/173/c/c/cc9686111dcffffffb5fcfaf0cf069fb.jpg"
         @ref = "https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896"
+        @artist = FactoryBot.create(:artist, name: "edsfox", url_string: "https://edsfox.deviantart.com")
       end
 
       context "without a referer" do
@@ -123,6 +134,7 @@ module Sources
           assert_equal("", @site.profile_url)
           assert_equal("", @site.page_url)
           assert_equal(@site.image_url, @site.canonical_url)
+          assert_equal([], @site.artists)
           assert_nothing_raised { @site.to_h }
         end
       end
@@ -136,6 +148,7 @@ module Sources
           assert_equal("https://www.deviantart.com/edsfox", @site.profile_url)
           assert_equal("https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896", @site.page_url)
           assert_equal(@site.page_url, @site.canonical_url)
+          assert_equal([@artist], @site.artists)
           assert_nothing_raised { @site.to_h }
         end
       end

--- a/test/unit/sources/deviantart_test.rb
+++ b/test/unit/sources/deviantart_test.rb
@@ -14,6 +14,7 @@ module Sources
 
       should "work" do
         assert_equal(["http://origin-orig.deviantart.net/d533/f/2014/004/8/d/holiday_elincia_by_aeror404-d70rm0s.jpg"], @site.image_urls)
+        assert_equal(@site.image_url, @site.canonical_url)
       end
     end
 
@@ -21,13 +22,17 @@ module Sources
       should "work" do
         @site = Sources::Strategies.find("https://pre00.deviantart.net/423b/th/pre/i/2017/281/e/0/mindflayer_girl01_by_nickbeja-dbpxdt8.png")
         assert_equal("https://pre00.deviantart.net/423b/th/pre/i/2017/281/e/0/mindflayer_girl01_by_nickbeja-dbpxdt8.png", @site.image_url)
+        assert_equal(@site.image_url, @site.canonical_url)
+        assert_nothing_raised { @site.to_h }
       end
     end
 
     context "The source for a download-disabled DeviantArt artwork page" do
       should "get the image url" do
         @site = Sources::Strategies.find("https://noizave.deviantart.com/art/test-no-download-697415967")
+
         assert_equal(["https://img00.deviantart.net/56ee/i/2017/219/2/3/test__no_download_by_noizave-dbj81lr.jpg"], @site.image_urls)
+        assert_equal(@site.image_url, @site.canonical_url)
       end
     end
 
@@ -38,6 +43,7 @@ module Sources
         assert_equal("hideyoshi", @site.artist_name)
         assert_equal("https://www.deviantart.com/hideyoshi", @site.profile_url)
         assert_equal("http://origin-orig.deviantart.net/9e1f/f/2016/265/3/5/legend_of_galactic_heroes_by_hideyoshi-daihpha.jpg", @site.image_url)
+        assert_equal(@site.image_url, @site.canonical_url)
       end
     end
 
@@ -45,9 +51,11 @@ module Sources
       should "work" do
         @site = Sources::Strategies.find("http://origin-orig.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png")
 
+        assert_equal(@site.url, @site.image_url)
+        assert_equal("https://www.deviantart.com/noizave/art/test-post-please-ignore-685436408", @site.page_url)
+        assert_equal(@site.image_url, @site.canonical_url)
         assert_equal("noizave", @site.artist_name)
         assert_equal("https://www.deviantart.com/noizave", @site.profile_url)
-        assert_equal("http://origin-orig.deviantart.net/7b5b/f/2017/160/c/5/test_post_please_ignore_by_noizave-dbc3a48.png", @site.image_url)
         assert_equal(%w[bar baz foo], @site.tags.map(&:first))
         assert_nothing_raised { @site.to_h }
       end
@@ -64,6 +72,72 @@ module Sources
       should "return the full size image url" do
         @site = Sources::Strategies.find("http://th00.deviantart.net/fs71/PRE/f/2014/065/3/b/goruto_by_xyelkiltrox-d797tit.png")
         assert_equal("http://origin-orig.deviantart.net/0f1e/f/2014/065/3/b/goruto_by_xyelkiltrox-d797tit.png", @site.image_url)
+      end
+    end
+
+    context "The source for a *.deviantart.net/*/:title_by_:artist.jpg url" do
+      setup do
+        @url = "http://fc08.deviantart.net/files/f/2007/120/c/9/cool_like_me_by_47ness.jpg"
+        @ref = "https://47ness.deviantart.com/art/Cool-Like-Me-54339311"
+      end
+
+      context "without a referer" do
+        should "work" do
+          @site = Sources::Strategies.find(@url)
+
+          assert_equal(@site.url, @site.image_url)
+          assert_equal("47ness", @site.artist_name)
+          assert_equal("https://www.deviantart.com/47ness", @site.profile_url)
+          assert_equal("", @site.page_url)
+          assert_equal(@site.image_url, @site.canonical_url)
+          assert_nothing_raised { @site.to_h }
+        end
+      end
+
+      context "with a referer" do
+        should "work" do
+          @site = Sources::Strategies.find(@url, @ref)
+
+          assert_equal("http://origin-orig.deviantart.net/a418/f/2007/120/c/9/cool_like_me_by_47ness.jpg", @site.image_url)
+          assert_equal("47ness", @site.artist_name)
+          assert_equal("https://www.deviantart.com/47ness", @site.profile_url)
+          assert_equal("https://www.deviantart.com/47ness/art/Cool-Like-Me-54339311", @site.page_url)
+          assert_equal(@site.page_url, @site.canonical_url)
+          assert_nothing_raised { @site.to_h }
+        end
+      end
+    end
+
+    context "The source for a *.deviantart.net/*/:hash.jpg url" do
+      setup do
+        @url = "http://pre06.deviantart.net/8497/th/pre/f/2009/173/c/c/cc9686111dcffffffb5fcfaf0cf069fb.jpg"
+        @ref = "https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896"
+      end
+
+      context "without a referer" do
+        should "work" do
+          @site = Sources::Strategies.find(@url)
+
+          assert_equal(@url, @site.image_url)
+          assert_equal("", @site.artist_name)
+          assert_equal("", @site.profile_url)
+          assert_equal("", @site.page_url)
+          assert_equal(@site.image_url, @site.canonical_url)
+          assert_nothing_raised { @site.to_h }
+        end
+      end
+
+      context "with a referer" do
+        should "work" do
+          @site = Sources::Strategies.find(@url, @ref)
+
+          assert_equal("http://origin-orig.deviantart.net/66c1/f/2009/173/c/c/cc9686111dcffffffb5fcfaf0cf069fb.jpg", @site.image_url)
+          assert_equal("edsfox", @site.artist_name)
+          assert_equal("https://www.deviantart.com/edsfox", @site.profile_url)
+          assert_equal("https://www.deviantart.com/edsfox/art/Silverhawks-Quicksilver-126872896", @site.page_url)
+          assert_equal(@site.page_url, @site.canonical_url)
+          assert_nothing_raised { @site.to_h }
+        end
       end
     end
 


### PR DESCRIPTION
Fixes #3864:

* Fixes the DeviantArt strategy erroring out in certain cases where we can't do the API call because the image URL doesn't contain the deviation ID.
* Fixes the artist finder to still work even if we can't perform the API call, if the URL contains the artist name.
* Fixes `canonical_url` to be the image URL, if the URL contains the deviation ID, otherwise use the page URL.

