### PR TITLE
Optimize tag set presenters

### DIFF
--- a/app/logical/storage_manager.rb
+++ b/app/logical/storage_manager.rb
@@ -115,7 +115,7 @@ class StorageManager
   def seo_tags(post)
     return "" if !tagged_filenames
 
-    tags = post.humanized_essential_tag_string.gsub(/[^a-z0-9]+/, "_").gsub(/(?:^_+)|(?:_+$)/, "").gsub(/_{2,}/, "_")
+    tags = post.presenter.humanized_essential_tag_string.gsub(/[^a-z0-9]+/, "_").gsub(/(?:^_+)|(?:_+$)/, "").gsub(/_{2,}/, "_")
     "__#{tags}__"
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -56,10 +56,6 @@ class Tag < ApplicationRecord
     extend ActiveSupport::Concern
 
     module ClassMethods
-      def counts_for(tag_names)
-        select_all_sql("SELECT name, post_count FROM tags WHERE name IN (?)", tag_names)
-      end
-
       def highest_post_count
         Cache.get("highest-post-count", 4.hours) do
           select("post_count").order("post_count DESC").first.post_count

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -1,6 +1,6 @@
 class PostPresenter < Presenter
   attr_reader :pool, :next_post_in_pool
-  delegate :tag_list_html, :split_tag_list_html, :inline_tag_list_html, to: :tag_set_presenter
+  delegate :tag_list_html, :split_tag_list_html, :split_tag_list_text, :inline_tag_list_html, to: :tag_set_presenter
 
   def self.preview(post, options = {})
     if post.nil?
@@ -149,22 +149,6 @@ class PostPresenter < Presenter
 
   def filename_for_download
     "#{humanized_essential_tag_string} - #{@post.md5}.#{@post.file_ext}"
-  end
-
-  def categorized_tag_groups
-    string = []
-
-    TagCategory.categorized_list.each do |category|
-      if @post.typed_tags(category).any?
-        string << @post.typed_tags(category).join(" ")
-      end
-    end
-    
-    string
-  end
-
-  def categorized_tag_string
-    categorized_tag_groups.join(" \n")
   end
 
   def safe_mode_message(template)

--- a/app/presenters/post_presenter.rb
+++ b/app/presenters/post_presenter.rb
@@ -144,7 +144,7 @@ class PostPresenter < Presenter
   end
 
   def humanized_essential_tag_string
-    @post.humanized_essential_tag_string
+    @humanized_essential_tag_string ||= tag_set_presenter.humanized_essential_tag_string(default: "##{@post.id}")
   end
 
   def filename_for_download

--- a/app/presenters/post_set_presenters/favorite.rb
+++ b/app/presenters/post_set_presenters/favorite.rb
@@ -1,7 +1,8 @@
 module PostSetPresenters
   class Favorite < Base
     attr_accessor :post_set, :tag_set_presenter
-    delegate :favorites, :to => :post_set
+    delegate :favorites, :posts, :to => :post_set
+    delegate :tag_list_html, to: :tag_set_presenter
 
     def initialize(post_set)
       @post_set = post_set
@@ -10,14 +11,6 @@ module PostSetPresenters
           post_set.tag_string
         ).map {|x| x[0]}
       )
-    end
-
-    def tag_list_html(template)
-      tag_set_presenter.tag_list_html(template)
-    end
-
-    def posts
-      @posts ||= post_set.posts
     end
   end
 end

--- a/app/presenters/post_set_presenters/pool.rb
+++ b/app/presenters/post_set_presenters/pool.rb
@@ -12,10 +12,6 @@ module PostSetPresenters
       )
     end
 
-    def tag_list_html(template)
-      tag_set_presenter.tag_list_html(template)
-    end
-
     def post_previews_html(template)
       html = ""
 

--- a/app/presenters/post_set_presenters/post.rb
+++ b/app/presenters/post_set_presenters/post.rb
@@ -67,12 +67,8 @@ module PostSetPresenters
       SavedSearch.labels_for(CurrentUser.user.id).map {|x| "search:#{x}"}
     end
 
-    def tag_list_html(template, options = {})
-      if post_set.is_saved_search?
-        options[:name_only] = true
-      end
-      
-      tag_set_presenter.tag_list_html(template, options)
+    def tag_list_html(**options)
+      tag_set_presenter.tag_list_html(name_only: post_set.is_saved_search?, **options)
     end
   end
 end

--- a/app/presenters/upload_presenter.rb
+++ b/app/presenters/upload_presenter.rb
@@ -1,5 +1,12 @@
 class UploadPresenter < Presenter
+  attr_reader :upload
+  delegate :inline_tag_list_html, to: :tag_set_presenter
+
   def initialize(upload)
     @upload = upload
+  end
+
+  def tag_set_presenter
+    @tag_set_presenter ||= TagSetPresenter.new(upload.tag_string.split)
   end
 end

--- a/app/views/comments/index.atom.builder
+++ b/app/views/comments/index.atom.builder
@@ -9,7 +9,7 @@ atom_feed(root_url: comments_url(host: Danbooru.config.hostname)) do |feed|
 
   @comments.each do |comment|
     feed.entry(comment, published: comment.created_at, updated: comment.updated_at) do |entry|
-      entry.title("@#{comment.creator_name} on post ##{comment.post_id} (#{comment.post.humanized_essential_tag_string})")
+      entry.title("@#{comment.creator_name} on post ##{comment.post_id} (#{comment.post.presenter.humanized_essential_tag_string})")
       entry.content(<<-EOS.strip_heredoc, type: "html")
         <img src="#{comment.post.preview_file_url}"/>
 

--- a/app/views/comments/partials/index/_header.html.erb
+++ b/app/views/comments/partials/index/_header.html.erb
@@ -26,7 +26,7 @@
   </div>
   <div class="row list-of-tags">
     <strong>Tags</strong>
-    <%= post.presenter.inline_tag_list_html(self) %>
+    <%= post.presenter.inline_tag_list_html %>
   </div>
 </div>
 

--- a/app/views/favorites/index.html.erb
+++ b/app/views/favorites/index.html.erb
@@ -9,7 +9,7 @@
 
       <section id="tag-box">
         <h1>Tags</h1>
-        <%= @favorite_set.presenter.tag_list_html(self) %>
+        <%= @favorite_set.presenter.tag_list_html %>
       </section>
 
       <section id="related-box">

--- a/app/views/moderator/post/queues/_post.html.erb
+++ b/app/views/moderator/post/queues/_post.html.erb
@@ -31,7 +31,7 @@
       <% if post.has_active_pools? %>
         <li><strong>Pools</strong>: <%= render "pools/inline_list", pools: post.pools.undeleted %></li>
       <% end %>
-      <li><strong>Tags</strong>: <%= post.presenter.inline_tag_list_html(self) %></li>
+      <li><strong>Tags</strong>: <%= post.presenter.inline_tag_list_html %></li>
     </ul>
   </section>
 </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -9,7 +9,7 @@
 
       <section id="tag-box">
         <h1>Tags</h1>
-        <%= @post_set.presenter.tag_list_html(self) %>
+        <%= @post_set.presenter.tag_list_html(current_query: params[:tags], show_extra_links: CurrentUser.user.is_gold?) %>
       </section>
 
       <%= render "posts/partials/index/options" %>

--- a/app/views/posts/partials/show/_edit.html.erb
+++ b/app/views/posts/partials/show/_edit.html.erb
@@ -78,7 +78,7 @@
   <div class="input">
     <div>
       <%= f.label :tag_string, "Tags" %>
-      <%= f.text_area :tag_string, :size => "50x5", :value => post.presenter.categorized_tag_string + " ", :data => { :autocomplete => "tag-edit" } %>
+      <%= f.text_area :tag_string, :size => "50x5", :value => post.presenter.split_tag_list_text + " ", :data => { :autocomplete => "tag-edit" } %>
       <span id="open-edit-dialog" class="ui-icon ui-icon-arrow-1-ne" title="detach" style="display: none;" data-shortcut="shift+e"/>
     </div>
 

--- a/app/views/posts/show.html+tooltip.erb
+++ b/app/views/posts/show.html+tooltip.erb
@@ -46,5 +46,5 @@
     <% end %>
   </div>
 
-  <%= @post.presenter.inline_tag_list_html(self, humanize_tags: false) %>
+  <%= @post.presenter.inline_tag_list_html(humanize_tags: false) %>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -6,7 +6,7 @@
       <%= render "posts/partials/index/blacklist" %>
 
       <section id="tag-list">
-        <%= @post.presenter.split_tag_list_html(self) %>
+        <%= @post.presenter.split_tag_list_html(current_query: params[:tags], show_extra_links: CurrentUser.user.is_gold?) %>
       </section>
 
       <section id="post-information">

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -57,7 +57,7 @@
 
               <span class="info">
                 <strong>Tags</strong>
-                <%= TagSetPresenter.new(upload.tag_string.split).inline_tag_list_html(self) %>
+                <%= upload.presenter.inline_tag_list_html %>
               </span>
             </td>
             <td>


### PR DESCRIPTION
This implements the third item in #3922. Currently the post show page does these queries:

* One call to the database to get the tag counts for the sidebar taglist.
* One call to memcache to get the tag categories for the sidebar taglist.
* Another call to memcache to get the tag categories for the tag string inside the post edit form.
* Another call to memcache to get the tag categories when generating the `humanized_essential_tag_string` (used for the page title and the image filename, among other things).

This basically moves all the code dealing with these tag lists into `TagSetPresenter`, so that the tags can be fetched from the database once and reused for all these things.

I think these memcache calls, though redundant, ultimately didn't contribute much to page render time, so this is more of a code cleanup than optimization.