### PR TITLE
#3900: Allow to search for urls associated with artists using wildcards

### DIFF
--- a/app/controllers/artist_urls_controller.rb
+++ b/app/controllers/artist_urls_controller.rb
@@ -1,6 +1,14 @@
 class ArtistUrlsController < ApplicationController
-  respond_to :json
-  before_action :member_only
+  respond_to :json, :xml, :html
+  before_action :member_only, except: [:index]
+
+  def index
+    @artist_urls = ArtistUrl.includes(:artist).search(search_params).paginate(params[:page], :limit => params[:limit], :search_count => params[:search])
+    respond_with(@artist_urls) do |format|
+      format.json { render json: @artist_urls.to_json(include: "artist",) }
+      format.xml { render xml: @artist_urls.to_xml(include: "artist", root: "artist-urls") }
+    end
+  end
 
   def update
     @artist_url = ArtistUrl.find(params[:id])

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -9,14 +9,30 @@ class ApplicationRecord < ActiveRecord::Base
         "#{table_name}.#{column_for_attribute(attr).name}"
       end
 
+      def where_like(attr, value)
+        where("#{qualified_column_for(attr)} LIKE ? ESCAPE E'\\\\'", value.to_escaped_for_sql_like)
+      end
+
+      def where_not_like(attr, value)
+        where.not("#{qualified_column_for(attr)} LIKE ? ESCAPE E'\\\\'", value.to_escaped_for_sql_like)
+      end
+
       def where_ilike(attr, value)
         where("lower(#{qualified_column_for(attr)}) LIKE ? ESCAPE E'\\\\'", value.mb_chars.downcase.to_escaped_for_sql_like)
+      end
+
+      def where_not_ilike(attr, value)
+        where.not("lower(#{qualified_column_for(attr)}) LIKE ? ESCAPE E'\\\\'", value.mb_chars.downcase.to_escaped_for_sql_like)
       end
 
       # https://www.postgresql.org/docs/current/static/functions-matching.html#FUNCTIONS-POSIX-REGEXP
       # "(?e)" means force use of ERE syntax; see sections 9.7.3.1 and 9.7.3.4.
       def where_regex(attr, value)
         where("#{qualified_column_for(attr)} ~ ?", "(?e)" + value)
+      end
+
+      def where_not_regex(attr, value)
+        where.not("#{qualified_column_for(attr)} ~ ?", "(?e)" + value)
       end
 
       def attribute_matches(attribute, value, **options)
@@ -66,6 +82,30 @@ class ApplicationRecord < ActiveRecord::Base
           where("#{table_name}.#{index_column} @@ plainto_tsquery(:ts_config, :value)", ts_config: ts_config, value: value)
         else
           where("to_tsvector(:ts_config, #{qualified_column}) @@ plainto_tsquery(:ts_config, :value)", ts_config: ts_config, value: value)
+        end
+      end
+
+      def search_text_attribute(attr, params, **options)
+        if params[attr].present?
+          where(attr => params[attr])
+        elsif params[:"#{attr}_eq"].present?
+          where(attr => params[:"#{attr}_eq"])
+        elsif params[:"#{attr}_not_eq"].present?
+          where.not(attr => params[:"#{attr}_not_eq"])
+        elsif params[:"#{attr}_like"].present?
+          where_like(attr, params[:"#{attr}_like"])
+        elsif params[:"#{attr}_ilike"].present?
+          where_ilike(attr, params[:"#{attr}_ilike"])
+        elsif params[:"#{attr}_not_like"].present?
+          where_not_like(attr, params[:"#{attr}_not_like"])
+        elsif params[:"#{attr}_not_ilike"].present?
+          where_not_ilike(attr, params[:"#{attr}_not_ilike"])
+        elsif params[:"#{attr}_regex"].present?
+          where_regex(attr, params[:"#{attr}_regex"])
+        elsif params[:"#{attr}_not_regex"].present?
+          where_not_regex(attr, params[:"#{attr}_not_regex"])
+        else
+          all
         end
       end
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,6 +5,20 @@ class ApplicationRecord < ActiveRecord::Base
 
   concerning :SearchMethods do
     class_methods do
+      def qualified_column_for(attr)
+        "#{table_name}.#{column_for_attribute(attr).name}"
+      end
+
+      def where_ilike(attr, value)
+        where("lower(#{qualified_column_for(attr)}) LIKE ? ESCAPE E'\\\\'", value.mb_chars.downcase.to_escaped_for_sql_like)
+      end
+
+      # https://www.postgresql.org/docs/current/static/functions-matching.html#FUNCTIONS-POSIX-REGEXP
+      # "(?e)" means force use of ERE syntax; see sections 9.7.3.1 and 9.7.3.4.
+      def where_regex(attr, value)
+        where("#{qualified_column_for(attr)} ~ ?", "(?e)" + value)
+      end
+
       def attribute_matches(attribute, value, **options)
         return all if value.nil?
 

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -53,6 +53,8 @@ class ArtistUrl < ApplicationRecord
 
     q = q.attribute_matches(:artist_id, params[:artist_id])
     q = q.attribute_matches(:is_active, params[:is_active])
+    q = q.search_text_attribute(:url, params)
+    q = q.search_text_attribute(:normalized_url, params)
 
     q = q.artist_matches(params[:artist])
     q = q.url_matches(params[:url_matches])

--- a/app/models/artist_url.rb
+++ b/app/models/artist_url.rb
@@ -45,6 +45,24 @@ class ArtistUrl < ApplicationRecord
     end
   end
 
+  def self.search(params = {})
+    q = super
+
+    q = q.attribute_matches(:artist_id, params[:artist_id])
+    q = q.attribute_matches(:is_active, params[:is_active])
+
+    case params[:order]
+    when /\A(id|artist_id|url|normalized_url|is_active|created_at|updated_at)(?:_(asc|desc))?\z/i
+      dir = $2 || :desc
+      q = q.order($1 => dir).order(id: :desc)
+    else
+      q = q.apply_default_order(params)
+    end
+
+    q
+  end
+
+
   def parse_prefix
     case url
     when /^-/

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,0 +1,44 @@
+<div id="c-artist-urls">
+  <div id="a-index">
+    <%= simple_form_for(:search, url: artist_urls_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+      <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_active] %>
+      <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"]], selected: params[:search][:order] %>
+      <%= f.submit "Search" %>
+    <% end %>
+
+    <table class="striped" width="100%">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Artist Name</th>
+          <th>URL</th>
+          <th>Normalized URL</th>
+          <th>Active?</th>
+          <th>Created</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @artist_urls.each do |artist_url| %>
+          <tr>
+            <%= tag.td artist_url.id %>
+            <%= tag.td link_to(artist_url.artist.name, artist_url.artist) %>
+            <%= tag.td external_link_to(artist_url.url.to_s) %>
+            <%= tag.td external_link_to(artist_url.normalized_url) %>
+            <%= tag.td artist_url.is_active.to_s %>
+            <%= tag.td artist_url.created_at %>
+            <%= tag.td artist_url.updated_at %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+
+    <%= numbered_paginator(@artist_urls) %>
+  </div>
+</div>
+
+<%= render "artists/secondary_links" %>
+
+<% content_for(:page_title) do %>
+  Artist URLs - <%= Danbooru.config.app_name %>
+<% end %>

--- a/app/views/artist_urls/index.html.erb
+++ b/app/views/artist_urls/index.html.erb
@@ -1,6 +1,11 @@
 <div id="c-artist-urls">
   <div id="a-index">
     <%= simple_form_for(:search, url: artist_urls_path, method: :get, defaults: { required: false }, html: { class: "inline-form" }) do |f| %>
+      <%= f.simple_fields_for :artist do |fa| %>
+        <%= fa.input :name, label: "Artist Name", input_html: { value: params.dig(:search, :artist, :name), "data-autocomplete": "artist" } %>
+      <% end %>
+      <%= f.input :url_matches, label: "URL", input_html: { value: params[:search][:url_matches] } %>
+      <%= f.input :normalized_url_matches, label: "Normalized URL", input_html: { value: params[:search][:normalized_url_matches] } %>
       <%= f.input :is_active, label: "Active?", collection: [["Yes", true], ["No", false]], include_blank: true, selected: params[:search][:is_active] %>
       <%= f.input :order, collection: [["ID", "id"], ["Created", "created_at"], ["Updated", "updated_at"]], selected: params[:search][:order] %>
       <%= f.submit "Search" %>

--- a/app/views/artists/_secondary_links.html.erb
+++ b/app/views/artists/_secondary_links.html.erb
@@ -5,6 +5,7 @@
     <%= subnav_link_to "Banned", banned_artists_path %>
     <%= subnav_link_to "New", new_artist_path %>
     <%= subnav_link_to "Recent changes", artist_versions_path %>
+    <%= subnav_link_to "URLs", artist_urls_path %>
     <% if @artist && !@artist.new_record? %>
       <li>|</li>
       <%= subnav_link_to "Posts (#{Post.fast_count(@artist.name)})", posts_path(:tags => @artist.name) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,7 +81,7 @@ Rails.application.routes.draw do
       get :banned
     end
   end
-  resources :artist_urls, only: [:update]
+  resources :artist_urls, only: [:index, :update]
   resources :artist_versions, :only => [:index] do
     collection do
       get :search

--- a/db/migrate/20180916002448_add_trigram_index_to_artist_urls.rb
+++ b/db/migrate/20180916002448_add_trigram_index_to_artist_urls.rb
@@ -1,0 +1,12 @@
+class AddTrigramIndexToArtistUrls < ActiveRecord::Migration[5.2]
+  def change
+    change_table :artist_urls do |t|
+      t.remove_index column: :url, name: :index_artist_urls_on_url
+      t.remove_index column: :url, name: :index_artist_urls_on_url_pattern, opclass: :text_pattern_ops
+      t.remove_index column: :normalized_url, name: :index_artist_urls_on_normalized_url
+
+      t.index :url, name: :index_artist_urls_on_url_trgm, using: :gin, opclass: :gin_trgm_ops
+      t.index :normalized_url, name: :index_artist_urls_on_normalized_url_trgm, using: :gin, opclass: :gin_trgm_ops
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -4945,13 +4945,6 @@ CREATE INDEX index_artist_urls_on_artist_id ON public.artist_urls USING btree (a
 
 
 --
--- Name: index_artist_urls_on_normalized_url; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX index_artist_urls_on_normalized_url ON public.artist_urls USING btree (normalized_url);
-
-
---
 -- Name: index_artist_urls_on_normalized_url_pattern; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -4959,17 +4952,17 @@ CREATE INDEX index_artist_urls_on_normalized_url_pattern ON public.artist_urls U
 
 
 --
--- Name: index_artist_urls_on_url; Type: INDEX; Schema: public; Owner: -
+-- Name: index_artist_urls_on_normalized_url_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_artist_urls_on_url ON public.artist_urls USING btree (url);
+CREATE INDEX index_artist_urls_on_normalized_url_trgm ON public.artist_urls USING gin (normalized_url public.gin_trgm_ops);
 
 
 --
--- Name: index_artist_urls_on_url_pattern; Type: INDEX; Schema: public; Owner: -
+-- Name: index_artist_urls_on_url_trgm; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_artist_urls_on_url_pattern ON public.artist_urls USING btree (url text_pattern_ops);
+CREATE INDEX index_artist_urls_on_url_trgm ON public.artist_urls USING gin (url public.gin_trgm_ops);
 
 
 --
@@ -7532,6 +7525,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180518175154'),
 ('20180804203201'),
 ('20180816230604'),
-('20180912185624');
+('20180912185624'),
+('20180913184128'),
+('20180916002448');
 
 

--- a/test/functional/artist_urls_controller_test.rb
+++ b/test/functional/artist_urls_controller_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+class ArtistUrlsControllerTest < ActionDispatch::IntegrationTest
+  context "The artist urls controller" do
+    context "index page" do
+      should "render" do
+        get artist_urls_path
+        assert_response :success
+      end
+
+      should "render for a complex search" do
+        @artist = FactoryBot.create(:artist, name: "bkub", url_string: "-http://bkub.com")
+
+        get artist_urls_path(search: {
+          artist: { name: "bkub", },
+          url_matches: "*bkub*",
+          is_active: "false",
+          order: "created_at"
+        })
+
+        assert_response :success
+      end
+    end
+  end
+end

--- a/test/unit/artist_url_test.rb
+++ b/test/unit/artist_url_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class ArtistUrlTest < ActiveSupport::TestCase
+  def assert_search_equals(results, conditions)
+    assert_equal(results.map(&:id), subject.search(conditions).map(&:id))
+  end
+
   context "An artist url" do
     setup do
       CurrentUser.user = FactoryBot.create(:user)
@@ -158,6 +162,37 @@ class ArtistUrlTest < ActiveSupport::TestCase
 
       url = FactoryBot.create(:artist_url, url: "https://nijie.info/members.php?id=161703")
       assert_equal("http://nijie.info/members.php?id=161703/", url.normalized_url)
+    end
+
+    context "#search method" do
+      subject { ArtistUrl }
+
+      should "work" do
+        @bkub = FactoryBot.create(:artist, name: "bkub", is_active: true, url_string: "https://bkub.com")
+        @masao = FactoryBot.create(:artist, name: "masao", is_active: false, url_string: "-https://masao.com")
+        @bkub_url = @bkub.urls.first
+        @masao_url = @masao.urls.first
+
+        assert_search_equals([@bkub_url], is_active: true)
+        assert_search_equals([@bkub_url], artist: { name: "bkub" })
+
+        assert_search_equals([@bkub_url], url_matches: "*bkub*")
+        assert_search_equals([@bkub_url], url_matches: "/^https?://bkub\.com$/")
+
+        assert_search_equals([@bkub_url], normalized_url_matches: "*bkub*")
+        assert_search_equals([@bkub_url], normalized_url_matches: "/^https?://bkub\.com/$/")
+        assert_search_equals([@bkub_url], normalized_url_matches: "https://bkub.com")
+
+        assert_search_equals([@bkub_url], url: "https://bkub.com")
+        assert_search_equals([@bkub_url], url_eq: "https://bkub.com")
+        assert_search_equals([@bkub_url], url_not_eq: "https://masao.com")
+        assert_search_equals([@bkub_url], url_like: "*bkub*")
+        assert_search_equals([@bkub_url], url_ilike: "*BKUB*")
+        assert_search_equals([@bkub_url], url_not_like: "*masao*")
+        assert_search_equals([@bkub_url], url_not_ilike: "*MASAO*")
+        assert_search_equals([@bkub_url], url_regex: "bkub")
+        assert_search_equals([@bkub_url], url_not_regex: "masao")
+      end
     end
   end
 end


### PR DESCRIPTION
Partial fix for #3900: 

* Adds an `/artist_urls` index page. This is mainly intended for api use, but there's a basic html page too.

* Adds `search[url_matches]=...` and `search[normalized_url_matches]=...` params on the `/artist_urls` page. These params are overloaded such that if the input looks like `/pixiv/` it does a regex search, otherwise if it looks like `*pixiv*` it does a wildcard search, otherwise it does an artist finder search:

```
# regex search
/artist_urls?search[normalized_url_matches]=/pixiv/

# wildcard search
/artist_urls?search[normalized_url_matches]=*pixiv*

# artist finder search - normalize to the profile url and search for the profile url instead.
/artist_urls?search[normalized_url_matches]=https://www.pixiv.net/member_illust.php%3Fmode=medium%26illust_id=46503128
=> /artist_urls?search[normalized_url_matches]=http://www.pixiv.net/member.php%3Fid=9948/
```

* Adds the following search params:

```
/artist_urls?search[url]=...            # matches exactly
/artist_urls?search[url_eq]=...         # matches exactly
/artist_urls?search[url_not_eq]=...     # does not match exactly
/artist_urls?search[url_like]=...       # matches wildcard (case sensitive)
/artist_urls?search[url_ilike]=...      # matches wildcard (case insensitive)
/artist_urls?search[url_not_like]=...   # does not match wildcard (case sensitive)
/artist_urls?search[url_not_ilike]=...  # does not match wildcard (case insensitive)
/artist_urls?search[url_regex]=...      # matches regex
/artist_urls?search[url_not_regex]=...  # does not match regex

/artist_urls?search[normalized_url]=... # all the same options as above
```

These options are provided for API use. Some of these things are more useful than others, but I went ahead and provided them all for completeness.

The method that handles this (`ApplicationRecord#search_text_attribute`) is designed to be generic, to make it possible to support these kind of searches in other places on the site too.