### PR TITLE
Fix #3439: Identify external links in DText.

### DIFF
--- a/app/javascript/src/styles/common/dtext.scss
+++ b/app/javascript/src/styles/common/dtext.scss
@@ -87,6 +87,18 @@ div.prose {
       margin-bottom: 0;
     }
   }
+
+  // https://fontawesome.com/how-to-use/on-the-web/advanced/css-pseudo-elements
+  a.dtext-external-link::after {
+    display: none;
+    font: 900 1em "Font Awesome 5 Free";
+    content: "\f35d"; // https://fontawesome.com/icons/external-link-alt?style=solid
+  }
+
+  a.dtext-external-link svg {
+    width: 0.75em;
+    padding-left: 0.25em;
+  }
 }
 
 div.dtext-preview {

--- a/app/views/layouts/default.html.erb
+++ b/app/views/layouts/default.html.erb
@@ -70,7 +70,7 @@
     "url" : "<%= root_url %>"
   }
   </script>
-  <script defer src="https://use.fontawesome.com/releases/v5.0.10/js/all.js" integrity="sha384-slN8GvtUJGnv6ca26v8EzVaR9DC58QEwsIk9q1QXdCU8Yu8ck/tL/5szYlBbqmS+" crossorigin="anonymous"></script>
+  <script defer data-search-pseudo-elements src="https://use.fontawesome.com/releases/v5.3.1/js/all.js" integrity="sha384-kW+oWsYx3YpxvjtZjFXqazFpA7UP/MbiY4jvs+RWZo2+N94PFZ36T6TFkc9O3qoB" crossorigin="anonymous"></script>
   <script>
     if (typeof window.Danbooru !== "object") {
       window.Danbooru = {};


### PR DESCRIPTION
Fixes #3439. Adds an external link icon to offsite links in dtext:

![image](https://user-images.githubusercontent.com/8430473/45384914-07e66000-b5d5-11e8-8cb3-e8e47a1c938b.png)

Also upgrades Font Awesome to 5.3.1 (this was necessary for `data-search-pseudo-elements`, see [here](https://fontawesome.com/how-to-use/on-the-web/advanced/css-pseudo-elements)).