### PR TITLE
Fix #3873: Batch bookmarklet for tumblr reports wrong posts as already uploaded

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -4,6 +4,7 @@ class UploadsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:preprocess]
 
   def new
+    @source = Sources::Strategies.find(params[:url], params[:ref]) if params[:url].present?
     @upload_notice_wiki = WikiPage.titled(Danbooru.config.upload_notice_wiki_page).first
     @upload, @remote_size = UploadService::ControllerHelper.prepare(
       url: params[:url], ref: params[:ref]
@@ -13,7 +14,7 @@ class UploadsController < ApplicationController
 
   def batch
     @url = params.dig(:batch, :url) || params[:url]
-    @source = UploadService::ControllerHelper.batch(@url, params[:ref])
+    @source = Sources::Strategies.find(@url, params[:ref]) if @url.present?
     respond_with(@source)
   end
 

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -5,7 +5,7 @@ class UploadsController < ApplicationController
 
   def new
     @upload_notice_wiki = WikiPage.titled(Danbooru.config.upload_notice_wiki_page).first
-    @upload, @post, @source, @remote_size = UploadService::ControllerHelper.prepare(
+    @upload, @remote_size = UploadService::ControllerHelper.prepare(
       url: params[:url], ref: params[:ref]
     )
     respond_with(@upload)
@@ -43,7 +43,7 @@ class UploadsController < ApplicationController
   end
 
   def preprocess
-    @upload, @post, @source, @remote_size = UploadService::ControllerHelper.prepare(
+    @upload, @remote_size = UploadService::ControllerHelper.prepare(
       url: upload_params[:source], file: upload_params[:file], ref: upload_params[:referer_url]
     )
     render body: nil

--- a/app/javascript/src/styles/specific/posts.scss
+++ b/app/javascript/src/styles/specific/posts.scss
@@ -13,12 +13,14 @@ article.post-preview {
     @include inline-block;
   }
 
-  &.pooled {
-    height: 214px;
+  &.captioned {
+    height: auto;
+    vertical-align: text-top;
   }
 
   .desc {
    font-size: 80%;
+   margin-bottom: 0;
   }
 
   img {
@@ -31,19 +33,6 @@ article.post-preview {
 
   &[data-has-sound=true]:before {
     @include sound-icon;
-  }
-}
-
-#iqdb-similar {
-  overflow: hidden;
-
-  .post-preview {
-    height: auto;
-    margin-bottom: 0;
-  }
-
-  p {
-    margin-bottom: 0;
   }
 }
 

--- a/app/javascript/src/styles/specific/uploads.scss
+++ b/app/javascript/src/styles/specific/uploads.scss
@@ -9,8 +9,17 @@ div#c-uploads {
       margin-bottom: 2em;
     }
 
-    ul#links {
+    ul#upload-image-metadata, ul#links {
       margin-bottom: 1em;
+    }
+
+    div#related-posts-by-source, div#iqdb-similar {
+      display: inline-block;
+
+      .hint {
+        white-space: nowrap;
+        max-width: 100%;
+      }
     }
 
     label[for="upload_as_pending"] {

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -179,6 +179,18 @@ module Sources
         return {}
       end
 
+      # A search query that should return any posts that were previously
+      # uploaded from the same source. These may be duplicates, or they may be
+      # other posts from the same gallery.
+      def related_posts_search_query
+        "source:#{canonical_url}"
+      end
+
+      def related_posts(limit = 5)
+        CurrentUser.as_system { Post.tag_match(related_posts_search_query).paginate(1, limit: limit) }
+      end
+      memoize :related_posts
+
       def to_h
         return {
           :artist_name => artist_name,

--- a/app/logical/sources/strategies/pixiv.rb
+++ b/app/logical/sources/strategies/pixiv.rb
@@ -153,6 +153,10 @@ module Sources
         translated_tags
       end
 
+      def related_posts_search_query
+        illust_id.present? ? "pixiv:#{illust_id}" : "source:#{canonical_url}"
+      end
+
     public
 
       def image_urls_sub

--- a/app/logical/upload_service/controller_helper.rb
+++ b/app/logical/upload_service/controller_helper.rb
@@ -23,11 +23,5 @@ class UploadService
 
       return [upload]
     end
-
-    def self.batch(url, ref = nil)
-      if url
-        return Sources::Strategies.find(url, ref)
-      end
-    end
   end
 end

--- a/app/logical/upload_service/controller_helper.rb
+++ b/app/logical/upload_service/controller_helper.rb
@@ -4,14 +4,8 @@ class UploadService
       upload = Upload.new
 
       if Utils.is_downloadable?(url) && file.nil?
-        strategy = Sources::Strategies.find(url, ref)
-        post = Post.where("SourcePattern(lower(posts.source)) IN (?)", [url, strategy.canonical_url]).first
-
-        if post.nil?
-          # this gets called from UploadsController#new so we need
-          # to preprocess async
-          Preprocessor.new(source: url, referer_url: ref).delay(priority: -1, queue: "default").delayed_start(CurrentUser.id)
-        end
+        # this gets called from UploadsController#new so we need to preprocess async
+        Preprocessor.new(source: url, referer_url: ref).delay(priority: -1, queue: "default").delayed_start(CurrentUser.id)
 
         begin
           download = Downloads::File.new(url, ref)
@@ -19,7 +13,7 @@ class UploadService
         rescue Exception
         end
 
-        return [upload, post, strategy, remote_size]
+        return [upload, remote_size]
       end
 
       if file

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -27,7 +27,7 @@ class PostPresenter < Presenter
       cropped_src = post.preview_file_url
     end
 
-    html =  %{<article itemscope itemtype="http://schema.org/ImageObject" id="post_#{post.id}" class="#{preview_class(post, options[:pool], options)}" #{data_attributes(post)}>}
+    html =  %{<article itemscope itemtype="http://schema.org/ImageObject" id="post_#{post.id}" class="#{preview_class(post, options)}" #{data_attributes(post)}>}
     if options[:tags].present? && !CurrentUser.is_anonymous?
       tag_param = "?tags=#{CGI::escape(options[:tags])}"
     elsif options[:pool_id] || options[:pool]
@@ -72,10 +72,10 @@ class PostPresenter < Presenter
     html.html_safe
   end
 
-  def self.preview_class(post, description = nil, options = {})
+  def self.preview_class(post, options = {})
     klass = "post-preview"
     # klass << " large-cropped" if post.has_cropped? && options[:show_cropped]
-    klass << " pooled" if description
+    klass << " captioned" if options.values_at(:pooled, :size, :similarity).any?(&:present?)
     klass << " post-status-pending" if post.is_pending?
     klass << " post-status-flagged" if post.is_flagged?
     klass << " post-status-deleted" if post.is_deleted?

--- a/app/views/iqdb_queries/_matches.html.erb
+++ b/app/views/iqdb_queries/_matches.html.erb
@@ -1,9 +1,11 @@
 <% if @matches.present? %>
-  <h3>Similar</h3>
+  <h3>Similar Posts</h3>
+  <p class="hint">Found <%= pluralize(@matches.length, "similar post") %>:</p>
+
   <% @matches.each do |match| %>
     <%= PostPresenter.preview(match["post"], :tags => "status:any", :similarity => match["score"], :size => true) %>
   <% end %>
 <% else %>
-  <h3>Similar</h3>
-  <p>No matches found</p>
+  <h3>Similar Posts</h3>
+  <p class="hint">No similar posts found.</p>
 <% end %>

--- a/app/views/sources/_info.html.erb
+++ b/app/views/sources/_info.html.erb
@@ -1,5 +1,3 @@
-<%# source %>
-
 <div id="source-info">
   <p><%= link_to "Fetch source data", source_path(:format => "json"), :id => "fetch-data-manual" %></p>
   <p><%= content_tag "span", "Loading source data...", :id => "loading-data", :style => "display: none;" %></p>

--- a/app/views/uploads/_image.html.erb
+++ b/app/views/uploads/_image.html.erb
@@ -5,7 +5,7 @@
     <%= image_tag(@source.image_url, :title => "Preview", :id => "image") %>
   <% end %>
 
-  <ul>
+  <ul id="upload-image-metadata">
     <% if @remote_size %>
       <li><strong>Size:</strong> <%= number_to_human_size(@remote_size) %></li>
     <% end %>

--- a/app/views/uploads/_post.html.erb
+++ b/app/views/uploads/_post.html.erb
@@ -1,6 +1,0 @@
-<%# post %>
-<% if post %>
-  <h2 style="margin-bottom: 1em;">
-    This post was probably already uploaded (<%= link_to "post ##{post.id}", post_path(post), :target => "_blank" %>)
-  </h2>
-<% end %>

--- a/app/views/uploads/_related_posts.html.erb
+++ b/app/views/uploads/_related_posts.html.erb
@@ -1,0 +1,27 @@
+<%# source %>
+
+<% if source.present? && source.related_posts.present? %>
+  <div id="related-posts-by-source">
+    <h3>Related Posts</h3>
+
+    <p class="hint">
+      Found <%= link_to pluralize(source.related_posts.total_count, "other post"), posts_path(tags: source.related_posts_search_query) %> from the same source:
+    </p>
+
+    <div>
+      <% source.related_posts.each do |post| %>
+        <%= PostPresenter.preview(post, show_deleted: true, size: true) %>
+      <% end %>
+    </div>
+  </div>
+<% end %>
+
+<% if Danbooru.config.iqdbs_server %>
+  <% if params[:url] %>
+    <div class="input" id="iqdb-similar">
+      <p><em>Loading similar...</em></p>
+    </div>
+  <% else %>
+    <div class="input" id="iqdb-similar" style="display: none;"></div>
+  <% end %>
+<% end %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -12,8 +12,7 @@
       <% end %>
 
       <%= render "image" %>
-      <%= render "post", :post => @post %>
-      <%= render "sources/info", :source => @source %>
+      <%= render "sources/info" %>
 
       <div id="client-errors" class="error-messages ui-state-error ui-corner-all" style="display:none"></div>
 

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -12,6 +12,7 @@
       <% end %>
 
       <%= render "image" %>
+      <%= render "related_posts", source: @source %>
       <%= render "sources/info" %>
 
       <div id="client-errors" class="error-messages ui-state-error ui-corner-all" style="display:none"></div>
@@ -89,16 +90,6 @@
             </div>
           </div>
         </div>
-
-        <% if Danbooru.config.iqdbs_server %>
-          <% if params[:url] %>
-            <div class="input" id="iqdb-similar">
-              <p><em>Loading similar...</em></p>
-            </div>
-          <% else %>
-            <div class="input" id="iqdb-similar" style="display: none;"></div>
-          <% end %>
-        <% end %>
 
         <div class="input">
           <div>


### PR DESCRIPTION
Should fix #3873. This replaces the `This post has probably already been uploaded` message with a `Related Posts` section, showing the actual thumbnails of other posts uploaded from the same source. In other words, it shows which other images were previously uploaded from the same Twitter/Tumblr/Pixiv gallery:

![image](https://user-images.githubusercontent.com/8430473/45193924-40252180-b216-11e8-9f02-3ad9de13666e.png)
