### PR TITLE
Fix #4004: Add additional order by metatags for posts

### DIFF
--- a/app/javascript/src/javascripts/autocomplete.js.erb
+++ b/app/javascript/src/javascripts/autocomplete.js.erb
@@ -5,6 +5,7 @@ let Autocomplete = {};
 
 Autocomplete.METATAGS = <%= Tag::METATAGS.to_json.html_safe %>;
 Autocomplete.TAG_CATEGORIES = <%= TagCategory.mapping.to_json.html_safe %>;
+Autocomplete.ORDER_METATAGS = <%= Tag::ORDER_METATAGS.to_json.html_safe %>;
 
 Autocomplete.TAG_PREFIXES = "-|~|" + Object.keys(Autocomplete.TAG_CATEGORIES).map(category => category + ":").join("|");
 Autocomplete.TAG_PREFIXES_REGEX = new RegExp("^(" + Autocomplete.TAG_PREFIXES + ")(.*)$", "i");
@@ -389,24 +390,7 @@ Autocomplete.render_item = function(list, item) {
 };
 
 Autocomplete.static_metatags = {
-  order: [
-    "id", "id_desc",
-    "score", "score_asc",
-    "favcount", "favcount_asc",
-    "created_at", "created_at_asc",
-    "change", "change_asc",
-    "comment", "comment_asc",
-    "comment_bumped", "comment_bumped_asc",
-    "note", "note_asc",
-    "artcomm", "artcomm_asc",
-    "mpixels", "mpixels_asc",
-    "portrait", "landscape",
-    "filesize", "filesize_asc",
-    "tagcount", "tagcount_asc",
-    "rank",
-    "random",
-    "custom"
-  ].concat(<%= TagCategory.short_name_list.map {|category| [category + "tags", category + "tags_asc"]}.flatten %>),
+  order: Autocomplete.ORDER_METATAGS,
   status: [
     "any", "deleted", "active", "pending", "flagged", "banned", "modqueue", "unmoderated"
   ],

--- a/app/logical/post_query_builder.rb
+++ b/app/logical/post_query_builder.rb
@@ -1,8 +1,9 @@
 class PostQueryBuilder
-  attr_accessor :query_string
+  attr_accessor :query_string, :read_only
 
-  def initialize(query_string)
+  def initialize(query_string, read_only: false)
     @query_string = query_string
+    @read_only = read_only
   end
 
   def add_range_relation(arr, field, relation)
@@ -91,14 +92,12 @@ class PostQueryBuilder
     return CurrentUser.user.hide_deleted_posts?
   end
 
-  def build(relation = nil)
+  def build
     unless query_string.is_a?(Hash)
       q = Tag.parse_query(query_string)
     end
 
-    if relation.nil?
-      relation = Post.where("true")
-    end
+    relation = read_only ? PostReadOnly.all : Post.all
 
     if q[:tag_count].to_i > Danbooru.config.tag_query_limit
       raise ::Post::SearchError.new("You cannot search for more than #{Danbooru.config.tag_query_limit} tags at a time")

--- a/app/models/artist_commentary.rb
+++ b/app/models/artist_commentary.rb
@@ -19,7 +19,7 @@ class ArtistCommentary < ApplicationRecord
     end
 
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post)).reorder("")
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def deleted

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -52,7 +52,7 @@ class Comment < ApplicationRecord
     end
 
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post)).reorder("")
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def for_creator(user_id)

--- a/app/models/note.rb
+++ b/app/models/note.rb
@@ -18,7 +18,7 @@ class Note < ApplicationRecord
     end
 
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post)).reorder("")
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def for_creator(user_id)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1662,7 +1662,7 @@ class Post < ApplicationRecord
 
       if read_only
         begin
-          PostQueryBuilder.new(query).build(PostReadOnly.where("true"))
+          PostQueryBuilder.new(query, read_only: true).build
         rescue PG::ConnectionBad
           PostQueryBuilder.new(query).build
         end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1625,6 +1625,52 @@ class Post < ApplicationRecord
       relation
     end
 
+    def with_flag_stats
+      relation = left_outer_joins(:flags).group(:id).select("posts.*")
+      relation = relation.select("COUNT(post_flags.id) AS flag_count")
+      relation = relation.select("COUNT(post_flags.id) FILTER (WHERE post_flags.is_resolved = TRUE)  AS resolved_flag_count")
+      relation = relation.select("COUNT(post_flags.id) FILTER (WHERE post_flags.is_resolved = FALSE) AS unresolved_flag_count")
+      relation
+    end
+
+    def with_appeal_stats
+      relation = left_outer_joins(:appeals).group(:id).select("posts.*")
+      relation = relation.select("COUNT(post_appeals.id) AS appeal_count")
+      relation
+    end
+
+    def with_approval_stats
+      relation = left_outer_joins(:approvals).group(:id).select("posts.*")
+      relation = relation.select("COUNT(post_approvals.id) AS approval_count")
+      relation
+    end
+
+    def with_replacement_stats
+      relation = left_outer_joins(:replacements).group(:id).select("posts.*")
+      relation = relation.select("COUNT(post_replacements.id) AS replacement_count")
+      relation
+    end
+
+    def with_child_stats
+      relation = left_outer_joins(:children).group(:id).select("posts.*")
+      relation = relation.select("COUNT(children_posts.id) AS child_count")
+      relation = relation.select("COUNT(children_posts.id) FILTER (WHERE children_posts.is_deleted = TRUE)  AS deleted_child_count")
+      relation = relation.select("COUNT(children_posts.id) FILTER (WHERE children_posts.is_deleted = FALSE) AS active_child_count")
+      relation
+    end
+
+    def with_pool_stats
+      pool_posts = Pool.joins("CROSS JOIN unnest(post_ids) AS post_id").select(:id, :is_deleted, :category, "post_id")
+      relation = joins("LEFT OUTER JOIN (#{pool_posts.to_sql}) pools ON pools.post_id = posts.id").group(:id).select("posts.*")
+
+      relation = relation.select("COUNT(pools.id) AS pool_count")
+      relation = relation.select("COUNT(pools.id) FILTER (WHERE pools.is_deleted = TRUE) AS deleted_pool_count")
+      relation = relation.select("COUNT(pools.id) FILTER (WHERE pools.is_deleted = FALSE) AS active_pool_count")
+      relation = relation.select("COUNT(pools.id) FILTER (WHERE pools.category = 'series') AS series_pool_count")
+      relation = relation.select("COUNT(pools.id) FILTER (WHERE pools.category = 'collection') AS collection_pool_count")
+      relation
+    end
+
     def with_stats(tables)
       return all if tables.empty?
 

--- a/app/models/post_appeal.rb
+++ b/app/models/post_appeal.rb
@@ -11,7 +11,7 @@ class PostAppeal < ApplicationRecord
 
   module SearchMethods
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post))
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def resolved

--- a/app/models/post_approval.rb
+++ b/app/models/post_approval.rb
@@ -35,7 +35,7 @@ class PostApproval < ApplicationRecord
   concerning :SearchMethods do
     class_methods do
       def post_tags_match(query)
-        PostQueryBuilder.new(query).build(self.joins(:post))
+        where(post_id: PostQueryBuilder.new(query).build.reorder(""))
       end
 
       def search(params)

--- a/app/models/post_flag.rb
+++ b/app/models/post_flag.rb
@@ -33,7 +33,7 @@ class PostFlag < ApplicationRecord
     end
 
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post))
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def resolved

--- a/app/models/post_replacement.rb
+++ b/app/models/post_replacement.rb
@@ -21,7 +21,7 @@ class PostReplacement < ApplicationRecord
   concerning :Search do
     class_methods do
       def post_tags_match(query)
-        PostQueryBuilder.new(query).build(self.joins(:post))
+        where(post_id: PostQueryBuilder.new(query).build.reorder(""))
       end
 
       def search(params = {})

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,9 @@
 class Tag < ApplicationRecord
   COSINE_SIMILARITY_RELATED_TAG_THRESHOLD = 300
+  COUNT_METATAGS = %w[
+    comment_count deleted_comment_count active_comment_count
+    note_count deleted_note_count active_note_count
+  ]
   METATAGS = %w[
     -user user -approver approver commenter comm noter noteupdater artcomm
     -pool pool ordpool -favgroup favgroup -fav fav ordfav md5 -rating rating
@@ -7,7 +11,7 @@ class Tag < ApplicationRecord
     -source id -id date age order limit -status status tagcount parent -parent
     child pixiv_id pixiv search upvote downvote filetype -filetype flagger
     -flagger appealer -appealer disapproval -disapproval
-  ] + TagCategory.short_name_list.map {|x| "#{x}tags"}
+  ] + TagCategory.short_name_list.map {|x| "#{x}tags"} + COUNT_METATAGS
 
   SUBQUERY_METATAGS = %w[commenter comm noter noteupdater artcomm flagger -flagger appealer -appealer]
 
@@ -789,6 +793,9 @@ class Tag < ApplicationRecord
             if CurrentUser.user.is_moderator?
               q[:downvote] = User.name_to_id(g2)
             end
+
+          when *COUNT_METATAGS
+            q[g1.to_sym] = parse_helper(g2)
 
           end
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -23,6 +23,28 @@ class Tag < ApplicationRecord
 
   SUBQUERY_METATAGS = %w[commenter comm noter noteupdater artcomm flagger -flagger appealer -appealer]
 
+  ORDER_METATAGS = %w[
+    id id_desc
+    score score_asc
+    favcount favcount_asc
+    created_at created_at_asc
+    change change_asc
+    comment comment_asc
+    comment_bumped comment_bumped_asc
+    note note_asc
+    artcomm artcomm_asc
+    mpixels mpixels_asc
+    portrait landscape
+    filesize filesize_asc
+    tagcount tagcount_asc
+    rank
+    random
+    custom
+  ] +
+  COUNT_METATAGS +
+  COUNT_METATAG_SYNONYMS.flat_map { |str| [str, "#{str}_asc"] } +
+  TagCategory.short_name_list.flat_map { |str| ["#{str}tags", "#{str}tags_asc"] }
+
   has_one :wiki_page, :foreign_key => "title", :primary_key => "name"
   has_one :artist, :foreign_key => "name", :primary_key => "name"
   has_one :antecedent_alias, -> {active}, :class_name => "TagAlias", :foreign_key => "antecedent_name", :primary_key => "name"

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -3,6 +3,10 @@ class Tag < ApplicationRecord
   COUNT_METATAGS = %w[
     comment_count deleted_comment_count active_comment_count
     note_count deleted_note_count active_note_count
+    flag_count resolved_flag_count unresolved_flag_count
+    child_count deleted_child_count active_child_count
+    pool_count deleted_pool_count active_pool_count series_pool_count collection_pool_count
+    appeal_count approval_count replacement_count
   ]
   METATAGS = %w[
     -user user -approver approver commenter comm noter noteupdater artcomm

--- a/app/models/upload.rb
+++ b/app/models/upload.rb
@@ -175,7 +175,7 @@ class Upload < ApplicationRecord
     end
 
     def post_tags_match(query)
-      PostQueryBuilder.new(query).build(self.joins(:post)).reorder("")
+      where(post_id: PostQueryBuilder.new(query).build.reorder(""))
     end
 
     def search(params)

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2111,6 +2111,10 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match([posts[1], posts[0]], "note_count:1")
       assert_tag_match([posts[0]], "active_note_count:1")
       assert_tag_match([posts[1]], "deleted_note_count:1")
+
+      assert_tag_match([posts[1], posts[0]], "notes:1")
+      assert_tag_match([posts[0]], "active_notes:1")
+      assert_tag_match([posts[1]], "deleted_notes:1")
     end
 
     should "return posts for the artcomm:<name> metatag" do
@@ -2418,6 +2422,8 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:rank")
       assert_tag_match(posts.reverse, "order:note_count")
       assert_tag_match(posts.reverse, "order:note_count_desc")
+      assert_tag_match(posts.reverse, "order:notes")
+      assert_tag_match(posts.reverse, "order:notes_desc")
 
       assert_tag_match(posts, "order:id_asc")
       assert_tag_match(posts, "order:score_asc")
@@ -2436,6 +2442,7 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts, "order:chartags_asc")
       assert_tag_match(posts, "order:copytags_asc")
       assert_tag_match(posts, "order:note_count_asc")
+      assert_tag_match(posts, "order:notes_asc")
     end
 
     should "return posts for order:comment_bumped" do

--- a/test/unit/post_test.rb
+++ b/test/unit/post_test.rb
@@ -2103,6 +2103,16 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match([posts[1]], "noter:none")
     end
 
+    should "return posts for the note_count:<N> metatag" do
+      posts = FactoryBot.create_list(:post, 3)
+      FactoryBot.create(:note, post: posts[0], is_active: true)
+      FactoryBot.create(:note, post: posts[1], is_active: false)
+
+      assert_tag_match([posts[1], posts[0]], "note_count:1")
+      assert_tag_match([posts[0]], "active_note_count:1")
+      assert_tag_match([posts[1]], "deleted_note_count:1")
+    end
+
     should "return posts for the artcomm:<name> metatag" do
       users = FactoryBot.create_list(:user, 2)
       posts = FactoryBot.create_list(:post, 2)
@@ -2387,6 +2397,8 @@ class PostTest < ActiveSupport::TestCase
         p
       end
 
+      FactoryBot.create(:note, post: posts.second)
+
       assert_tag_match(posts.reverse, "order:id_desc")
       assert_tag_match(posts.reverse, "order:score")
       assert_tag_match(posts.reverse, "order:favcount")
@@ -2404,6 +2416,8 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts.reverse, "order:chartags")
       assert_tag_match(posts.reverse, "order:copytags")
       assert_tag_match(posts.reverse, "order:rank")
+      assert_tag_match(posts.reverse, "order:note_count")
+      assert_tag_match(posts.reverse, "order:note_count_desc")
 
       assert_tag_match(posts, "order:id_asc")
       assert_tag_match(posts, "order:score_asc")
@@ -2421,6 +2435,7 @@ class PostTest < ActiveSupport::TestCase
       assert_tag_match(posts, "order:arttags_asc")
       assert_tag_match(posts, "order:chartags_asc")
       assert_tag_match(posts, "order:copytags_asc")
+      assert_tag_match(posts, "order:note_count_asc")
     end
 
     should "return posts for order:comment_bumped" do


### PR DESCRIPTION
Fixes #4004. This adds numerous metatags for searching by various kinds of counts:

* `comments`, `active_comments`, `deleted_comments`
* `notes`, `active_notes`, `deleted_notes`
* `flags`, `resolved_flags`, `unresolved_flags`
* `children`, `active_children`, `deleted_children`
* `pools`, `active_pools`, `deleted_pools`, `series_pools`, `collection_pools`
* `appeals`
* `approvals`
* `replacements`

All metatags can be used both for ordering (e.g. `order:notes`) and for searching (`notes:>5`). Ordering supports both ascending and descending directions (`order:notes_asc`, `order:notes_desc`). Negated searches aren't supported (`-notes:5` doesn't work).

`*_count` can be used as a synonym for any of these tags. For example: `order:note_count`, `child_count:>5`.

Most of these searches will be timeout-prone unless constrained by other tags, or by id or date ranges (`id:>3000000`, `age:<1y`). But they will work for smaller searches, and there are already other metatags that tend to timeout unless constrained (`source:*blah*`, `order:score`), so I don't think it makes things worse.

This is what one of these searches boils down to:

```ruby
Post.tag_match("comments:>5 order:notes")

Post.with_comment_stats.with_note_stats.where("comment_count > 5").order("note_count DESC, id 
DESC")

SELECT
  "posts".*
FROM (
  SELECT
    posts.*,
    COUNT(comments.id) AS comment_count,
    COUNT(comments.id) FILTER (WHERE comments.is_deleted = TRUE) AS deleted_comment_count,
    COUNT(comments.id) FILTER (WHERE comments.is_deleted = FALSE) AS active_comment_count,
    COUNT(notes.id) AS note_count,
    COUNT(notes.id) FILTER (WHERE notes.is_active = TRUE)  AS active_note_count,
    COUNT(notes.id) FILTER (WHERE notes.is_active = FALSE) AS deleted_note_count
  FROM "posts"
  LEFT OUTER JOIN "comments" ON "comments"."post_id" = "posts"."id"
  LEFT OUTER JOIN "notes" ON "notes"."post_id" = "posts"."id"
  GROUP BY "posts"."id"
) posts
WHERE
  (posts.comment_count > 5)
ORDER BY "posts"."note_count" DESC, "posts"."id" DESC
LIMIT 20
OFFSET 0
```