### PR TITLE
Cleanup artist finder

### DIFF
--- a/app/controllers/artists_controller.rb
+++ b/app/controllers/artists_controller.rb
@@ -92,20 +92,6 @@ class ArtistsController < ApplicationController
     end
   end
 
-  def finder
-    @artists = Artist.find_artists(params[:url], params[:referer_url])
-
-    respond_with(@artists) do |format|
-      format.xml do
-        render :xml => @artists.to_xml(:include => [:sorted_urls], :root => "artists")
-      end
-      format.json do
-        render :json => @artists.to_json(:include => [:sorted_urls])
-        expires_in params[:expiry].to_i.days if params[:expiry]
-      end
-    end
-  end
-
 private
 
   def load_artist

--- a/app/javascript/src/javascripts/posts.js.erb
+++ b/app/javascript/src/javascripts/posts.js.erb
@@ -441,7 +441,7 @@ Post.initialize_post_sections = function() {
       $("#share").hide();
       $("#post_tag_string").focus().selectEnd().height($("#post_tag_string")[0].scrollHeight);
       $("#related-tags-button").trigger("click");
-      $("#find-artist-button").trigger("click");
+      $("#fetch-data-manual").trigger("click");
       $("#recommended").hide();
     } else if (e.target.hash === "#recommended") {
       $("#comments").hide();

--- a/app/javascript/src/javascripts/related_tag.js.erb
+++ b/app/javascript/src/javascripts/related_tag.js.erb
@@ -1,3 +1,4 @@
+import Upload from './uploads';
 import Utility from './utility';
 import Cookie from './cookie';
 
@@ -16,7 +17,6 @@ RelatedTag.initialize_buttons = function() {
   <% TagCategory.related_button_list.each do |category| %>
     RelatedTag.common_bind("#related-<%= category %>-button", "<%= category %>"); // eslint-disable-line indent
   <% end %>
-  $("#find-artist-button").on("click.danbooru", RelatedTag.find_artist);
 }
 
 RelatedTag.tags_include = function(name) {
@@ -281,21 +281,6 @@ RelatedTag.toggle_tag = function(e) {
   e.preventDefault();
 }
 
-RelatedTag.find_artist = function(e) {
-  $("#artist-tags").html("<em>Loading...</em>");
-  var url = $("#upload_source,#post_source");
-  var referer_url = $("#upload_referer_url");
-  $.get("/artists/finder.json", {"url": url.val(), "referer_url": referer_url.val()}, RelatedTag.process_artist);
-  if (e) {
-    e.preventDefault();
-  }
-}
-
-RelatedTag.process_artist = function(data) {
-  RelatedTag.recent_artists = data;
-  RelatedTag.build_all();
-}
-
 RelatedTag.toggle = function() {
   if ($("#related-tags").is(":visible")) {
     RelatedTag.hide();
@@ -332,7 +317,7 @@ RelatedTag.disable_artist_url = function(e) {
             is_active: false
           }
         }
-      }).done(RelatedTag.find_artist);
+      }).done(Upload.fetch_data_manual);
     }
   });
   return false;

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -129,6 +129,8 @@ module Sources
         normalize_for_artist_finder.present?
       end
 
+      # The url to use for artist finding purposes. This will be stored in the
+      # artist entry. Normally this will be the profile url.
       def normalize_for_artist_finder
         profile_url || url
       end
@@ -139,8 +141,7 @@ module Sources
       end
 
       def artists
-        url = profile_url.presence || image_url.presence
-        Artist.find_artists(url)
+        Artist.url_matches(normalize_for_artist_finder)
       end
 
       def file_url

--- a/app/logical/sources/strategies/twitter.rb
+++ b/app/logical/sources/strategies/twitter.rb
@@ -66,14 +66,6 @@ module Sources::Strategies
       ""
     end
 
-    def artists
-      if profile_url.present?
-        Artist.find_artists(profile_url)
-      else
-        []
-      end
-    end
-
     def artist_name
       return "" if api_response.blank?
       api_response.attrs[:user][:screen_name]

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -69,7 +69,6 @@
     <%= f.label :source %>
     <%= f.text_field :source %>
     <%= button_tag "Similar", :id => "similar-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-    <%= button_tag "Artist", :id => "find-artist-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
   </div>
 
   <% if Danbooru.config.iqdbs_server %>

--- a/app/views/uploads/new.html.erb
+++ b/app/views/uploads/new.html.erb
@@ -43,7 +43,6 @@
           <%= f.label :source %>
           <%= f.text_field :source, :size => 50, :value => params[:url] %>
           <%= button_tag "Similar", :id => "similar-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
-          <%= button_tag "Artist", :id => "find-artist-button", :type => "button", :class => "ui-button ui-widget ui-corner-all sub gradient" %>
           <span class="hint">You can enter a URL to have <%= Danbooru.config.app_name %> automatically download and process it</span>
         </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -79,7 +79,6 @@ Rails.application.routes.draw do
     collection do
       get :show_or_new
       get :banned
-      get :finder
     end
   end
   resources :artist_urls, only: [:update]

--- a/test/functional/artists_controller_test.rb
+++ b/test/functional/artists_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class ArtistsControllerTest < ActionDispatch::IntegrationTest
   def assert_artist_found(expected_artist, source_url = nil)
     if source_url
-      get_auth finder_artists_path(format: "json", url: source_url), @user
+      get_auth artists_path(format: "json", search: { url_matches: source_url }), @user
       if response.body =~ /Net::OpenTimeout/
         skip "Remote connection to #{source_url} failed"
         return
@@ -16,9 +16,7 @@ class ArtistsControllerTest < ActionDispatch::IntegrationTest
   end
 
   def assert_artist_not_found(source_url)
-    tries = 0
-
-    get_auth finder_artists_path(format: "json", url: source_url), @user
+    get_auth artists_path(format: "json", search: { url_matches: source_url }), @user
     if response.body =~ /Net::OpenTimeout/
       skip "Remote connection to #{source_url} failed"
       return

--- a/test/unit/artist_test.rb
+++ b/test/unit/artist_test.rb
@@ -154,9 +154,7 @@ class ArtistTest < ActiveSupport::TestCase
     should "resolve ambiguous urls" do
       bobross = FactoryBot.create(:artist, :name => "bob_ross", :url_string => "http://artists.com/bobross/image.jpg")
       bob = FactoryBot.create(:artist, :name => "bob", :url_string => "http://artists.com/bob/image.jpg")
-      matches = Artist.find_all_by_url("http://artists.com/bob/test.jpg")
-      assert_equal(1, matches.size)
-      assert_equal("bob", matches.first.name)
+      assert_artist_found("bob", "http://artists.com/bob/test.jpg")
     end
 
     should "parse urls" do
@@ -190,7 +188,7 @@ class ArtistTest < ActiveSupport::TestCase
     should "ignore pixiv.net/ and pixiv.net/img/ url matches" do
       a1 = FactoryBot.create(:artist, :name => "yomosaka", :url_string => "http://i2.pixiv.net/img18/img/evazion/14901720.png")
       a2 = FactoryBot.create(:artist, :name => "niwatazumi_bf", :url_string => "http://i2.pixiv.net/img18/img/evazion/14901720_big_p0.png")
-      assert_equal([], Artist.find_all_by_url("http://i2.pixiv.net/img28/img/kyang692/35563903.jpg"))
+      assert_artist_not_found("http://i2.pixiv.net/img28/img/kyang692/35563903.jpg")
     end
 
     should "find matches by url" do
@@ -198,11 +196,11 @@ class ArtistTest < ActiveSupport::TestCase
       a2 = FactoryBot.create(:artist, :name => "subway", :url_string => "http://subway.com/x/test.jpg")
       a3 = FactoryBot.create(:artist, :name => "minko", :url_string => "https://minko.com/x/test.jpg")
 
-      assert_equal(["rembrandt"], Artist.find_all_by_url("http://rembrandt.com/x/test.jpg").map(&:name))
-      assert_equal(["rembrandt"], Artist.find_all_by_url("http://rembrandt.com/x/another.jpg").map(&:name))
-      assert_equal([], Artist.find_all_by_url("http://nonexistent.com/test.jpg").map(&:name))
-      assert_equal(["minko"], Artist.find_all_by_url("https://minko.com/x/test.jpg").map(&:name))
-      assert_equal(["minko"], Artist.find_all_by_url("http://minko.com/x/test.jpg").map(&:name))
+      assert_artist_found("rembrandt", "http://rembrandt.com/x/test.jpg")
+      assert_artist_found("rembrandt", "http://rembrandt.com/x/another.jpg")
+      assert_artist_not_found("http://nonexistent.com/test.jpg")
+      assert_artist_found("minko", "https://minko.com/x/test.jpg")
+      assert_artist_found("minko", "http://minko.com/x/test.jpg")
     end
 
     should "be case-insensitive to domains when finding matches by url" do
@@ -212,7 +210,7 @@ class ArtistTest < ActiveSupport::TestCase
 
     should "not find duplicates" do
       FactoryBot.create(:artist, :name => "warhol", :url_string => "http://warhol.com/x/a/image.jpg\nhttp://warhol.com/x/b/image.jpg")
-      assert_equal(["warhol"], Artist.find_all_by_url("http://warhol.com/x/test.jpg").map(&:name))
+      assert_artist_found("warhol", "http://warhol.com/x/test.jpg")
     end
 
     should "not include duplicate urls" do
@@ -222,7 +220,7 @@ class ArtistTest < ActiveSupport::TestCase
 
     should "hide deleted artists" do
       FactoryBot.create(:artist, :name => "warhol", :url_string => "http://warhol.com/a/image.jpg", :is_active => false)
-      assert_equal([], Artist.find_all_by_url("http://warhol.com/a/image.jpg").map(&:name))
+      assert_artist_not_found("http://warhol.com/a/image.jpg")
     end
 
     context "when finding deviantart artists" do


### PR DESCRIPTION
This cleans up some things in the artist finding code. The main point of this is to replace the ajax call to `/artists/finder.json` with a call to `/sources.js`:

* On posts, automatically trigger "Fetch source data" when clicking the Edit tab, instead of triggering the artist finder button. This way we find both the artist and the translated tags in one ajax call.

* Remove the "Artist" finder button next to the source field. This button isn't necessary given that "Fetch source data" finds the artist itself.

* Remove the /artists/finder.json API endpoint. This is no longer used after removing the "Artist" finder button.

* Clean up the artist finding logic in `Artist#url_matches` such that we only lookup the url once, not multiple times.