### PR TITLE
Fix Ugoiras when image cropping is disabled

### DIFF
--- a/app/logical/pixiv_ugoira_converter.rb
+++ b/app/logical/pixiv_ugoira_converter.rb
@@ -73,7 +73,7 @@ class PixivUgoiraConverter
 
     DanbooruImageResizer.crop(file, Danbooru.config.small_image_width, Danbooru.config.small_image_width, 85)
   ensure
-    file.close!
+    file&.close!
   end
 
   def self.generate_preview(ugoira_file)


### PR DESCRIPTION
since file is `nil` and has no `#close!` when `Danbooru.config.enable_image_cropping` is false

the more proper method might be to use a `begin; ...; ensure; file.close!; end` part around the parts related to `file`

I should really stop using the web editor... (in #4140 I changed the wrong `file.close!`)