### PR TITLE
#3767: Prioritize md5 check over source download

### DIFF
--- a/app/logical/upload_service/preprocessor.rb
+++ b/app/logical/upload_service/preprocessor.rb
@@ -33,24 +33,24 @@ class UploadService
     memoize :canonical_source
 
     def in_progress?
-      if Utils.is_downloadable?(source)
-        return Upload.where(status: "preprocessing", source: source).exists?
-      end
-
       if md5.present?
         return Upload.where(status: "preprocessing", md5: md5).exists?
+      end
+
+      if Utils.is_downloadable?(source)
+        return Upload.where(status: "preprocessing", source: source).exists?
       end
 
       false
     end
 
     def predecessor
-      if Utils.is_downloadable?(source)
-        return Upload.where(status: ["preprocessed", "preprocessing"], source: source).first
-      end
-
       if md5.present?
         return Upload.where(status: ["preprocessed", "preprocessing"], md5: md5).first
+      end
+
+      if Utils.is_downloadable?(source)
+        return Upload.where(status: ["preprocessed", "preprocessing"], source: source).first
       end
     end
 


### PR DESCRIPTION
in case both an upload from disk and a source were specified, this caused
an md5 mismatch error to be thrown

this seems to be necessary because, as I understand it, a upload record with the correct file (and md5) is already created before the form is submitted, but later not found because `predecessor` incorrectly returns  in the `if Utils.is_downloadable?(source)` branch (just checks whether source is http/https) which is taken if basically any source is present.

I have been testing this on my own instance for a few months now and haven't experienced any issues, but I would still appreciate someone looking over this.