### PR TITLE
Fix Ugoiras when image cropping is disabled

### DIFF
--- a/app/logical/pixiv_ugoira_converter.rb
+++ b/app/logical/pixiv_ugoira_converter.rb
@@ -83,6 +83,6 @@ class PixivUgoiraConverter
 
     DanbooruImageResizer.resize(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 85)
   ensure
-    file.close!
+    file&.close!
   end
 end


### PR DESCRIPTION
since file is `nil` and has no `#close!` when `Danbooru.config.enable_image_cropping` is false

the more proper method might be to use a `begin; ...; ensure; file.close!; end` part around the parts related to `file`