### PR TITLE
Remove references to Keeper/TopTagger

### DIFF
--- a/app/helpers/delayed_jobs_helper.rb
+++ b/app/helpers/delayed_jobs_helper.rb
@@ -61,9 +61,6 @@ module DelayedJobsHelper
     when "BulkRevert#process"
       "<strong>bulk revert</strong>"
 
-    when "PostKeeperManager.check_and_update"
-      "<strong>update top tagger</strong>"
-
     else
       h(job.name)
     end
@@ -71,9 +68,6 @@ module DelayedJobsHelper
 
   def print_handler(job)
     case job.name
-    when "PostKeeperManager.check_and_assign"
-      ""
-
     when "Tag.increment_post_counts", "Tag.decrement_post_counts"
       ""
 
@@ -130,9 +124,6 @@ module DelayedJobsHelper
 
     when "BulkRevert#process"
       h(job.payload_object.args.join(" "))
-
-    when "PostKeeperManager.check_and_update"
-      h(job.payload_object.args[0])
     end
   end
 end

--- a/app/javascript/src/javascripts/blacklists.js
+++ b/app/javascript/src/javascripts/blacklists.js
@@ -156,7 +156,6 @@ Blacklist.post_match = function(post, entry) {
     tags.push("user:" + $post.attr("data-uploader").toLowerCase());
   }
   tags.push("uploaderid:" + $post.attr("data-uploader-id"));
-  tags.push("toptaggerid:" + $post.attr("data-top-tagger"));
   $.each(String($post.data("flags")).match(/\S+/g) || [], function(i, v) {
     tags.push("status:" + v);
   });


### PR DESCRIPTION
Fixes #4057. The **keeper_data** field was left as is in case it's still being kept around for other reasons, such as backwards compatibility. If it can be gotten rid of though, I can add a migration which will remove that value.