### PR TITLE
Fix #4038: Attempting to create an IP-ban bans the creator.

### DIFF
--- a/app/logical/moderator/ip_addr_search.rb
+++ b/app/logical/moderator/ip_addr_search.rb
@@ -26,7 +26,7 @@ module Moderator
       add_row(sums, ArtistVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, NoteVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
       add_row(sums, WikiPageVersion.where(updater_ip_addr: ip_addrs).group(:updater).count)
-      add_row(sums, Comment.where(ip_addr: ip_addrs).group(:creator).count)
+      add_row(sums, Comment.where(creator_ip_addr: ip_addrs).group(:creator).count)
       add_row(sums, Dmail.where(creator_ip_addr: ip_addrs).group(:from).count)
       add_row(sums, PostAppeal.where(creator_ip_addr: ip_addrs).group(:creator).count)
       add_row(sums, PostFlag.where(creator_ip_addr: ip_addrs).group(:creator).count)
@@ -55,7 +55,7 @@ module Moderator
       add_row(sums, PoolArchive.where(updater_id: users.map(&:id)).group(:updater_ip_addr).count) if PoolArchive.enabled?
       add_row(sums, PostArchive.where(updater_id: users.map(&:id)).group(:updater_ip_addr).count) if PostArchive.enabled?
       add_row(sums, WikiPageVersion.where(updater: users).group(:updater_ip_addr).count)
-      add_row(sums, Comment.where(creator: users).group(:ip_addr).count)
+      add_row(sums, Comment.where(creator: users).group(:creator_ip_addr).count)
       add_row(sums, Dmail.where(from: users).group(:creator_ip_addr).count)
       add_row(sums, PostAppeal.where(creator: users).where.not(creator_ip_addr: nil).group(:creator_ip_addr).count)
       add_row(sums, PostFlag.where(creator: users).group(:creator_ip_addr).count)

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -178,7 +178,7 @@ class ApplicationRecord < ActiveRecord::Base
     protected
 
     def hidden_attributes
-      [:uploader_ip_addr, :updater_ip_addr, :creator_ip_addr, :ip_addr]
+      [:uploader_ip_addr, :updater_ip_addr, :creator_ip_addr]
     end
 
     def method_attributes
@@ -243,7 +243,6 @@ class ApplicationRecord < ActiveRecord::Base
             if rec.creator_id.nil?
               rec.creator_id = CurrentUser.id
               rec.creator_ip_addr = CurrentUser.ip_addr if rec.respond_to?(:creator_ip_addr=)
-              rec.ip_addr = CurrentUser.ip_addr if rec.respond_to?(:ip_addr=)
             end
           end
 

--- a/app/models/ip_ban.rb
+++ b/app/models/ip_ban.rb
@@ -26,7 +26,7 @@ class IpBan < ApplicationRecord
   end
 
   def self.query(user_ids)
-    comments = count_by_ip_addr("comments", user_ids, "creator_id", "ip_addr")
+    comments = count_by_ip_addr("comments", user_ids, "creator_id", "creator_ip_addr")
     notes = count_by_ip_addr("note_versions", user_ids, "updater_id", "updater_ip_addr")
 #    pools = count_by_ip_addr("pool_versions", user_ids, "updater_id", "updater_ip_addr")
     wiki_pages = count_by_ip_addr("wiki_page_versions", user_ids, "updater_id", "updater_ip_addr")

--- a/app/views/comments/partials/show/_comment.html.erb
+++ b/app/views/comments/partials/show/_comment.html.erb
@@ -38,7 +38,7 @@
               <li>|</li>
               <li>
                 <strong>IP</strong>
-                <span><%= link_to_ip comment.ip_addr %></span>
+                <span><%= link_to_ip comment.creator_ip_addr %></span>
               </li>
             <% end %>
           <% end %>

--- a/db/migrate/20190109210822_rename_ip_addr_on_comments.rb
+++ b/db/migrate/20190109210822_rename_ip_addr_on_comments.rb
@@ -1,0 +1,5 @@
+class RenameIpAddrOnComments < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :comments, :ip_addr, :creator_ip_addr
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -895,7 +895,7 @@ CREATE TABLE public.comments (
     post_id integer NOT NULL,
     creator_id integer NOT NULL,
     body text NOT NULL,
-    ip_addr inet NOT NULL,
+    creator_ip_addr inet NOT NULL,
     body_index tsvector NOT NULL,
     score integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone,
@@ -5090,10 +5090,10 @@ CREATE INDEX index_comments_on_creator_id_and_post_id ON public.comments USING b
 
 
 --
--- Name: index_comments_on_ip_addr; Type: INDEX; Schema: public; Owner: -
+-- Name: index_comments_on_creator_ip_addr; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_comments_on_ip_addr ON public.comments USING btree (ip_addr);
+CREATE INDEX index_comments_on_creator_ip_addr ON public.comments USING btree (creator_ip_addr);
 
 
 --
@@ -7519,6 +7519,7 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20181114185032'),
 ('20181114202744'),
 ('20181130004740'),
-('20181202172145');
+('20181202172145'),
+('20190109210822');
 
 

--- a/test/unit/ip_ban_test.rb
+++ b/test/unit/ip_ban_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class IpBanTest < ActiveSupport::TestCase
   setup do
     @user = FactoryBot.create(:user)
-    CurrentUser.user = @user
+    CurrentUser.user = FactoryBot.create(:mod_user)
     CurrentUser.ip_addr = "127.0.0.1"
     Danbooru.config.stubs(:member_comment_time_threshold).returns(1.week.from_now)
   end
@@ -15,15 +15,22 @@ class IpBanTest < ActiveSupport::TestCase
 
   should "be able to count the number of comments an IP address is associated with" do
     comment = FactoryBot.create(:comment)
-    counts = IpBan.count_by_ip_addr("comments", [comment.creator_id], "creator_id", "ip_addr")
-    assert_equal([{"ip_addr" => "127.0.0.1", "count" => 1}], counts)
+    counts = IpBan.count_by_ip_addr("comments", [comment.creator_id], "creator_id", "creator_ip_addr")
+    assert_equal([{"creator_ip_addr" => "127.0.0.1", "count" => 1}], counts)
   end
 
   should "be able to count any updates from a user, groupiny by IP address" do
     CurrentUser.scoped(@user, "1.2.3.4") do
       comment = FactoryBot.create(:comment, :body => "aaa")
       counts = IpBan.query([comment.creator_id])
-      assert_equal([{"ip_addr" => "1.2.3.4", "count" => 1}], counts["comments"])
+      assert_equal([{"creator_ip_addr" => "1.2.3.4", "count" => 1}], counts["comments"])
     end
+  end
+
+  should "be able to ban a user" do
+    ip_ban = IpBan.create(ip_addr: "1.2.3.4", reason: "test")
+
+    assert_equal("1.2.3.4", ip_ban.ip_addr.to_s)
+    assert(IpBan.is_banned?("1.2.3.4"))
   end
 end


### PR DESCRIPTION
Fixes #4038:

* Rename comments.ip_addr to comments.creator_ip_addr.
* Fix belongs_to_creator to not clobber ip_addr field.