### PR TITLE
Fix #3934: Post#fast_count has very slow worst case behavior

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1164,7 +1164,7 @@ class Post < ApplicationRecord
   end
 
   module CountMethods
-    def fast_count(tags = "", options = {})
+    def fast_count(tags = "", timeout: 1_000, raise_on_timeout: false)
       tags = tags.to_s
       tags += " rating:s" if CurrentUser.safe_mode?
       tags += " -status:deleted" if CurrentUser.hide_deleted_posts? && !Tag.has_metatag?(tags, "status", "-status")
@@ -1194,7 +1194,7 @@ class Post < ApplicationRecord
       count = get_count_from_cache(tags)
 
       if count.nil?
-        count = fast_count_search(tags, options)
+        count = fast_count_search(tags, timeout: timeout, raise_on_timeout: raise_on_timeout)
       end
 
       count
@@ -1202,14 +1202,14 @@ class Post < ApplicationRecord
       0
     end
 
-    def fast_count_search(tags, options = {})
-      count = PostReadOnly.with_timeout(3_000, nil, {:tags => tags}) do
+    def fast_count_search(tags, timeout:, raise_on_timeout:)
+      count = PostReadOnly.with_timeout(timeout, nil, tags: tags) do
         PostReadOnly.tag_match(tags).count
       end
 
       if count.nil?
         # give up
-        if options[:raise_on_timeout]
+        if raise_on_timeout
           raise TimeoutError.new("timed out")
         end
 


### PR DESCRIPTION
This is a fix for #3934. This lowers the fast count timeout from 3 seconds to 1 second, and removes the batched search fallback.

As discussed in #3934, IMO it's better to let fast count fail fast than to take a long time trying to determine the page count.