### PR TITLE
Wiki pages: convert other_names column to array (#3987)

### DIFF
--- a/app/controllers/pools_controller.rb
+++ b/app/controllers/pools_controller.rb
@@ -94,7 +94,7 @@ class PoolsController < ApplicationController
   private
 
   def pool_params
-    permitted_params = %i[name description category is_active post_ids]
+    permitted_params = %i[name description category is_active post_ids post_ids_string]
     params.require(:pool).permit(*permitted_params, post_ids: [])
   end
 end

--- a/app/controllers/wiki_pages_controller.rb
+++ b/app/controllers/wiki_pages_controller.rb
@@ -5,7 +5,7 @@ class WikiPagesController < ApplicationController
   before_action :normalize_search_params, :only => [:index]
   
   def new
-    @wiki_page = WikiPage.new(wiki_page_create_params)
+    @wiki_page = WikiPage.new(wiki_page_params(:create))
     respond_with(@wiki_page)
   end
 
@@ -54,13 +54,13 @@ class WikiPagesController < ApplicationController
   end
 
   def create
-    @wiki_page = WikiPage.create(wiki_page_create_params)
+    @wiki_page = WikiPage.create(wiki_page_params(:create))
     respond_with(@wiki_page)
   end
 
   def update
     @wiki_page = WikiPage.find(params[:id])
-    @wiki_page.update(wiki_page_update_params)
+    @wiki_page.update(wiki_page_params(:update))
     respond_with(@wiki_page)
   end
 
@@ -98,18 +98,11 @@ class WikiPagesController < ApplicationController
     end
   end
 
-  def wiki_page_create_params
-    permitted_params = %i[title body other_names skip_secondary_validations]
+  def wiki_page_params(context)
+    permitted_params = %i[body other_names other_names_string skip_secondary_validations]
     permitted_params += %i[is_locked is_deleted] if CurrentUser.is_builder?
+    permitted_params += %i[title] if context == :create || CurrentUser.is_builder?
 
     params.fetch(:wiki_page, {}).permit(permitted_params)
   end
-
-  def wiki_page_update_params
-    permitted_params = %i[body other_names skip_secondary_validations]
-    permitted_params += %i[title is_locked is_deleted] if CurrentUser.is_builder?
-
-    params.fetch(:wiki_page, {}).permit(permitted_params)
-  end
-
 end

--- a/app/helpers/wiki_pages_helper.rb
+++ b/app/helpers/wiki_pages_helper.rb
@@ -18,7 +18,7 @@ module WikiPagesHelper
   end
 
   def wiki_page_other_names_list(wiki_page)
-    names_html = wiki_page.other_names_array.map{|name| link_to(name, "http://www.pixiv.net/search.php?s_mode=s_tag_full&word=#{u(name)}", :class => "wiki-other-name")}
+    names_html = wiki_page.other_names.map{|name| link_to(name, "http://www.pixiv.net/search.php?s_mode=s_tag_full&word=#{u(name)}", :class => "wiki-other-name")}
     names_html.join(" ").html_safe
   end
 end

--- a/app/logical/sources/strategies/base.rb
+++ b/app/logical/sources/strategies/base.rb
@@ -187,7 +187,7 @@ module Sources
       def translate_tag(untranslated_tag)
         return [] if untranslated_tag.blank?
 
-        translated_tag_names = WikiPage.active.other_names_equal(untranslated_tag).uniq.pluck(:title)
+        translated_tag_names = WikiPage.active.other_names_include(untranslated_tag).uniq.pluck(:title)
         translated_tag_names = TagAlias.to_aliased(translated_tag_names)
         translated_tags = Tag.where(name: translated_tag_names)
 

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -269,6 +269,37 @@ class ApplicationRecord < ActiveRecord::Base
     end
   end
 
+  concerning :AttributeMethods do
+    class_methods do
+      # Defines `<attribute>_string`, `<attribute>_string=`, and `<attribute>=`
+      # methods for converting an array attribute to or from a string.
+      #
+      # The `<attribute>=` setter parses strings into an array using the
+      # `parse` regex. The resulting strings can be converted to another type
+      # with the `cast` option.
+      def array_attribute(name, parse: /[^[:space:]]+/, cast: :itself)
+        define_method "#{name}_string" do
+          send(name).join(" ")
+        end
+
+        define_method "#{name}_string=" do |value|
+          raise ArgumentError, "#{name} must be a String" unless value.respond_to?(:to_str)
+          send("#{name}=", value)
+        end
+
+        define_method "#{name}=" do |value|
+          if value.respond_to?(:to_str)
+            super value.to_str.scan(parse).map(&cast)
+          elsif value.respond_to?(:to_a)
+            super value.to_a
+          else
+            raise ArgumentError, "#{name} must be a String or an Array"
+          end
+        end
+      end
+    end
+  end
+
   def warnings
     @warnings ||= ActiveModel::Errors.new(self)
   end

--- a/app/models/wiki_page_version.rb
+++ b/app/models/wiki_page_version.rb
@@ -1,4 +1,5 @@
 class WikiPageVersion < ApplicationRecord
+  array_attribute :other_names
   belongs_to :wiki_page
   belongs_to_updater
   belongs_to :artist, optional: true
@@ -44,9 +45,5 @@ class WikiPageVersion < ApplicationRecord
 
   def category_name
     Tag.category_for(title)
-  end
-
-  def other_names_array
-    other_names.to_s.split(/[[:space:]]+/)
   end
 end

--- a/app/views/pools/edit.html.erb
+++ b/app/views/pools/edit.html.erb
@@ -8,7 +8,7 @@
       <%= f.input :name, :as => :string, :input_html => { :value => @pool.pretty_name } %>
       <%= dtext_field "pool", "description" %>
       <%= dtext_preview_button "pool", "description" %>
-      <%= f.input :post_ids, as: :text, label: "Posts", input_html: { value: @pool.post_ids.join(" ") } %>
+      <%= f.input :post_ids_string, as: :text, label: "Posts" %>
       <%= f.input :category, :collection => ["series", "collection"], :include_blank => false %>
       <%= f.input :is_active %>
       <%= f.button :submit %>

--- a/app/views/pools/new.html.erb
+++ b/app/views/pools/new.html.erb
@@ -7,7 +7,7 @@
     <%= simple_form_for(@pool) do |f| %>
       <%= f.input :name, :as => :string, :required => true %>
       <%= dtext_field "pool", "description" %>
-      <%= f.input :post_ids, as: :text, label: "Posts", input_html: { value: @pool.post_ids.join(" ") } %>
+      <%= f.input :post_ids_string, as: :text, label: "Posts" %>
       <%= f.input :category, :collection => ["series", "collection"], :include_blank => true, :selected => "", :required => true %>
       <%= f.input :is_active %>
       <%= f.button :submit, "Submit" %>

--- a/app/views/wiki_pages/_form.html.erb
+++ b/app/views/wiki_pages/_form.html.erb
@@ -10,7 +10,7 @@
       <h1 id="wiki-page-title"><%= @wiki_page.pretty_title %></h1>
     <% end %>
 
-    <%= f.input :other_names, :as => :text, :label => "Other names (<a href='/wiki_pages/help:translated_tags'>view help</a>)".html_safe, :hint => "Names used for this tag on other sites such as Pixiv. Separate with spaces." %>
+    <%= f.input :other_names_string, as: :text, label: "Other names (#{link_to "help", wiki_pages_path(title: "help:translated_tags")})".html_safe, hint: "Names used for this tag on other sites such as Pixiv. Separate with spaces." %>
 
     <%= dtext_field "wiki_page", "body" %>
 

--- a/db/migrate/20181113174914_change_strings_to_arrays_on_wiki_pages.rb
+++ b/db/migrate/20181113174914_change_strings_to_arrays_on_wiki_pages.rb
@@ -1,0 +1,26 @@
+class ChangeStringsToArraysOnWikiPages < ActiveRecord::Migration[5.2]
+  def up
+    WikiPage.without_timeout do
+      change_column :wiki_pages, :other_names, "text[]", using: "string_to_array(other_names, ' ')::text[]", default: "{}"
+      change_column :wiki_page_versions, :other_names, "text[]", using: "string_to_array(other_names, ' ')::text[]", default: "{}"
+
+      remove_column :wiki_pages, :other_names_index
+      execute "DROP TRIGGER trigger_wiki_pages_on_update_for_other_names ON wiki_pages"
+
+      add_index :wiki_pages, :other_names, using: :gin
+    end
+  end
+
+  def down
+    WikiPage.without_timeout do
+      remove_index :wiki_pages, :other_names
+
+      add_column :wiki_pages, :other_names_index, :tsvector
+      add_index :wiki_pages, :other_names_index, using: :gin
+      execute "CREATE TRIGGER trigger_wiki_pages_on_update_for_other_names BEFORE INSERT OR UPDATE ON wiki_pages FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('other_names_index', 'public.danbooru', 'other_names')"
+
+      change_column :wiki_pages, :other_names, "text", using: "array_to_string(other_names, ' ')", default: nil
+      change_column :wiki_page_versions, :other_names, "text", using: "array_to_string(other_names, ' ')", default: nil
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3363,7 +3363,7 @@ CREATE TABLE public.wiki_page_versions (
     is_locked boolean NOT NULL,
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
-    other_names text,
+    other_names text[] DEFAULT '{}'::text[],
     is_deleted boolean DEFAULT false NOT NULL
 );
 
@@ -3402,8 +3402,7 @@ CREATE TABLE public.wiki_pages (
     created_at timestamp without time zone,
     updated_at timestamp without time zone,
     updater_id integer,
-    other_names text,
-    other_names_index tsvector,
+    other_names text[] DEFAULT '{}'::text[],
     is_deleted boolean DEFAULT false NOT NULL
 );
 
@@ -7312,10 +7311,10 @@ CREATE INDEX index_wiki_pages_on_body_index_index ON public.wiki_pages USING gin
 
 
 --
--- Name: index_wiki_pages_on_other_names_index; Type: INDEX; Schema: public; Owner: -
+-- Name: index_wiki_pages_on_other_names; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_wiki_pages_on_other_names_index ON public.wiki_pages USING gin (other_names_index);
+CREATE INDEX index_wiki_pages_on_other_names ON public.wiki_pages USING gin (other_names);
 
 
 --
@@ -7400,13 +7399,6 @@ CREATE TRIGGER trigger_posts_on_tag_index_update BEFORE INSERT OR UPDATE ON publ
 --
 
 CREATE TRIGGER trigger_wiki_pages_on_update BEFORE INSERT OR UPDATE ON public.wiki_pages FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('body_index', 'public.danbooru', 'body', 'title');
-
-
---
--- Name: wiki_pages trigger_wiki_pages_on_update_for_other_names; Type: TRIGGER; Schema: public; Owner: -
---
-
-CREATE TRIGGER trigger_wiki_pages_on_update_for_other_names BEFORE INSERT OR UPDATE ON public.wiki_pages FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger('other_names_index', 'public.danbooru', 'other_names');
 
 
 --
@@ -7579,6 +7571,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20180913184128'),
 ('20180916002448'),
 ('20181108162204'),
-('20181108205842');
+('20181108205842'),
+('20181113174914');
 
 

--- a/test/unit/wiki_page_test.rb
+++ b/test/unit/wiki_page_test.rb
@@ -63,7 +63,7 @@ class WikiPageTest < ActiveSupport::TestCase
 
       should "normalize its other names" do
         @wiki_page.update(:other_names => "foo*bar baz baz 加賀（艦これ）")
-        assert(%w[foo*bar baz 加賀(艦これ)], @wiki_page.other_names_array)
+        assert_equal(%w[foo*bar baz 加賀(艦これ)], @wiki_page.other_names)
       end
 
       should "search by title" do


### PR DESCRIPTION
Addresses #3987 for wiki pages. Converts `wiki_pages.other_names` and `wiki_page_versions.other_names` to arrays.